### PR TITLE
docs: fix behavior spelling in lattice module

### DIFF
--- a/src/algs/lattice.rs
+++ b/src/algs/lattice.rs
@@ -1,5 +1,5 @@
 //! Set-lattice helpers: meet, join, adjacency and helpers.
-//! All output vectors are **sorted & deduplicated** for deterministic behaviour.
+//! All output vectors are **sorted & deduplicated** for deterministic behavior.
 //!
 //! This module provides utilities for set-lattice operations on mesh topologies,
 //! including adjacency queries and helpers for use with [`Sieve`] structures.


### PR DESCRIPTION
## Summary
- standardize module comment to use American spelling for deterministic behavior

## Testing
- `cargo test` *(fails: The system library `ompi` required by crate `mpi-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b9e149d08329a8f65d95c9f7e98e