### PR TITLE
Add borrow-based traversal iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ criterion = "0.4"
 [features]
 default = []            # keep core lean
 mpi-support = ["mpi", "rayon", "rand", "ahash"]
-sieve_point_only = []
 metis-support = ["metis", "metis-sys", "libffi-sys","bindgen","pkg-config"]
 sieve_ref_fast_dag = []
 

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -9,31 +9,33 @@
 //! [`InMemoryOrientedSieveArc`], and [`InMemoryStackArc`] type aliases for convenience.
 //! Avoid wrappers that convert between `T` and `Arc<T>` on the fly; they add allocations and defeat sharing.
 
-/// Core trait for sieve data structures.
-pub mod sieve_trait;
-/// Trait for sieves that support full topology mutation.
-pub mod mutable;
-/// Orientation-aware extensions to [`Sieve`].
-pub mod oriented;
 /// In-memory implementation of the [`Sieve`] trait.
 pub mod in_memory;
 /// In-memory implementation storing per-arrow orientations.
 pub mod in_memory_oriented;
+/// Trait for sieves that support full topology mutation.
+pub mod mutable;
+/// Orientation-aware extensions to [`Sieve`].
+pub mod oriented;
 /// Reference-returning extensions to [`Sieve`].
 pub mod sieve_ref;
+/// Core trait for sieve data structures.
+pub mod sieve_trait;
 /// Strata sieve implementation.
 pub mod strata;
 /// Concrete traversal iterators without dynamic dispatch.
 pub mod traversal_iter;
 
 // Re-export the core trait and in‐memory impl at top level
-pub use sieve_trait::Sieve;
-pub use mutable::MutableSieve;
-pub use oriented::{Orientation, OrientedSieve};
 pub use in_memory::InMemorySieve;
 pub use in_memory_oriented::InMemoryOrientedSieve;
+pub use mutable::MutableSieve;
+pub use oriented::{Orientation, OrientedSieve};
 pub use sieve_ref::SieveRef;
-pub use traversal_iter::{ClosureBothIter, ClosureIter, StarIter};
+pub use sieve_trait::Sieve;
+pub use traversal_iter::{
+    ClosureBothIter, ClosureBothIterRef, ClosureIter, ClosureIterRef, StarIter, StarIterRef,
+};
 
 use std::sync::Arc;
 

--- a/src/topology/sieve/sieve_trait.rs
+++ b/src/topology/sieve/sieve_trait.rs
@@ -7,7 +7,9 @@
 
 use crate::mesh_error::MeshSieveError;
 use crate::topology::sieve::strata::compute_strata;
-use crate::topology::sieve::traversal_iter::{ClosureBothIter, ClosureIter, StarIter};
+use crate::topology::sieve::traversal_iter::{
+    ClosureBothIter, ClosureBothIterRef, ClosureIter, ClosureIterRef, StarIter, StarIterRef,
+};
 
 pub use crate::topology::cache::InvalidateCache;
 
@@ -135,6 +137,10 @@ where
     }
 
     // --- graph traversals ---
+    /// If you only require point IDs during traversal, implement
+    /// [`SieveRef`](crate::topology::sieve::SieveRef) and use the `_ref`
+    /// variants which borrow payloads and avoid cloning.
+
     /// Concrete iterator over the transitive closure (downward) from `seeds`.
     /// Prefer this over [`closure`] for zero-alloc traversal.
     fn closure_iter<'s, I>(&'s self, seeds: I) -> ClosureIter<'s, Self>
