### PR TITLE
Add strata chart and deterministic traversals

### DIFF
--- a/src/algs/traversal.rs
+++ b/src/algs/traversal.rs
@@ -1,16 +1,25 @@
 //! DFS/BFS traversal helpers for Sieve topologies.
 
-use crate::topology::sieve::Sieve;
+use crate::mesh_error::MeshSieveError;
 use crate::topology::point::PointId;
+use crate::topology::sieve::Sieve;
+use crate::topology::sieve::strata::compute_strata;
 use std::collections::{HashSet, VecDeque};
 
 pub type Point = PointId;
 
 #[derive(Clone, Copy, Debug)]
-pub enum Dir { Down, Up, Both }
+pub enum Dir {
+    Down,
+    Up,
+    Both,
+}
 
 #[derive(Clone, Copy, Debug)]
-pub enum Strategy { DFS, BFS }
+pub enum Strategy {
+    DFS,
+    BFS,
+}
 
 pub struct TraversalBuilder<'a, S: Sieve> {
     sieve: &'a S,
@@ -23,20 +32,43 @@ pub struct TraversalBuilder<'a, S: Sieve> {
 }
 
 impl<'a, S: Sieve> TraversalBuilder<'a, S>
-where S::Point: Ord + Copy
+where
+    S::Point: Ord + Copy,
 {
     pub fn new(sieve: &'a S) -> Self {
-        Self { sieve, seeds: Vec::new(), dir: Dir::Down, strat: Strategy::DFS,
-               max_depth: None, early_stop: None }
+        Self {
+            sieve,
+            seeds: Vec::new(),
+            dir: Dir::Down,
+            strat: Strategy::DFS,
+            max_depth: None,
+            early_stop: None,
+        }
     }
     pub fn seeds<I: IntoIterator<Item = S::Point>>(mut self, it: I) -> Self {
-        self.seeds = it.into_iter().collect(); self
+        self.seeds = it.into_iter().collect();
+        self
     }
-    pub fn dir(mut self, d: Dir) -> Self { self.dir = d; self }
-    pub fn dfs(mut self) -> Self { self.strat = Strategy::DFS; self }
-    pub fn bfs(mut self) -> Self { self.strat = Strategy::BFS; self }
-    pub fn max_depth(mut self, d: Option<u32>) -> Self { self.max_depth = d; self }
-    pub fn early_stop(mut self, f: &'a dyn Fn(S::Point) -> bool) -> Self { self.early_stop = Some(f); self }
+    pub fn dir(mut self, d: Dir) -> Self {
+        self.dir = d;
+        self
+    }
+    pub fn dfs(mut self) -> Self {
+        self.strat = Strategy::DFS;
+        self
+    }
+    pub fn bfs(mut self) -> Self {
+        self.strat = Strategy::BFS;
+        self
+    }
+    pub fn max_depth(mut self, d: Option<u32>) -> Self {
+        self.max_depth = d;
+        self
+    }
+    pub fn early_stop(mut self, f: &'a dyn Fn(S::Point) -> bool) -> Self {
+        self.early_stop = Some(f);
+        self
+    }
 
     pub fn run(self) -> Vec<S::Point> {
         match self.strat {
@@ -46,13 +78,26 @@ where S::Point: Ord + Copy
     }
 
     fn run_dfs(self) -> Vec<S::Point> {
-        let TraversalBuilder { sieve, seeds, dir, strat: _, max_depth, early_stop } = self;
+        let TraversalBuilder {
+            sieve,
+            seeds,
+            dir,
+            strat: _,
+            max_depth,
+            early_stop,
+        } = self;
         let mut seen: HashSet<S::Point> = seeds.iter().copied().collect();
         let mut stack: Vec<(S::Point, u32)> = seeds.into_iter().map(|p| (p, 0)).collect();
 
         while let Some((p, d)) = stack.pop() {
-            if let Some(f) = early_stop { if f(p) { break; } }
-            if max_depth.map_or(false, |md| d >= md) { continue; }
+            if let Some(f) = early_stop {
+                if f(p) {
+                    break;
+                }
+            }
+            if max_depth.map_or(false, |md| d >= md) {
+                continue;
+            }
             for q in step_neighbors(sieve, dir, p) {
                 if seen.insert(q) {
                     stack.push((q, d + 1));
@@ -65,13 +110,26 @@ where S::Point: Ord + Copy
     }
 
     fn run_bfs(self) -> Vec<S::Point> {
-        let TraversalBuilder { sieve, seeds, dir, strat: _, max_depth, early_stop } = self;
+        let TraversalBuilder {
+            sieve,
+            seeds,
+            dir,
+            strat: _,
+            max_depth,
+            early_stop,
+        } = self;
         let mut seen: HashSet<S::Point> = seeds.iter().copied().collect();
         let mut q: VecDeque<(S::Point, u32)> = seeds.into_iter().map(|p| (p, 0)).collect();
 
         while let Some((p, d)) = q.pop_front() {
-            if let Some(f) = early_stop { if f(p) { break; } }
-            if max_depth.map_or(false, |md| d >= md) { continue; }
+            if let Some(f) = early_stop {
+                if f(p) {
+                    break;
+                }
+            }
+            if max_depth.map_or(false, |md| d >= md) {
+                continue;
+            }
             for qn in step_neighbors(sieve, dir, p) {
                 if seen.insert(qn) {
                     q.push_back((qn, d + 1));
@@ -84,7 +142,11 @@ where S::Point: Ord + Copy
     }
 }
 
-fn step_neighbors<'a, S: Sieve>(sieve: &'a S, dir: Dir, p: S::Point) -> Box<dyn Iterator<Item = S::Point> + 'a> {
+fn step_neighbors<'a, S: Sieve>(
+    sieve: &'a S,
+    dir: Dir,
+    p: S::Point,
+) -> Box<dyn Iterator<Item = S::Point> + 'a> {
     match dir {
         Dir::Down => Box::new(sieve.cone_points(p)),
         Dir::Up => Box::new(sieve.support_points(p)),
@@ -100,7 +162,11 @@ where
     S: Sieve<Point = Point>,
     I: IntoIterator<Item = Point>,
 {
-    TraversalBuilder::new(sieve).dir(Dir::Down).dfs().seeds(seeds).run()
+    TraversalBuilder::new(sieve)
+        .dir(Dir::Down)
+        .dfs()
+        .seeds(seeds)
+        .run()
 }
 
 /// Complete transitive star following `support` arrows.
@@ -109,34 +175,152 @@ where
     S: Sieve<Point = Point>,
     I: IntoIterator<Item = Point>,
 {
-    TraversalBuilder::new(sieve).dir(Dir::Up).dfs().seeds(seeds).run()
+    TraversalBuilder::new(sieve)
+        .dir(Dir::Up)
+        .dfs()
+        .seeds(seeds)
+        .run()
 }
 
 /// Computes the link of a point (definition unchanged).
 pub fn link<S: Sieve<Point = Point>>(sieve: &S, p: Point) -> Vec<Point> {
     let mut cl = closure(sieve, [p]);
     let mut st = star(sieve, [p]);
-    cl.sort_unstable(); st.sort_unstable();
+    cl.sort_unstable();
+    st.sort_unstable();
     use std::collections::HashSet;
     let cone: HashSet<_> = sieve.cone_points(p).collect();
-    let sup:  HashSet<_> = sieve.support_points(p).collect();
+    let sup: HashSet<_> = sieve.support_points(p).collect();
     cl.retain(|x| st.binary_search(x).is_ok() && *x != p && !cone.contains(x) && !sup.contains(x));
     cl
 }
 
 /// Optional BFS distance map – used by coarsening / agglomeration.
 pub fn depth_map<S: Sieve<Point = Point>>(sieve: &S, seed: Point) -> Vec<(Point, u32)> {
-    let out = TraversalBuilder::new(sieve).dir(Dir::Down).bfs().seeds([seed]).run();
+    let out = TraversalBuilder::new(sieve)
+        .dir(Dir::Down)
+        .bfs()
+        .seeds([seed])
+        .run();
     // reconstruct depths with a second BFS (cheap) to keep signature unchanged
     use std::collections::{HashMap, VecDeque};
     let mut depth = HashMap::new();
     let mut q = VecDeque::from([(seed, 0)]);
     while let Some((p, d)) = q.pop_front() {
         if depth.insert(p, d).is_none() {
-            for qn in sieve.cone_points(p) { q.push_back((qn, d+1)); }
+            for qn in sieve.cone_points(p) {
+                q.push_back((qn, d + 1));
+            }
         }
     }
-    let mut v: Vec<_> = out.into_iter().map(|p| (p, *depth.get(&p).unwrap_or(&0))).collect();
+    let mut v: Vec<_> = out
+        .into_iter()
+        .map(|p| (p, *depth.get(&p).unwrap_or(&0)))
+        .collect();
     v.sort_by_key(|&(p, _)| p);
     v
+}
+
+// --- ordered traversals using strata chart ---
+
+/// Deterministic transitive closure following `cone` arrows, emitting points in
+/// chart order (height-major, then point order).
+pub fn closure_ordered<I, S>(sieve: &mut S, seeds: I) -> Result<Vec<S::Point>, MeshSieveError>
+where
+    S: Sieve,
+    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    I: IntoIterator<Item = S::Point>,
+{
+    let cache = compute_strata(sieve)?;
+    let chart = cache.chart_points;
+    let index_map = cache.chart_index;
+    let n = chart.len();
+    let mut seen = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+
+    for p in seeds {
+        if let Some(i) = index_map.get(&p).copied() {
+            if !seen[i] {
+                seen[i] = true;
+                stack.push(i);
+            }
+        }
+    }
+
+    while let Some(i) = stack.pop() {
+        let p = chart[i];
+        let mut nbrs: Vec<usize> = Vec::new();
+        for q in sieve.cone_points(p) {
+            if let Some(j) = index_map.get(&q).copied() {
+                nbrs.push(j);
+            }
+        }
+        nbrs.sort_unstable();
+        nbrs.dedup();
+        for j in nbrs.into_iter().rev() {
+            if !seen[j] {
+                seen[j] = true;
+                stack.push(j);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for (i, flag) in seen.iter().enumerate() {
+        if *flag {
+            out.push(chart[i]);
+        }
+    }
+    Ok(out)
+}
+
+/// Deterministic transitive star following `support` arrows, emitting points in
+/// chart order (height-major, then point order).
+pub fn star_ordered<I, S>(sieve: &mut S, seeds: I) -> Result<Vec<S::Point>, MeshSieveError>
+where
+    S: Sieve,
+    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    I: IntoIterator<Item = S::Point>,
+{
+    let cache = compute_strata(sieve)?;
+    let chart = cache.chart_points;
+    let index_map = cache.chart_index;
+    let n = chart.len();
+    let mut seen = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+
+    for p in seeds {
+        if let Some(i) = index_map.get(&p).copied() {
+            if !seen[i] {
+                seen[i] = true;
+                stack.push(i);
+            }
+        }
+    }
+
+    while let Some(i) = stack.pop() {
+        let p = chart[i];
+        let mut nbrs: Vec<usize> = Vec::new();
+        for q in sieve.support_points(p) {
+            if let Some(j) = index_map.get(&q).copied() {
+                nbrs.push(j);
+            }
+        }
+        nbrs.sort_unstable();
+        nbrs.dedup();
+        for j in nbrs.into_iter().rev() {
+            if !seen[j] {
+                seen[j] = true;
+                stack.push(j);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for (i, flag) in seen.iter().enumerate() {
+        if *flag {
+            out.push(chart[i]);
+        }
+    }
+    Ok(out)
 }

--- a/src/topology/sieve/sieve_trait.rs
+++ b/src/topology/sieve/sieve_trait.rs
@@ -322,6 +322,24 @@ where
         Ok(Box::new(pts.into_iter()))
     }
 
+    /// Deterministic contiguous index for a point within the strata chart.
+    fn chart_index(&mut self, p: Self::Point) -> Result<Option<usize>, MeshSieveError>
+    where
+        Self: Sized,
+    {
+        let cache = compute_strata(self)?;
+        Ok(cache.index_of(p))
+    }
+
+    /// Full chart of points in deterministic order (index → point).
+    fn chart_points(&mut self) -> Result<Vec<Self::Point>, MeshSieveError>
+    where
+        Self: Sized,
+    {
+        let cache = compute_strata(self)?;
+        Ok(cache.chart_points.clone())
+    }
+
     /// # Strata helpers example
     /// ```rust
     /// # use mesh_sieve::topology::sieve::Sieve;

--- a/src/topology/sieve/strata.rs
+++ b/src/topology/sieve/strata.rs
@@ -8,8 +8,8 @@
 //! Returns `Err(MeshSieveError::MissingPointInCone(p))` if a `cone` points to `p` not in `points()`,
 //! or `Err(MeshSieveError::CycleDetected)` if the topology contains a cycle.
 
-use crate::topology::sieve::Sieve;
 use crate::mesh_error::MeshSieveError;
+use crate::topology::sieve::Sieve;
 use std::collections::HashMap;
 
 /// Precomputed stratum information for a sieve.
@@ -19,19 +19,49 @@ use std::collections::HashMap;
 #[derive(Clone, Debug)]
 pub struct StrataCache<P> {
     /// Map from point to its height (distance from any zero-in-degree source).
-    pub height:   HashMap<P,u32>,
+    pub height: HashMap<P, u32>,
     /// Map from point to its depth (distance down to any zero-out-degree sink).
-    pub depth:    HashMap<P,u32>,
+    pub depth: HashMap<P, u32>,
     /// Vectors of points at each height: `strata[h] = points at height h`.
-    pub strata:   Vec<Vec<P>>,
+    pub strata: Vec<Vec<P>>,
     /// Maximum height (diameter) of the sieve.
     pub diameter: u32,
+
+    /// Deterministic global ordering of points (height-major, then point order).
+    pub chart_points: Vec<P>, // index -> point
+    /// Reverse lookup from point to chart index.
+    pub chart_index: HashMap<P, usize>, // point -> index
 }
 
 impl<P: Copy + Eq + std::hash::Hash + Ord> StrataCache<P> {
     /// Create a new, empty `StrataCache`.
     pub fn new() -> Self {
-        Self { height: HashMap::new(), depth: HashMap::new(), strata: Vec::new(), diameter: 0 }
+        Self {
+            height: HashMap::new(),
+            depth: HashMap::new(),
+            strata: Vec::new(),
+            diameter: 0,
+            chart_points: Vec::new(),
+            chart_index: HashMap::new(),
+        }
+    }
+
+    /// Index of `p` in the chart, if present.
+    #[inline]
+    pub fn index_of(&self, p: P) -> Option<usize> {
+        self.chart_index.get(&p).copied()
+    }
+
+    /// Point at chart index `i`.
+    #[inline]
+    pub fn point_at(&self, i: usize) -> P {
+        self.chart_points[i]
+    }
+
+    /// Total number of points in the chart.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.chart_points.len()
     }
 }
 
@@ -42,9 +72,7 @@ impl<P: Copy + Eq + std::hash::Hash + Ord> StrataCache<P> {
 /// # Errors
 /// Returns `Err(MeshSieveError::MissingPointInCone(p))` if a `cone` points to `p` not in `points()`,
 /// or `Err(MeshSieveError::CycleDetected)` if the topology contains a cycle.
-pub fn compute_strata<S>(
-    s: &mut S
-) -> Result<StrataCache<S::Point>, MeshSieveError>
+pub fn compute_strata<S>(s: &mut S) -> Result<StrataCache<S::Point>, MeshSieveError>
 where
     S: Sieve,
     S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
@@ -53,19 +81,27 @@ where
     let mut in_deg = HashMap::new();
     for p in s.points() {
         in_deg.entry(p).or_insert(0);
-        for (q,_) in s.cone(p) { *in_deg.entry(q).or_insert(0) += 1; }
+        for (q, _) in s.cone(p) {
+            *in_deg.entry(q).or_insert(0) += 1;
+        }
     }
     // 2) Kahn’s topo sort
-    let mut stack: Vec<_> = in_deg.iter().filter(|&(_,d)| *d==0).map(|(&p,_)| p).collect();
+    let mut stack: Vec<_> = in_deg
+        .iter()
+        .filter(|&(_, d)| *d == 0)
+        .map(|(&p, _)| p)
+        .collect();
     let mut topo = Vec::new();
     while let Some(p) = stack.pop() {
         topo.push(p);
-        for (q,_) in s.cone(p) {
+        for (q, _) in s.cone(p) {
             let d = in_deg
                 .get_mut(&q)
                 .ok_or_else(|| MeshSieveError::MissingPointInCone(format!("{:?}", q)))?;
             *d -= 1;
-            if *d==0 { stack.push(q); }
+            if *d == 0 {
+                stack.push(q);
+            }
         }
     }
     // 3) detect cycles
@@ -75,21 +111,50 @@ where
     // 4) heights
     let mut height = HashMap::new();
     for &p in &topo {
-        let h = s.support(p)
-                .map(|(pred,_)| height.get(&pred).copied().unwrap_or(0))
-                .max().map_or(0, |m| m+1);
-        height.insert(p,h);
+        let h = s
+            .support(p)
+            .map(|(pred, _)| height.get(&pred).copied().unwrap_or(0))
+            .max()
+            .map_or(0, |m| m + 1);
+        height.insert(p, h);
     }
     let max_h = *height.values().max().unwrap_or(&0);
-    let mut strata = vec![Vec::new(); (max_h+1) as usize];
-    for (&p,&h) in &height { strata[h as usize].push(p) }
+    let mut strata = vec![Vec::new(); (max_h + 1) as usize];
+    for (&p, &h) in &height {
+        strata[h as usize].push(p)
+    }
     // 5) depths
     let mut depth = HashMap::new();
     for &p in topo.iter().rev() {
-        let d = s.cone(p)
-                .map(|(succ,_)| depth.get(&succ).copied().unwrap_or(0))
-                .max().map_or(0, |m| m+1);
-        depth.insert(p,d);
+        let d = s
+            .cone(p)
+            .map(|(succ, _)| depth.get(&succ).copied().unwrap_or(0))
+            .max()
+            .map_or(0, |m| m + 1);
+        depth.insert(p, d);
     }
-    Ok(StrataCache { height, depth, strata, diameter: max_h })
+
+    // 6) sort strata for deterministic chart
+    for level in &mut strata {
+        level.sort_unstable();
+    }
+    // 7) flatten strata into chart
+    let mut chart_points = Vec::with_capacity(height.len());
+    for level in &strata {
+        chart_points.extend(level.iter().copied());
+    }
+    // 8) reverse index
+    let mut chart_index = HashMap::with_capacity(chart_points.len());
+    for (i, p) in chart_points.iter().copied().enumerate() {
+        chart_index.insert(p, i);
+    }
+
+    Ok(StrataCache {
+        height,
+        depth,
+        strata,
+        diameter: max_h,
+        chart_points,
+        chart_index,
+    })
 }

--- a/tests/deterministic_traversal.rs
+++ b/tests/deterministic_traversal.rs
@@ -1,0 +1,31 @@
+use mesh_sieve::algs::traversal::{closure_ordered, star_ordered};
+use mesh_sieve::topology::sieve::Sieve;
+use mesh_sieve::topology::sieve::in_memory::InMemorySieve;
+
+#[test]
+fn closure_is_deterministic_in_chart_order() {
+    let mut s = InMemorySieve::<u32, ()>::new();
+    // 0 -> 2,1; 1 -> 3; 2 -> 3
+    s.add_arrow(0, 2, ());
+    s.add_arrow(0, 1, ());
+    s.add_arrow(1, 3, ());
+    s.add_arrow(2, 3, ());
+
+    let cl1 = closure_ordered(&mut s, [0]).unwrap();
+    let cl2 = closure_ordered(&mut s, [0]).unwrap();
+    assert_eq!(cl1, cl2);
+    assert_eq!(cl1, vec![0, 1, 2, 3]);
+}
+
+#[test]
+fn star_is_deterministic_in_chart_order() {
+    let mut s = InMemorySieve::<u32, ()>::new();
+    // 0 -> 1, 2 -> 1, 3 -> 2
+    s.add_arrow(0, 1, ());
+    s.add_arrow(2, 1, ());
+    s.add_arrow(3, 2, ());
+
+    let st1 = star_ordered(&mut s, [1]).unwrap();
+    let st2 = star_ordered(&mut s, [1]).unwrap();
+    assert_eq!(st1, st2);
+}


### PR DESCRIPTION
## Summary
- track deterministic point chart in strata cache
- expose chart helpers on the Sieve trait
- add ordered closure/star traversals using chart indices

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fccc10dc83298a84ad5e6ecee90b