### PR TITLE
Add orientation-aware Section helpers and invert star orientation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod data;
 pub mod overlap;
 pub mod algs;
 pub mod mesh_error;
+pub mod section;
 #[cfg(feature = "mpi-support")]
 pub mod partitioning;
 

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,0 +1,65 @@
+//! Minimal PetscSection-like interface to describe DOF layout on points.
+//!
+//! This lightweight trait provides just enough information to map mesh
+//! points to contiguous spans in a global array. It can be paired with
+//! [`OrientedSieve`](crate::topology::sieve::oriented::OrientedSieve) to
+//! iterate over degrees of freedom on transitive closures.
+
+/// Minimal interface describing degrees of freedom associated with points.
+pub trait Section {
+    /// Point identifier type.
+    type Point: Copy + Ord;
+
+    /// Number of degrees of freedom for point `p`.
+    fn dof(&self, p: Self::Point) -> usize;
+    /// Offset where point `p`'s DOFs begin in a contiguous array.
+    fn offset(&self, p: Self::Point) -> usize;
+}
+
+/// Iterate `(offset, dof)` pairs over the closure of `cell`.
+///
+/// The iterator order mirrors [`closure_o`](crate::topology::sieve::oriented::OrientedSieve::closure_o):
+/// points are sorted by their identifier. If a different ordering is
+/// required (e.g. by topological dimension), callers should sort the
+/// resulting collection accordingly.
+pub fn section_on_closure<S, Sec>(
+    sieve: &S,
+    sec: &Sec,
+    cell: S::Point,
+) -> impl Iterator<Item = (usize, usize)>
+where
+    S: crate::topology::sieve::oriented::OrientedSieve,
+    Sec: Section<Point = S::Point>,
+{
+    sieve
+        .closure_o([cell])
+        .into_iter()
+        .map(move |(p, _)| (sec.offset(p), sec.dof(p)))
+}
+
+/// Same as [`section_on_closure`] but also returns the accumulated
+/// orientation from the seed to each point.
+pub fn section_on_closure_o<S, Sec>(
+    sieve: &S,
+    sec: &Sec,
+    cell: S::Point,
+) -> impl Iterator<Item = (usize, usize, S::Orient)>
+where
+    S: crate::topology::sieve::oriented::OrientedSieve,
+    Sec: Section<Point = S::Point>,
+{
+    sieve
+        .closure_o([cell])
+        .into_iter()
+        .map(move |(p, o)| (sec.offset(p), sec.dof(p), o))
+}
+
+/// Optional hook for applying orientations to local element buffers.
+pub trait ApplyOrientation {
+    /// The orientation type used by the Sieve.
+    type Orient: crate::topology::sieve::oriented::Orientation;
+
+    /// Apply orientation `o` to the degrees-of-freedom slice `buf`.
+    /// Implementations may permute indices or apply sign changes.
+    fn apply(&self, o: Self::Orient, buf: &mut [f64]);
+}

--- a/src/topology/sieve/sieve_trait.rs
+++ b/src/topology/sieve/sieve_trait.rs
@@ -54,6 +54,17 @@ where
     /// All “cap” points (with incoming arrows).
     fn cap_points<'a>(&'a self) -> Box<dyn Iterator<Item = Self::Point> + 'a>;
 
+    /// Convenience iterator over the destination points in `p`'s cone,
+    /// discarding payload values.
+    fn cone_points<'a>(&'a self, p: Self::Point) -> Box<dyn Iterator<Item = Self::Point> + 'a> {
+        Box::new(self.cone(p).map(|(q, _)| q))
+    }
+    /// Convenience iterator over the source points in `p`'s support,
+    /// discarding payload values.
+    fn support_points<'a>(&'a self, p: Self::Point) -> Box<dyn Iterator<Item = Self::Point> + 'a> {
+        Box::new(self.support(p).map(|(q, _)| q))
+    }
+
     /// Return an iterator over **all** points in this Sieve’s domain
     /// (points that appear as a source or a destination of any arrow).
     fn points<'a>(&'a self) -> Box<dyn Iterator<Item = Self::Point> + 'a> {

--- a/tests/oriented_closure.rs
+++ b/tests/oriented_closure.rs
@@ -1,0 +1,44 @@
+use mesh_sieve::topology::sieve::InMemoryOrientedSieve;
+use mesh_sieve::topology::sieve::oriented::OrientedSieve;
+use mesh_sieve::section::{Section, section_on_closure_o};
+
+#[derive(Default)]
+struct ToySection;
+impl Section for ToySection {
+    type Point = u32;
+    fn dof(&self, _p: u32) -> usize { 1 }
+    fn offset(&self, p: u32) -> usize { p as usize }
+}
+
+#[test]
+fn oriented_closure_accumulates() {
+    // Build: cell 0 -> edges 10,11 with orientations +1, -1; edge 10 -> vertex 20 with +1
+    // Accumulated orientation to 20 should be (+1 compose +1) = +2
+    let mut s = InMemoryOrientedSieve::<u32, (), i32>::new();
+    s.add_arrow_o(0, 10, (),  1);
+    s.add_arrow_o(0, 11, (), -1);
+    s.add_arrow_o(10, 20, (), 1);
+
+    let cl = s.closure_o([0]);
+    // Points appear sorted: 0,10,11,20 with accumulated orientations from seed 0
+    assert_eq!(cl, vec![(0,0), (10,1), (11,-1), (20,2)]);
+
+    // Combine with Section helper
+    let sec = ToySection::default();
+    let spans: Vec<_> = section_on_closure_o(&s, &sec, 0).collect();
+    assert_eq!(spans, vec![(0,1,0), (10,1,1), (11,1,-1), (20,1,2)]);
+}
+
+#[test]
+fn star_orientation_inverts_step() {
+    // Reverse traversal should invert the step orientation
+    let mut s = InMemoryOrientedSieve::<u32, (), i32>::new();
+    s.add_arrow_o(7, 3, (),  2); // ori(7->3)=+2
+    s.add_arrow_o(3, 1, (), -1); // ori(3->1)=-1
+
+    // Star from leaf 1 should go up and compose inverses:
+    // inv(-1)=+1, then inv(+2)=-2 => total -1 at point 7
+    let st = s.star_o([1]);
+    // sorted by point: (1,0), (3,1), (7,-1)
+    assert_eq!(st, vec![(1,0), (3,1), (7,-1)]);
+}


### PR DESCRIPTION
## Summary
- invert stored orientations when traversing support closures
- provide point-only cone/support helpers for Sieve
- introduce lightweight Section trait with closure utilities and tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee496894832994532525f6f8ae6a