### PR TITLE
Add reference-based sieve traversals

### DIFF
--- a/src/algs/mod.rs
+++ b/src/algs/mod.rs
@@ -11,6 +11,7 @@ pub mod lattice;
 pub mod metis_partition;
 pub mod partition;
 pub mod traversal;
+pub mod traversal_ref;
 pub mod rcm;
 
 pub use completion::complete_section;

--- a/src/algs/traversal_ref.rs
+++ b/src/algs/traversal_ref.rs
@@ -1,0 +1,73 @@
+//! Clone-free DFS/BFS helpers for Sieves that implement `SieveRef`.
+
+use crate::topology::point::PointId;
+use crate::topology::sieve::Sieve;
+use crate::topology::sieve::SieveRef;
+use std::collections::{HashSet, VecDeque};
+
+pub type Point = PointId;
+
+/// Generic DFS over point-only neighbors.
+fn dfs_points<S, I, F>(sieve: &S, seeds: I, mut nbrs: F) -> Vec<Point>
+where
+    S: Sieve<Point = Point> + SieveRef,
+    I: IntoIterator<Item = Point>,
+    F: for<'a> FnMut(&'a S, Point) -> Box<dyn Iterator<Item = Point> + 'a>,
+{
+    let mut stack: Vec<Point> = seeds.into_iter().collect();
+    let mut seen: HashSet<Point> = stack.iter().copied().collect();
+
+    while let Some(p) = stack.pop() {
+        for q in nbrs(sieve, p) {
+            if seen.insert(q) {
+                stack.push(q);
+            }
+        }
+    }
+    let mut out: Vec<Point> = seen.into_iter().collect();
+    out.sort_unstable();
+    out
+}
+
+/// Transitive closure using `cone_points()` (no payload clones).
+#[inline]
+pub fn closure_ref<S, I>(sieve: &S, seeds: I) -> Vec<Point>
+where
+    S: Sieve<Point = Point> + SieveRef,
+    I: IntoIterator<Item = Point>,
+{
+    dfs_points(sieve, seeds, |s, p| Box::new(SieveRef::cone_points(s, p)))
+}
+
+/// Transitive star using `support_points()` (no payload clones).
+#[inline]
+pub fn star_ref<S, I>(sieve: &S, seeds: I) -> Vec<Point>
+where
+    S: Sieve<Point = Point> + SieveRef,
+    I: IntoIterator<Item = Point>,
+{
+    dfs_points(sieve, seeds, |s, p| {
+        Box::new(SieveRef::support_points(s, p))
+    })
+}
+
+/// BFS depth map using `cone_points()` (no payload clones).
+pub fn depth_map_ref<S>(sieve: &S, seed: Point) -> Vec<(Point, u32)>
+where
+    S: Sieve<Point = Point> + SieveRef,
+{
+    let mut depths = Vec::new();
+    let mut seen = HashSet::new();
+    let mut q = VecDeque::from([(seed, 0)]);
+
+    while let Some((p, d)) = q.pop_front() {
+        if seen.insert(p) {
+            depths.push((p, d));
+            for q_pt in SieveRef::cone_points(sieve, p) {
+                q.push_back((q_pt, d + 1));
+            }
+        }
+    }
+    depths.sort_by_key(|&(p, _)| p);
+    depths
+}

--- a/src/topology/sieve/in_memory.rs
+++ b/src/topology/sieve/in_memory.rs
@@ -4,7 +4,7 @@
 //! of a sieve using hash maps for adjacency storage. It supports generic point and payload types.
 
 use super::sieve_trait::Sieve;
-use super::sieve_refs::SieveRefs;
+use super::sieve_ref::SieveRef;
 use crate::topology::stratum::InvalidateCache;
 use crate::topology::stratum::StrataCache;
 use once_cell::sync::OnceCell;
@@ -496,7 +496,7 @@ impl<P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug, T: Clone> InMemoryS
     }
 }
 
-impl<P, T> SieveRefs for InMemorySieve<P, T>
+impl<P, T> SieveRef for InMemorySieve<P, T>
 where
     P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
     T: Clone,

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -12,7 +12,7 @@ pub mod in_memory;
 /// In-memory implementation storing per-arrow orientations.
 pub mod in_memory_oriented;
 /// Reference-returning extensions to [`Sieve`].
-pub mod sieve_refs;
+pub mod sieve_ref;
 /// Strata sieve implementation.
 pub mod strata;
 /// Sieve implementation using arc payloads.
@@ -23,4 +23,4 @@ pub use sieve_trait::Sieve;
 pub use oriented::{Orientation, OrientedSieve};
 pub use in_memory::InMemorySieve;
 pub use in_memory_oriented::InMemoryOrientedSieve;
-pub use sieve_refs::SieveRefs;
+pub use sieve_ref::SieveRef;

