### PR TITLE
Add deterministic traversal and point ordering

### DIFF
--- a/src/topology/sieve/in_memory.rs
+++ b/src/topology/sieve/in_memory.rs
@@ -3,9 +3,9 @@
 //! This module provides [`InMemorySieve`], a simple and efficient in-memory representation
 //! of a sieve using hash maps for adjacency storage. It supports generic point and payload types.
 
+use super::mutable::MutableSieve;
 use super::sieve_ref::SieveRef;
 use super::sieve_trait::Sieve;
-use super::mutable::MutableSieve;
 use crate::mesh_error::MeshSieveError;
 use crate::topology::cache::InvalidateCache;
 use crate::topology::sieve::strata::{compute_strata, StrataCache};
@@ -93,6 +93,17 @@ impl<P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug, T: Clone> InMemoryS
             if let Some(outs) = self.adjacency_out.get_mut(&src) {
                 outs.retain(|(d, _)| *d != dst);
             }
+        }
+    }
+
+    /// Sort adjacency lists in-place for deterministic neighbor order.
+    /// Mirrors remain consistent as edges are untouched.
+    pub fn sort_adjacency(&mut self) {
+        for outs in self.adjacency_out.values_mut() {
+            outs.sort_unstable_by_key(|(dst, _)| *dst);
+        }
+        for ins in self.adjacency_in.values_mut() {
+            ins.sort_unstable_by_key(|(src, _)| *src);
         }
     }
 

--- a/src/topology/sieve/sieve_trait.rs
+++ b/src/topology/sieve/sieve_trait.rs
@@ -111,6 +111,29 @@ where
         Box::new(set.into_iter())
     }
 
+    /// Deterministic set of all points in total order (`Ord`).
+    #[inline]
+    fn points_sorted(&self) -> Vec<Self::Point>
+    where
+        Self: Sized,
+    {
+        let mut v: Vec<_> = self.points().collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Deterministic whole-graph order guided by strata (height-major then `Ord`).
+    /// Uses the cached chart when available; computes strata otherwise.
+    ///
+    /// Returns an error if the topology is cyclic.
+    #[inline]
+    fn points_chart_order(&mut self) -> Result<Vec<Self::Point>, MeshSieveError>
+    where
+        Self: Sized,
+    {
+        self.chart_points()
+    }
+
     // --- graph traversals ---
     /// Concrete iterator over the transitive closure (downward) from `seeds`.
     /// Prefer this over [`closure`] for zero-alloc traversal.
@@ -157,6 +180,60 @@ where
         I: IntoIterator<Item = Self::Point>,
     {
         Box::new(self.closure_both_iter(seeds))
+    }
+
+    /// Deterministic closure iterator: seeds sorted by `Ord`.
+    #[inline]
+    fn closure_iter_sorted<'s, I>(&'s self, seeds: I) -> ClosureIter<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: Sized,
+    {
+        ClosureIter::new_sorted(self, seeds)
+    }
+
+    /// Deterministic star iterator: seeds sorted by `Ord`.
+    #[inline]
+    fn star_iter_sorted<'s, I>(&'s self, seeds: I) -> StarIter<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: Sized,
+    {
+        StarIter::new_sorted(self, seeds)
+    }
+
+    /// Deterministic bi-directional closure iterator: seeds sorted by `Ord`.
+    #[inline]
+    fn closure_both_iter_sorted<'s, I>(&'s self, seeds: I) -> ClosureBothIter<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: Sized,
+    {
+        ClosureBothIter::new_sorted(self, seeds)
+    }
+
+    /// Boxed deterministic closure iterator.
+    fn closure_sorted<'s, I>(&'s self, seeds: I) -> Box<dyn Iterator<Item = Self::Point> + 's>
+    where
+        I: IntoIterator<Item = Self::Point>,
+    {
+        Box::new(self.closure_iter_sorted(seeds))
+    }
+
+    /// Boxed deterministic star iterator.
+    fn star_sorted<'s, I>(&'s self, seeds: I) -> Box<dyn Iterator<Item = Self::Point> + 's>
+    where
+        I: IntoIterator<Item = Self::Point>,
+    {
+        Box::new(self.star_iter_sorted(seeds))
+    }
+
+    /// Boxed deterministic bi-directional closure iterator.
+    fn closure_both_sorted<'s, I>(&'s self, seeds: I) -> Box<dyn Iterator<Item = Self::Point> + 's>
+    where
+        I: IntoIterator<Item = Self::Point>,
+    {
+        Box::new(self.closure_both_iter_sorted(seeds))
     }
 
     // --- lattice ops ---
@@ -435,8 +512,7 @@ where
         &mut self,
         p: Self::Point,
         chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