@@ -234,6 +240,99 @@ where
         I: IntoIterator<Item = Self::Point>,
     {
         Box::new(self.closure_both_iter_sorted(seeds))
+    }
+
+    /// Borrow-based downward closure: requires [`SieveRef`] and clones no payloads.
+    #[inline]
+    fn closure_iter_ref<'s, I>(&'s self, seeds: I) -> ClosureIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        ClosureIterRef::new_ref(self, seeds)
+    }
+
+    /// Borrow-based upward star.
+    #[inline]
+    fn star_iter_ref<'s, I>(&'s self, seeds: I) -> StarIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        StarIterRef::new_ref(self, seeds)
+    }
+
+    /// Borrow-based both-direction closure.
+    #[inline]
+    fn closure_both_iter_ref<'s, I>(&'s self, seeds: I) -> ClosureBothIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        ClosureBothIterRef::new_ref(self, seeds)
+    }
+
+    /// Deterministic ref variant: seeds sorted/deduped.
+    #[inline]
+    fn closure_iter_ref_sorted<'s, I>(&'s self, seeds: I) -> ClosureIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        ClosureIterRef::new_ref_sorted(self, seeds)
+    }
+
+    /// Deterministic ref variant: seeds sorted/deduped.
+    #[inline]
+    fn star_iter_ref_sorted<'s, I>(&'s self, seeds: I) -> StarIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        StarIterRef::new_ref_sorted(self, seeds)
+    }
+
+    /// Deterministic ref variant: seeds sorted/deduped.
+    #[inline]
+    fn closure_both_iter_ref_sorted<'s, I>(&'s self, seeds: I) -> ClosureBothIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        ClosureBothIterRef::new_ref_sorted(self, seeds)
+    }
+
+    /// Strongly deterministic ref variant sorting neighbors on expansion.
+    #[inline]
+    fn closure_iter_ref_sorted_neighbors<'s, I>(&'s self, seeds: I) -> ClosureIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        ClosureIterRef::new_ref_sorted_neighbors(self, seeds)
+    }
+
+    /// Strongly deterministic ref variant sorting neighbors on expansion.
+    #[inline]
+    fn star_iter_ref_sorted_neighbors<'s, I>(&'s self, seeds: I) -> StarIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        StarIterRef::new_ref_sorted_neighbors(self, seeds)
+    }
+
+    /// Strongly deterministic ref variant sorting neighbors on expansion.
+    #[inline]
+    fn closure_both_iter_ref_sorted_neighbors<'s, I>(
+        &'s self,
+        seeds: I,
+    ) -> ClosureBothIterRef<'s, Self>
+    where
+        I: IntoIterator<Item = Self::Point>,
+        Self: crate::topology::sieve::SieveRef + Sized,
+    {
+        ClosureBothIterRef::new_ref_sorted_neighbors(self, seeds)
     }
 
     // --- lattice ops ---

--- a/src/topology/sieve/traversal_iter.rs
+++ b/src/topology/sieve/traversal_iter.rs
@@ -1,10 +1,23 @@
 //! Concrete traversal iterators for Sieve topologies.
 //!
-//! These provide stack+seen traversal without dynamic dispatch.
-//! Use via `Sieve::closure_iter`, `star_iter`, or `closure_both_iter`.
+//! Two families are provided:
+//! - **Value-based**: [`ClosureIter`], [`StarIter`], [`ClosureBothIter`]
+//!   which visit `(Point, Payload)` pairs and therefore clone payloads during
+//!   traversal.
+//! - **Borrow-based**: [`ClosureIterRef`], [`StarIterRef`],
+//!   [`ClosureBothIterRef`] which require [`SieveRef`] and operate purely on
+//!   points, cloning no payloads.
+//!
+//! All iterators are depth-first with a `stack` + `seen` set and deterministic
+//! "first seen wins" semantics. Deterministic constructors are available via
+//! the `*_sorted` and `*_sorted_neighbors` constructors.
+//!
+//! Use via the helper methods on [`Sieve`]: `closure_iter*`, `star_iter*`,
+//! or their `_ref` counterparts when `S: SieveRef`.
 
 use std::collections::HashSet;
 
+use super::sieve_ref::SieveRef;
 use super::sieve_trait::Sieve;
 
 #[derive(Copy, Clone, Debug)]
