### PR TITLE
Add orientation-aware sieve

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub mod partitioning;
 
 /// A convenient prelude to import the most-used traits & types:
 pub mod prelude {
-    pub use crate::topology::sieve::Sieve;
-    pub use crate::topology::sieve::InMemorySieve;
+    pub use crate::topology::sieve::{Sieve, OrientedSieve, Orientation};
+    pub use crate::topology::sieve::{InMemorySieve, InMemoryOrientedSieve};
     pub use crate::topology::stack::{Stack, InMemoryStack};
     pub use crate::topology::point::PointId;
     pub use crate::data::atlas::Atlas;

--- a/src/topology/sieve/in_memory_oriented.rs
+++ b/src/topology/sieve/in_memory_oriented.rs
@@ -1,0 +1,174 @@
+//! In-memory oriented Sieve: stores (dst, payload, orientation) per arrow.
+//! Implements both `Sieve` (payload-only view) and `OrientedSieve`.
+
+use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+
+use super::sieve_trait::Sieve;
+use super::super::stratum::{InvalidateCache, StrataCache, compute_strata};
+use super::oriented::{OrientedSieve, Orientation};
+use crate::mesh_error::MeshSieveError;
+
+#[derive(Clone, Debug)]
+pub struct InMemoryOrientedSieve<P, T=(), O=i32>
+where
+    P: Ord + std::fmt::Debug,
+    O: Orientation,
+{
+    pub adjacency_out: HashMap<P, Vec<(P, T, O)>>,
+    pub adjacency_in:  HashMap<P, Vec<(P, T, O)>>,
+    pub strata: OnceCell<StrataCache<P>>,
+}
+
+impl<P, T, O> Default for InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    O: Orientation,
+{
+    fn default() -> Self {
+        Self { adjacency_out: HashMap::new(),
+               adjacency_in: HashMap::new(),
+               strata: OnceCell::new() }
+    }
+}
+
+impl<P, T, O> InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+    O: Orientation,
+{
+    pub fn new() -> Self { Self::default() }
+
+    pub fn from_arrows<I: IntoIterator<Item=(P, P, T, O)>>(arrows: I) -> Self {
+        let mut s = Self::default();
+        for (src, dst, pay, ori) in arrows {
+            s.add_arrow_o(src, dst, pay, ori);
+        }
+        s
+    }
+
+    fn rebuild_support_from_out(&mut self) {
+        self.adjacency_in.clear();
+        for (&src, outs) in &self.adjacency_out {
+            for &(dst, ref pay, ori) in outs {
+                self.adjacency_in.entry(dst).or_default().push((src, pay.clone(), ori));
+            }
+        }
+    }
+
+    pub fn strata_cache(&mut self) -> Result<&StrataCache<P>, MeshSieveError> {
+        let self_ptr: *mut Self = self;
+        self.strata.get_or_try_init(|| {
+            let sieve = unsafe { &mut *self_ptr };
+            compute_strata(sieve)
+        })
+    }
+
+    pub fn invalidate_strata(&mut self) { self.strata.take(); }
+}
+
+// ----------- Sieve (payload-only view) -----------
+type MapOut<'a, P, T, O> = std::iter::Map<
+    std::slice::Iter<'a, (P, T, O)>,
+    fn(&'a (P, T, O)) -> (P, T)
+>;
+
+type MapOOut<'a, P, T, O> = std::iter::Map<
+    std::slice::Iter<'a, (P, T, O)>,
+    fn(&'a (P, T, O)) -> (P, O)
+>;
+
+impl<P, T, O> Sieve for InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+    O: Orientation,
+{
+    type Point = P;
+    type Payload = T;
+
+    type ConeIter<'a> = MapOut<'a, P, T, O> where Self: 'a;
+    type SupportIter<'a> = MapOut<'a, P, T, O> where Self: 'a;
+
+    fn cone<'a>(&'a self, p: P) -> Self::ConeIter<'a> {
+        fn map_fn<P: Copy, T: Clone, O: Copy>((dst, pay, _): &(P, T, O)) -> (P, T) { (*dst, pay.clone()) }
+        let f: fn(&(P, T, O)) -> (P, T) = map_fn::<P, T, O>;
+        self.adjacency_out.get(&p).map(|v| v.iter().map(f)).unwrap_or_else(|| [].iter().map(f))
+    }
+
+    fn support<'a>(&'a self, p: P) -> Self::SupportIter<'a> {
+        fn map_fn<P: Copy, T: Clone, O: Copy>((src, pay, _): &(P, T, O)) -> (P, T) { (*src, pay.clone()) }
+        let f: fn(&(P, T, O)) -> (P, T) = map_fn::<P, T, O>;
+        self.adjacency_in.get(&p).map(|v| v.iter().map(f)).unwrap_or_else(|| [].iter().map(f))
+    }
+
+    fn add_arrow(&mut self, src: P, dst: P, payload: T) {
+        self.add_arrow_o(src, dst, payload, O::default());
+    }
+
+    fn remove_arrow(&mut self, src: P, dst: P) -> Option<T> {
+        let mut removed = None;
+        if let Some(v) = self.adjacency_out.get_mut(&src) {
+            if let Some(pos) = v.iter().position(|(d,_,_)| *d == dst) {
+                removed = Some(v.remove(pos).1);
+            }
+        }
+        if let Some(v) = self.adjacency_in.get_mut(&dst) {
+            if let Some(pos) = v.iter().position(|(s,_,_)| *s == src) {
+                v.remove(pos);
+            }
+        }
+        self.invalidate_cache();
+        removed
+    }
+
+    fn base_points<'a>(&'a self) -> Box<dyn Iterator<Item = P> + 'a> {
+        Box::new(self.adjacency_out.keys().copied())
+    }
+
+    fn cap_points<'a>(&'a self) -> Box<dyn Iterator<Item = P> + 'a> {
+        Box::new(self.adjacency_in.keys().copied())
+    }
+}
+
+impl<P, T, O> OrientedSieve for InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+    O: Orientation,
+{
+    type Orient = O;
+    type ConeOIter<'a> = MapOOut<'a, P, T, O> where Self: 'a;
+    type SupportOIter<'a> = MapOOut<'a, P, T, O> where Self: 'a;
+
+    fn cone_o<'a>(&'a self, p: P) -> Self::ConeOIter<'a> {
+        fn map_fn<P: Copy, T, O: Copy>((dst, _, ori): &(P, T, O)) -> (P, O) { (*dst, *ori) }
+        let f: fn(&(P, T, O)) -> (P, O) = map_fn::<P, T, O>;
+        self.adjacency_out.get(&p).map(|v| v.iter().map(f)).unwrap_or_else(|| [].iter().map(f))
+    }
+
+    fn support_o<'a>(&'a self, p: P) -> Self::SupportOIter<'a> {
+        fn map_fn<P: Copy, T, O: Copy>((src, _, ori): &(P, T, O)) -> (P, O) { (*src, *ori) }
+        let f: fn(&(P, T, O)) -> (P, O) = map_fn::<P, T, O>;
+        self.adjacency_in.get(&p).map(|v| v.iter().map(f)).unwrap_or_else(|| [].iter().map(f))
+    }
+
+    fn add_arrow_o(&mut self, src: P, dst: P, payload: T, orient: O) {
+        self.adjacency_out.entry(src).or_default().push((dst, payload.clone(), orient));
+        self.adjacency_in.entry(dst).or_default().push((src, payload, orient));
+        self.invalidate_cache();
+    }
+}
+
+impl<P, T, O> InvalidateCache for InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+    O: Orientation,
+{
+    fn invalidate_cache(&mut self) {
+        self.strata.take();
+    }
+}
+

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -5,8 +5,12 @@
 
 /// Core trait for sieve data structures.
 pub mod sieve_trait;