-    )
-    where
+    ) where
         Self: super::mutable::MutableSieve,
         Self::Payload: Clone,
     {
@@ -447,8 +523,7 @@ where
         &mut self,
         p: Self::Point,
         chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
-    )
-    where
+    ) where
         Self: super::mutable::MutableSieve,
         Self::Payload: Clone,
     {
@@ -459,8 +534,7 @@ where
         &mut self,
         q: Self::Point,
         chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
-    )
-    where
+    ) where
         Self: super::mutable::MutableSieve,
         Self::Payload: Clone,
     {
@@ -471,8 +545,7 @@ where
         &mut self,
         q: Self::Point,
         chain: impl IntoIterator<Item = (Self::Point, Self::Payload)>,
-    )
-    where
+    ) where
         Self: super::mutable::MutableSieve,
         Self::Payload: Clone,
     {

--- a/src/topology/sieve/tests/determinism_tests.rs
+++ b/src/topology/sieve/tests/determinism_tests.rs
@@ -1,0 +1,52 @@
+use crate::topology::sieve::{traversal_iter::ClosureIter, InMemorySieve, Sieve};
+
+#[test]
+fn points_sorted_is_stable() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    s.add_arrow(10, 20, ());
+    s.add_arrow(30, 20, ());
+    let a = s.points_sorted();
+    let b = s.points_sorted();
+    assert_eq!(a, b);
+    let mut expected = vec![10, 20, 30];
+    expected.sort();
+    assert_eq!(a, expected);
+}
+
+#[test]
+fn closure_iter_sorted_is_stable() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    s.add_arrow(1, 2, ());
+    s.add_arrow(1, 3, ());
+    s.add_arrow(2, 4, ());
+    s.add_arrow(3, 4, ());
+
+    let run = || -> Vec<u32> { s.closure_iter_sorted([3, 1, 2]).collect() };
+    let a = run();
+    let b = run();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn closure_iter_sorted_neighbors_is_lexicographic() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    // insert edges in non-lexicographic order
+    s.add_arrow(1, 3, ());
+    s.add_arrow(1, 2, ());
+    s.add_arrow(2, 5, ());
+    s.add_arrow(2, 4, ());
+
+    let v: Vec<_> = ClosureIter::new_sorted_neighbors(&s, [1]).collect();
+    assert_eq!(v, vec![1, 2, 4, 5, 3]);
+}
+
+#[test]
+fn points_chart_order_is_height_major() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    s.add_arrow(1, 2, ());
+    s.add_arrow(2, 4, ());
+    s.add_arrow(1, 3, ());
+    s.add_arrow(3, 5, ());
+    let chart = s.points_chart_order().unwrap();
+    assert_eq!(chart, vec![1, 2, 3, 4, 5]);
+}

--- a/src/topology/sieve/traversal_iter.rs
+++ b/src/topology/sieve/traversal_iter.rs
@@ -14,12 +14,19 @@ enum Dir {
     Both,
 }
 
+#[derive(Copy, Clone, Debug)]
+enum NeighborOrder {
+    AsIs,
+    Sorted,
+}
+
 /// Depth-first traversal iterator with deterministic "first seen wins" semantics.
 struct TraversalIter<'a, S: Sieve> {
     sieve: &'a S,
     stack: Vec<S::Point>,
     seen: HashSet<S::Point>,
     dir: Dir,
+    norder: NeighborOrder,
 }
 
 impl<'a, S> TraversalIter<'a, S>
