### PR TITLE
Introduce MutableSieve for safe topology mutation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod partitioning;
 
 /// A convenient prelude to import the most-used traits & types:
 pub mod prelude {
-    pub use crate::topology::sieve::{Sieve, OrientedSieve, Orientation};
+    pub use crate::topology::sieve::{Sieve, MutableSieve, OrientedSieve, Orientation};
     pub use crate::topology::sieve::{InMemorySieve, InMemoryOrientedSieve};
     pub use crate::topology::stack::{Stack, InMemoryStack};
     pub use crate::topology::point::PointId;

--- a/src/topology/sieve/in_memory_oriented.rs
+++ b/src/topology/sieve/in_memory_oriented.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 use super::oriented::{Orientation, OrientedSieve};
 use super::sieve_trait::Sieve;
+use super::mutable::MutableSieve;
 use crate::mesh_error::MeshSieveError;
 use crate::topology::cache::InvalidateCache;
 use crate::topology::sieve::strata::{compute_strata, StrataCache};
@@ -288,6 +289,14 @@ where
         Ok(self.strata_cache()?.chart_points.clone())
     }
 
+}
+
+impl<P, T, O> MutableSieve for InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+    O: Orientation,
+{
     fn reserve_cone(&mut self, p: P, additional: usize) {
         self.adjacency_out.entry(p).or_default().reserve(additional);
     }

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -5,6 +5,8 @@
 
 /// Core trait for sieve data structures.
 pub mod sieve_trait;
+/// Trait for sieves that support full topology mutation.
+pub mod mutable;
 /// Orientation-aware extensions to [`Sieve`].
 pub mod oriented;
 /// In-memory implementation of the [`Sieve`] trait.
@@ -22,6 +24,7 @@ pub mod traversal_iter;
 
 // Re-export the core trait and in‐memory impl at top level
 pub use sieve_trait::Sieve;
+pub use mutable::MutableSieve;
 pub use oriented::{Orientation, OrientedSieve};
 pub use in_memory::InMemorySieve;
 pub use in_memory_oriented::InMemoryOrientedSieve;

--- a/src/topology/sieve/mutable.rs
+++ b/src/topology/sieve/mutable.rs
@@ -1,0 +1,115 @@
+use super::sieve_trait::Sieve;
+use crate::topology::cache::InvalidateCache;
+
+/// Trait for sieves that support full topology mutation.
+///
+/// [`Sieve`] provides traversal and arrow-level mutation. `MutableSieve`
+/// extends it with point/role mutators and higher-level convenience routines
+/// that maintain mirror invariants and invalidate caches.
+pub trait MutableSieve: Sieve + InvalidateCache {
+    /// Insert a brand-new point (both roles appear, initially empty).
+    fn add_point(&mut self, p: Self::Point);
+
+    /// Remove a point and **all** incident arrows (both roles).
+    fn remove_point(&mut self, p: Self::Point);
+
+    /// Ensure `p` appears in the base set (outgoing role).
+    fn add_base_point(&mut self, p: Self::Point);
+
+    /// Ensure `p` appears in the cap set (incoming role).
+    fn add_cap_point(&mut self, p: Self::Point);
+
+    /// Remove `p` from base role (drop all outgoing arrows of `p`).
+    fn remove_base_point(&mut self, p: Self::Point);
+
+    /// Remove `p` from cap role (drop all incoming arrows to `p`).
+    fn remove_cap_point(&mut self, p: Self::Point);
+
+    // ---------- Generic convenience mutators (correct by construction) ----------
+
+    /// Replace the entire cone of `p` with `chain` ("last wins" per dst).
+    fn set_cone(
+        &mut self,
+        p: Self::Point,
+        chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
+    )
+    where
+        Self::Payload: Clone,
+    {
+        let old_dsts: Vec<_> = self.cone_points(p).collect();
+        for dst in old_dsts {
+            let _ = self.remove_arrow(p, dst);
+        }
+        for (dst, pay) in chain {
+            self.add_arrow(p, dst, pay);
+        }
+        self.invalidate_cache();
+    }
+
+    /// Append to the cone of `p` (upsert per edge).
+    fn add_cone(
+        &mut self,
+        p: Self::Point,
+        chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
+    )
+    where
+        Self::Payload: Clone,
+    {
+        for (dst, pay) in chain {
+            self.add_arrow(p, dst, pay);
+        }
+        self.invalidate_cache();
+    }
+
+    /// Replace the entire support of `q` with `chain` ("last wins" per src).
+    fn set_support(
+        &mut self,
+        q: Self::Point,
+        chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
+    )
+    where
+        Self::Payload: Clone,
+    {
+        let old_srcs: Vec<_> = self.support_points(q).collect();
+        for src in old_srcs {
+            let _ = self.remove_arrow(src, q);
+        }
+        for (src, pay) in chain {
+            self.add_arrow(src, q, pay);
+        }
+        self.invalidate_cache();
+    }
+
+    /// Append to the support of `q` (upsert per edge).
+    fn add_support(
+        &mut self,
+        q: Self::Point,
+        chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
+    )
+    where
+        Self::Payload: Clone,
+    {
+        for (src, pay) in chain {
+            self.add_arrow(src, q, pay);
+        }
+        self.invalidate_cache();
+    }
+
+    /// Optional preallocation hints; default no-ops are fine.
+    fn reserve_cone(&mut self, _p: Self::Point, _additional: usize) {}
+    fn reserve_support(&mut self, _q: Self::Point, _additional: usize) {}
+}
+
+#[cfg(test)]
+mod docs {
+    /// Calling mutators on a type that is only bound by [`Sieve`] fails to compile.
+    ///
+    /// ```compile_fail
+    /// use mesh_sieve::prelude::Sieve;
+    /// fn needs_mutation<S: Sieve<Point = u32>>(s: &mut S) {
+    ///     s.add_point(1);
+    /// }
+    /// ```
+    #[allow(dead_code)]
+    fn bound_enforced() {}
+}


### PR DESCRIPTION
## Summary
- add `MutableSieve` trait with required point and role mutators
- forward existing `Sieve` mutators to `MutableSieve`
- implement `MutableSieve` for in-memory sieves and expose it in the prelude

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e2ffec0083299449dfa997328726