+/// Orientation-aware extensions to [`Sieve`].
+pub mod oriented;
 /// In-memory implementation of the [`Sieve`] trait.
 pub mod in_memory;
+/// In-memory implementation storing per-arrow orientations.
+pub mod in_memory_oriented;
 /// Strata sieve implementation.
 pub mod strata;
 /// Sieve implementation using arc payloads.
@@ -14,4 +18,6 @@ pub mod arc_payload;
 
 // Re-export the core trait and in‐memory impl at top level
 pub use sieve_trait::Sieve;
+pub use oriented::{Orientation, OrientedSieve};
 pub use in_memory::InMemorySieve;
+pub use in_memory_oriented::InMemoryOrientedSieve;

--- a/src/topology/sieve/oriented.rs
+++ b/src/topology/sieve/oriented.rs
@@ -1,0 +1,106 @@
+//! Oriented variants of Sieve traversals in the spirit of PETSc DMPlex.
+//!
+//! - `Orientation` models a tiny group with `compose` and `inverse`,
+//!    so we can accumulate per-arrow orientations along transitive closure.
+//! - `OrientedSieve` extends `Sieve` with orientation-aware cone/support
+//!    and a constructor for arrows that includes an orientation.
+//!
+//! Default `closure_o`/`star_o` accumulate orientations via `compose`,
+//! and return a stable, point-sorted vector for deterministic behavior.
+
+use super::sieve_trait::Sieve;
+
+/// A minimal orientation "group".
+/// Implementations should satisfy:
+///   compose(id, a) = a, compose(a, id) = a, compose(a, inverse(a)) = id,
+///   and compose is associative.
+pub trait Orientation: Copy + Default + std::fmt::Debug + 'static {
+    fn compose(a: Self, b: Self) -> Self;
+    fn inverse(a: Self) -> Self;
+}
+
+/// Trivial orientation (no-op)
+impl Orientation for () {
+    #[inline] fn compose(_: (), _: ()) -> () { () }
+    #[inline] fn inverse(_: ()) -> () { () }
+}
+
+/// Common integer orientation (e.g. flips/rotations encoded as ints).
+/// Default composition is additive; customize with your own type if needed.
+impl Orientation for i32 {
+    #[inline] fn compose(a: i32, b: i32) -> i32 { a + b }
+    #[inline] fn inverse(a: i32) -> i32 { -a }
+}
+
+/// Sieve extension with orientation-aware incidence.
+pub trait OrientedSieve: Sieve {
+    type Orient: Orientation;
+
+    type ConeOIter<'a>: Iterator<Item = (Self::Point, Self::Orient)> where Self: 'a;
+    type SupportOIter<'a>: Iterator<Item = (Self::Point, Self::Orient)> where Self: 'a;
+
+    /// Oriented outgoing incidence from `p`. Pairs `(dst, orient(p->dst))`.
+    fn cone_o<'a>(&'a self, p: Self::Point) -> Self::ConeOIter<'a>;
+
+    /// Oriented incoming incidence to `p`. Pairs `(src, orient(src->p))`.
+    fn support_o<'a>(&'a self, p: Self::Point) -> Self::SupportOIter<'a>;
+
+    /// Insert an oriented arrow `src -> dst` with payload and orientation.
+    fn add_arrow_o(&mut self, src: Self::Point, dst: Self::Point,
+                   payload: Self::Payload, orient: Self::Orient);
+
+    /// Transitive closure with accumulated orientations (downward).
+    ///
+    /// Returns a **stable, point-sorted** `Vec<(point, orientation_from_seed)>`.
+    fn closure_o<'s, I>(&'s self, seeds: I) -> Vec<(Self::Point, Self::Orient)>
+    where
+        I: IntoIterator<Item = Self::Point>,
+    {
+        use std::collections::HashMap;
+        let mut stack: Vec<(Self::Point, Self::Orient)> =
+            seeds.into_iter().map(|p| (p, Self::Orient::default())).collect();
+
+        // first-arrival wins to keep deterministic, minimal composition
+        let mut best: HashMap<Self::Point, Self::Orient> = HashMap::new();
+
+        while let Some((p, acc)) = stack.pop() {
+            if best.contains_key(&p) { continue; }
+            best.insert(p, acc);
+            for (q, o) in self.cone_o(p) {
+                let nxt = <Self::Orient as Orientation>::compose(acc, o);
+                if !best.contains_key(&q) {
+                    stack.push((q, nxt));
+                }
+            }
+        }
+        let mut out: Vec<_> = best.into_iter().collect();
+        out.sort_unstable_by_key(|(pt, _)| *pt);
+        out
+    }
+
+    /// Transitive star with accumulated orientations (upward).
+    fn star_o<'s, I>(&'s self, seeds: I) -> Vec<(Self::Point, Self::Orient)>
+    where
+        I: IntoIterator<Item = Self::Point>,
+    {
+        use std::collections::HashMap;
+        let mut stack: Vec<(Self::Point, Self::Orient)> =
+            seeds.into_iter().map(|p| (p, Self::Orient::default())).collect();
+        let mut best: HashMap<Self::Point, Self::Orient> = HashMap::new();
+
+        while let Some((p, acc)) = stack.pop() {
+            if best.contains_key(&p) { continue; }
+            best.insert(p, acc);
+            for (q, o) in self.support_o(p) {
+                let nxt = <Self::Orient as Orientation>::compose(acc, o);
+                if !best.contains_key(&q) {
+                    stack.push((q, nxt));
+                }
+            }
+        }
+        let mut out: Vec<_> = best.into_iter().collect();
+        out.sort_unstable_by_key(|(pt, _)| *pt);
+        out
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `Orientation` and `OrientedSieve` trait for orientation-aware traversals
- implement `InMemoryOrientedSieve` storing per-arrow orientations
- re-export new oriented APIs and implementation

## Testing
- `cargo test` *(fails: `*mut ompi_communicator_t` cannot be shared between threads safely)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bb3720248329b3c48bf74c98f25d