@@ -30,39 +37,115 @@ where
     where
         I: IntoIterator<Item = S::Point>,
     {
+        Self::new_with_norder(sieve, seeds, dir, NeighborOrder::AsIs)
+    }
+
+    fn new_with_norder<I>(sieve: &'a S, seeds: I, dir: Dir, norder: NeighborOrder) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
         let stack: Vec<S::Point> = seeds.into_iter().collect();
         let seen: HashSet<S::Point> = stack.iter().copied().collect();
-        Self { sieve, stack, seen, dir }
+        Self {
+            sieve,
+            stack,
+            seen,
+            dir,
+            norder,
+        }
+    }
+
+    fn with_stack(sieve: &'a S, stack: Vec<S::Point>, dir: Dir) -> Self {
+        let seen: HashSet<S::Point> = stack.iter().copied().collect();
+        Self {
+            sieve,
+            stack,
+            seen,
+            dir,
+            norder: NeighborOrder::AsIs,
+        }
     }
 
     #[inline]
     fn push_down(&mut self, p: S::Point) {
-        #[cfg(feature = "sieve_point_only")]
-        for q in self.sieve.cone_points(p) {
-            if self.seen.insert(q) {
-                self.stack.push(q);
+        match self.norder {
+            NeighborOrder::AsIs => {
+                #[cfg(feature = "sieve_point_only")]
+                for q in self.sieve.cone_points(p) {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
+                #[cfg(not(feature = "sieve_point_only"))]
+                for (q, _) in self.sieve.cone(p) {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
             }
-        }
-        #[cfg(not(feature = "sieve_point_only"))]
-        for (q, _) in self.sieve.cone(p) {
-            if self.seen.insert(q) {
-                self.stack.push(q);
+            NeighborOrder::Sorted => {
+                #[cfg(feature = "sieve_point_only")]
+                {
+                    let mut buf: Vec<_> = self.sieve.cone_points(p).collect();
+                    buf.sort_unstable();
+                    for q in buf.into_iter().rev() {
+                        if self.seen.insert(q) {
+                            self.stack.push(q);
+                        }
+                    }
+                }
+                #[cfg(not(feature = "sieve_point_only"))]
+                {
+                    let mut buf: Vec<_> = self.sieve.cone(p).map(|(q, _)| q).collect();
+                    buf.sort_unstable();
+                    for q in buf.into_iter().rev() {
+                        if self.seen.insert(q) {
+                            self.stack.push(q);
+                        }
+                    }
+                }
             }
         }
     }
 
     #[inline]
     fn push_up(&mut self, p: S::Point) {
-        #[cfg(feature = "sieve_point_only")]
-        for q in self.sieve.support_points(p) {
-            if self.seen.insert(q) {
-                self.stack.push(q);
+        match self.norder {
+            NeighborOrder::AsIs => {
+                #[cfg(feature = "sieve_point_only")]
+                for q in self.sieve.support_points(p) {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
+                #[cfg(not(feature = "sieve_point_only"))]
+                for (q, _) in self.sieve.support(p) {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
             }
-        }
-        #[cfg(not(feature = "sieve_point_only"))]
-        for (q, _) in self.sieve.support(p) {
-            if self.seen.insert(q) {
-                self.stack.push(q);
+            NeighborOrder::Sorted => {
+                #[cfg(feature = "sieve_point_only")]
+                {
+                    let mut buf: Vec<_> = self.sieve.support_points(p).collect();
+                    buf.sort_unstable();
+                    for q in buf.into_iter().rev() {
+                        if self.seen.insert(q) {
+                            self.stack.push(q);
+                        }
+                    }
+                }
+                #[cfg(not(feature = "sieve_point_only"))]
+                {
+                    let mut buf: Vec<_> = self.sieve.support(p).map(|(q, _)| q).collect();
+                    buf.sort_unstable();
+                    for q in buf.into_iter().rev() {
+                        if self.seen.insert(q) {
+                            self.stack.push(q);
+                        }
+                    }
+                }
             }
         }
     }
@@ -107,6 +190,37 @@ impl<'a, S: Sieve> ClosureIter<'a, S> {
     {
         ClosureIter(TraversalIter::new(sieve, seeds, Dir::Down))
     }
+
+    /// Deterministic variant: seeds are sorted and deduped.
+    #[inline]
+    pub fn new_sorted<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<S::Point> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        ClosureIter(TraversalIter::with_stack(sieve, stack, Dir::Down))
+    }
+
+    /// Fully deterministic variant sorting neighbors on expansion.
+    #[inline]
+    pub fn new_sorted_neighbors<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<S::Point> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        let seen: HashSet<S::Point> = stack.iter().copied().collect();
+        ClosureIter(TraversalIter {
+            sieve,
+            stack,
+            seen,
+            dir: Dir::Down,
+            norder: NeighborOrder::Sorted,
+        })
+    }
 }
 
 impl<'a, S: Sieve> StarIter<'a, S> {
@@ -117,6 +231,37 @@ impl<'a, S: Sieve> StarIter<'a, S> {
     {
         StarIter(TraversalIter::new(sieve, seeds, Dir::Up))
     }
+
+    /// Deterministic variant: seeds are sorted and deduped.
+    #[inline]
+    pub fn new_sorted<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<S::Point> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        StarIter(TraversalIter::with_stack(sieve, stack, Dir::Up))
+    }
+
+    /// Fully deterministic variant sorting neighbors on expansion.
+    #[inline]
+    pub fn new_sorted_neighbors<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<S::Point> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        let seen: HashSet<S::Point> = stack.iter().copied().collect();
+        StarIter(TraversalIter {
+            sieve,
+            stack,
+            seen,
+            dir: Dir::Up,
+            norder: NeighborOrder::Sorted,
+        })
+    }
 }
 
 impl<'a, S: Sieve> ClosureBothIter<'a, S> {
@@ -126,6 +271,37 @@ impl<'a, S: Sieve> ClosureBothIter<'a, S> {
         I: IntoIterator<Item = S::Point>,
     {
         ClosureBothIter(TraversalIter::new(sieve, seeds, Dir::Both))
+    }
+
+    /// Deterministic variant: seeds are sorted and deduped.
+    #[inline]
+    pub fn new_sorted<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<S::Point> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        ClosureBothIter(TraversalIter::with_stack(sieve, stack, Dir::Both))
+    }
+
+    /// Fully deterministic variant sorting neighbors on expansion.
+    #[inline]
+    pub fn new_sorted_neighbors<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<S::Point> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        let seen: HashSet<S::Point> = stack.iter().copied().collect();
+        ClosureBothIter(TraversalIter {
+            sieve,
+            stack,
+            seen,
+            dir: Dir::Both,
+            norder: NeighborOrder::Sorted,
+        })
     }
 }
 
@@ -155,4 +331,3 @@ impl<'a, S: Sieve> Iterator for ClosureBothIter<'a, S> {
         self.0.next()
     }
 }
-


### PR DESCRIPTION
## Summary
- provide stable point ordering via `points_sorted` and `points_chart_order`
- add opt-in deterministic traversal constructors with seed and neighbor sorting
- allow in-memory sieves to sort adjacency lists
- cover deterministic behavior with new tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ea35a85c832988c8452967230115