--- a/src/topology/sieve/sieve_ref.rs
+++ b/src/topology/sieve/sieve_ref.rs
@@ -1,0 +1,35 @@
+//! Reference-based extensions for `Sieve` to avoid cloning payloads during traversal.
+//!
+//! This trait is additive: existing code using `Sieve` keeps working.
+//! Algorithms that want zero-clone traversal can require `SieveRef`.
+
+use super::sieve_trait::Sieve;
+
+pub trait SieveRef: Sieve {
+    /// Iterator over (dst, &payload) without cloning.
+    type ConeRefIter<'a>: Iterator<Item = (Self::Point, &'a Self::Payload)>
+    where
+        Self: 'a;
+
+    /// Iterator over (src, &payload) without cloning.
+    type SupportRefIter<'a>: Iterator<Item = (Self::Point, &'a Self::Payload)>
+    where
+        Self: 'a;
+
+    /// Borrowing cone.
+    fn cone_ref<'a>(&'a self, p: Self::Point) -> Self::ConeRefIter<'a>;
+
+    /// Borrowing support.
+    fn support_ref<'a>(&'a self, p: Self::Point) -> Self::SupportRefIter<'a>;
+
+    /// Point-only adapters (never touch payloads).
+    #[inline]
+    fn cone_points<'a>(&'a self, p: Self::Point) -> impl Iterator<Item = Self::Point> + 'a {
+        self.cone_ref(p).map(|(q, _)| q)
+    }
+
+    #[inline]
+    fn support_points<'a>(&'a self, p: Self::Point) -> impl Iterator<Item = Self::Point> + 'a {
+        self.support_ref(p).map(|(q, _)| q)
+    }
+}

--- a/src/topology/sieve/sieve_refs.rs
+++ b/src/topology/sieve/sieve_refs.rs
@@ -1,9 +1,0 @@
-use super::sieve_trait::Sieve;
-
-pub trait SieveRefs: Sieve {
-    type ConeRefIter<'a>: Iterator<Item = (Self::Point, &'a Self::Payload)> where Self: 'a;
-    type SupportRefIter<'a>: Iterator<Item = (Self::Point, &'a Self::Payload)> where Self: 'a;
-
-    fn cone_ref<'a>(&'a self, p: Self::Point) -> Self::ConeRefIter<'a>;
-    fn support_ref<'a>(&'a self, p: Self::Point) -> Self::SupportRefIter<'a>;
-}

--- a/tests/traversal_ref.rs
+++ b/tests/traversal_ref.rs
@@ -1,0 +1,51 @@
+use mesh_sieve::algs::traversal_ref::{closure_ref, depth_map_ref, star_ref};
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::in_memory::InMemorySieve;
+use mesh_sieve::topology::sieve::{Sieve, SieveRef};
+
+#[test]
+fn closure_star_depth_map_ref_work() {
+    let mut s = InMemorySieve::<PointId, String>::new();
+    let p1 = PointId::new(1).unwrap();
+    let p2 = PointId::new(2).unwrap();
+    let p3 = PointId::new(3).unwrap();
+    let p4 = PointId::new(4).unwrap();
+    s.add_arrow(p1, p2, "e12".into());
+    s.add_arrow(p2, p3, "e23".into());
+    s.add_arrow(p2, p4, "e24".into());
+
+    // Clone-free variants return same points as legacy versions:
+    let mut c = closure_ref(&s, [p1]);
+    c.sort_unstable();
+    assert_eq!(c, vec![p1, p2, p3, p4]);
+
+    let mut st = star_ref(&s, [p4]);
+    st.sort_unstable();
+    assert_eq!(st, vec![p1, p2, p4]);
+
+    let dm = depth_map_ref(&s, p1);
+    assert_eq!(dm, vec![(p1, 0), (p2, 1), (p3, 2), (p4, 2)]);
+}
+
+// Demonstrate direct borrowing access to payloads (no clones):
+#[test]
+fn cone_support_ref_borrow_payloads() {
+    let mut s = InMemorySieve::<PointId, Vec<u8>>::new();
+    let p10 = PointId::new(10).unwrap();
+    let p20 = PointId::new(20).unwrap();
+    let p30 = PointId::new(30).unwrap();
+    s.add_arrow(p10, p20, vec![1, 2, 3]);
+    s.add_arrow(p10, p30, vec![4, 5]);
+
+    // Borrowing cone gives &Vec<u8>
+    let mut sizes: Vec<_> = s.cone_ref(p10).map(|(_q, pay)| pay.len()).collect();
+    sizes.sort_unstable();
+    assert_eq!(sizes, vec![2, 3]);
+
+    // Borrowing support likewise
+    let sum: usize = s
+        .support_ref(p20)
+        .map(|(_p, pay)| pay.iter().copied().sum::<u8>() as usize)
+        .sum();
+    assert_eq!(sum, 1 + 2 + 3);
+}


### PR DESCRIPTION
## Summary
- add `SieveRef` subtrait for zero-clone traversal
- implement `SieveRef` for `InMemorySieve`
- introduce clone-free traversal helpers and tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f8a597848329a8c51f982a206ac6