@@ -70,13 +83,6 @@ where
     fn push_down(&mut self, p: S::Point) {
         match self.norder {
             NeighborOrder::AsIs => {
-                #[cfg(feature = "sieve_point_only")]
-                for q in self.sieve.cone_points(p) {
-                    if self.seen.insert(q) {
-                        self.stack.push(q);
-                    }
-                }
-                #[cfg(not(feature = "sieve_point_only"))]
                 for (q, _) in self.sieve.cone(p) {
                     if self.seen.insert(q) {
                         self.stack.push(q);
@@ -84,24 +90,11 @@ where
                 }
             }
             NeighborOrder::Sorted => {
-                #[cfg(feature = "sieve_point_only")]
-                {
-                    let mut buf: Vec<_> = self.sieve.cone_points(p).collect();
-                    buf.sort_unstable();
-                    for q in buf.into_iter().rev() {
-                        if self.seen.insert(q) {
-                            self.stack.push(q);
-                        }
-                    }
-                }
-                #[cfg(not(feature = "sieve_point_only"))]
-                {
-                    let mut buf: Vec<_> = self.sieve.cone(p).map(|(q, _)| q).collect();
-                    buf.sort_unstable();
-                    for q in buf.into_iter().rev() {
-                        if self.seen.insert(q) {
-                            self.stack.push(q);
-                        }
+                let mut buf: Vec<_> = self.sieve.cone(p).map(|(q, _)| q).collect();
+                buf.sort_unstable();
+                for q in buf.into_iter().rev() {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
                     }
                 }
             }
@@ -112,13 +105,6 @@ where
     fn push_up(&mut self, p: S::Point) {
         match self.norder {
             NeighborOrder::AsIs => {
-                #[cfg(feature = "sieve_point_only")]
-                for q in self.sieve.support_points(p) {
-                    if self.seen.insert(q) {
-                        self.stack.push(q);
-                    }
-                }
-                #[cfg(not(feature = "sieve_point_only"))]
                 for (q, _) in self.sieve.support(p) {
                     if self.seen.insert(q) {
                         self.stack.push(q);
@@ -126,24 +112,11 @@ where
                 }
             }
             NeighborOrder::Sorted => {
-                #[cfg(feature = "sieve_point_only")]
-                {
-                    let mut buf: Vec<_> = self.sieve.support_points(p).collect();
-                    buf.sort_unstable();
-                    for q in buf.into_iter().rev() {
-                        if self.seen.insert(q) {
-                            self.stack.push(q);
-                        }
-                    }
-                }
-                #[cfg(not(feature = "sieve_point_only"))]
-                {
-                    let mut buf: Vec<_> = self.sieve.support(p).map(|(q, _)| q).collect();
-                    buf.sort_unstable();
-                    for q in buf.into_iter().rev() {
-                        if self.seen.insert(q) {
-                            self.stack.push(q);
-                        }
+                let mut buf: Vec<_> = self.sieve.support(p).map(|(q, _)| q).collect();
+                buf.sort_unstable();
+                for q in buf.into_iter().rev() {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
                     }
                 }
             }
@@ -324,6 +297,286 @@ impl<'a, S: Sieve> Iterator for StarIter<'a, S> {
 }
 
 impl<'a, S: Sieve> Iterator for ClosureBothIter<'a, S> {
+    type Item = S::Point;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+/// Depth-first traversal iterator (borrow-based, point-only).
+struct TraversalIterRef<'a, S: Sieve + SieveRef> {
+    sieve: &'a S,
+    stack: Vec<S::Point>,
+    seen: HashSet<S::Point>,
+    dir: Dir,
+    norder: NeighborOrder,
+}
+
+impl<'a, S> TraversalIterRef<'a, S>
+where
+    S: Sieve + SieveRef,
+{
+    #[inline]
+    fn with_stack(sieve: &'a S, stack: Vec<S::Point>, dir: Dir, norder: NeighborOrder) -> Self {
+        let seen = stack.iter().copied().collect();
+        Self {
+            sieve,
+            stack,
+            seen,
+            dir,
+            norder,
+        }
+    }
+
+    #[inline]
+    fn push_down(&mut self, p: S::Point) {
+        match self.norder {
+            NeighborOrder::AsIs => {
+                for q in SieveRef::cone_points(self.sieve, p) {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
+            }
+            NeighborOrder::Sorted => {
+                let mut buf: Vec<_> = SieveRef::cone_points(self.sieve, p).collect();
+                buf.sort_unstable();
+                for q in buf.into_iter().rev() {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn push_up(&mut self, p: S::Point) {
+        match self.norder {
+            NeighborOrder::AsIs => {
+                for q in SieveRef::support_points(self.sieve, p) {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
+            }
+            NeighborOrder::Sorted => {
+                let mut buf: Vec<_> = SieveRef::support_points(self.sieve, p).collect();
+                buf.sort_unstable();
+                for q in buf.into_iter().rev() {
+                    if self.seen.insert(q) {
+                        self.stack.push(q);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'a, S> Iterator for TraversalIterRef<'a, S>
+where
+    S: Sieve + SieveRef,
+{
+    type Item = S::Point;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let p = self.stack.pop()?;
+        match self.dir {
+            Dir::Down => self.push_down(p),
+            Dir::Up => self.push_up(p),
+            Dir::Both => {
+                self.push_down(p);
+                self.push_up(p);
+            }
+        }
+        Some(p)
+    }
+}
+
+/// Downward closure iterator (borrow-based).
+pub struct ClosureIterRef<'a, S: Sieve + SieveRef>(TraversalIterRef<'a, S>);
+/// Upward star iterator (borrow-based).
+pub struct StarIterRef<'a, S: Sieve + SieveRef>(TraversalIterRef<'a, S>);
+/// Bidirectional closure iterator (borrow-based).
+pub struct ClosureBothIterRef<'a, S: Sieve + SieveRef>(TraversalIterRef<'a, S>);
+
+impl<'a, S> ClosureIterRef<'a, S>
+where
+    S: Sieve + SieveRef,
+{
+    #[inline]
+    pub fn new_ref<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let stack: Vec<_> = seeds.into_iter().collect();
+        ClosureIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Down,
+            NeighborOrder::AsIs,
+        ))
+    }
+
+    /// Deterministic: seeds sorted/deduped.
+    #[inline]
+    pub fn new_ref_sorted<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<_> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        ClosureIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Down,
+            NeighborOrder::AsIs,
+        ))
+    }
+
+    /// Deterministic + neighbor-sorted expansion.
+    #[inline]
+    pub fn new_ref_sorted_neighbors<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<_> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        ClosureIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Down,
+            NeighborOrder::Sorted,
+        ))
+    }
+}
+
+impl<'a, S> StarIterRef<'a, S>
+where
+    S: Sieve + SieveRef,
+{
+    #[inline]
+    pub fn new_ref<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let stack: Vec<_> = seeds.into_iter().collect();
+        StarIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Up,
+            NeighborOrder::AsIs,
+        ))
+    }
+
+    #[inline]
+    pub fn new_ref_sorted<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<_> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        StarIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Up,
+            NeighborOrder::AsIs,
+        ))
+    }
+
+    #[inline]
+    pub fn new_ref_sorted_neighbors<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<_> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        StarIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Up,
+            NeighborOrder::Sorted,
+        ))
+    }
+}
+
+impl<'a, S> ClosureBothIterRef<'a, S>
+where
+    S: Sieve + SieveRef,
+{
+    #[inline]
+    pub fn new_ref<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let stack: Vec<_> = seeds.into_iter().collect();
+        ClosureBothIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Both,
+            NeighborOrder::AsIs,
+        ))
+    }
+
+    #[inline]
+    pub fn new_ref_sorted<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<_> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        ClosureBothIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Both,
+            NeighborOrder::AsIs,
+        ))
+    }
+
+    #[inline]
+    pub fn new_ref_sorted_neighbors<I>(sieve: &'a S, seeds: I) -> Self
+    where
+        I: IntoIterator<Item = S::Point>,
+    {
+        let mut stack: Vec<_> = seeds.into_iter().collect();
+        stack.sort_unstable();
+        stack.dedup();
+        ClosureBothIterRef(TraversalIterRef::with_stack(
+            sieve,
+            stack,
+            Dir::Both,
+            NeighborOrder::Sorted,
+        ))
+    }
+}
+
+impl<'a, S: Sieve + SieveRef> Iterator for ClosureIterRef<'a, S> {
+    type Item = S::Point;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, S: Sieve + SieveRef> Iterator for StarIterRef<'a, S> {
+    type Item = S::Point;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, S: Sieve + SieveRef> Iterator for ClosureBothIterRef<'a, S> {
     type Item = S::Point;
 
     #[inline]

--- a/tests/traversal_iter_ref.rs
+++ b/tests/traversal_iter_ref.rs
@@ -1,0 +1,29 @@
+use mesh_sieve::topology::sieve::Sieve;
+use mesh_sieve::topology::sieve::in_memory::InMemorySieve;
+use mesh_sieve::topology::sieve::traversal_iter::{ClosureIter, ClosureIterRef};
+
+#[test]
+fn ref_and_value_closure_visit_same_set() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    s.add_arrow(1, 2, ());
+    s.add_arrow(1, 3, ());
+    s.add_arrow(2, 4, ());
+    s.add_arrow(3, 4, ());
+
+    let a: std::collections::BTreeSet<_> = ClosureIter::new(&s, [1]).collect();
+    let b: std::collections::BTreeSet<_> = ClosureIterRef::new_ref(&s, [1]).collect();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn ref_sorted_neighbors_is_deterministic() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    s.add_arrow(1, 3, ());
+    s.add_arrow(1, 2, ());
+    s.add_arrow(2, 5, ());
+    s.add_arrow(2, 4, ());
+
+    let v1: Vec<_> = ClosureIterRef::new_ref_sorted_neighbors(&s, [1]).collect();
+    let v2: Vec<_> = ClosureIterRef::new_ref_sorted_neighbors(&s, [1]).collect();
+    assert_eq!(v1, v2);
+}


### PR DESCRIPTION
## Summary
- add borrow-based traversal iterators that operate only on points
- expose Sieve helper methods for clone-free traversals and deterministic variants
- remove obsolete `sieve_point_only` feature and add ref traversal tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8f9b55d2483298a1fd45260584304