### PR TITLE
Introduce orientation groups and helpers

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -10,12 +10,14 @@
 
 pub mod arrow;
 pub mod cache;
+pub mod orientation;
 pub mod point;
 pub mod sieve;
 pub mod stack;
 pub mod utils;
 
 pub use cache::InvalidateCache;
+pub use orientation::*;
 pub use sieve::*;
 
 #[cfg(test)]

--- a/src/topology/orientation.rs
+++ b/src/topology/orientation.rs
@@ -1,0 +1,193 @@
+//! Canonical orientation groups for meshes (edges, triangles, quads, ...)
+//! with small, copyable representations.
+
+use core::fmt::{Debug, Formatter};
+
+use crate::topology::sieve::oriented::Orientation;
+
+/// 1-bit flip (edge reversal in 1D); group C₂.
+/// Compose = XOR; inverse = self.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[repr(transparent)]
+pub struct BitFlip(pub bool);
+impl Debug for BitFlip {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("BitFlip").field(&self.0).finish()
+    }
+}
+impl Orientation for BitFlip {
+    #[inline]
+    fn compose(a: Self, b: Self) -> Self {
+        BitFlip(a.0 ^ b.0)
+    }
+    #[inline]
+    fn inverse(a: Self) -> Self {
+        a
+    }
+}
+
+/// Pure rotation group C_N (polygon rotations); stored as u8 mod N.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct Rot<const N: u8>(pub u8);
+impl<const N: u8> Default for Rot<N> {
+    fn default() -> Self {
+        Rot(0)
+    }
+}
+impl<const N: u8> Debug for Rot<N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Rot").field(&self.0).finish()
+    }
+}
+impl<const N: u8> Orientation for Rot<N> {
+    #[inline]
+    fn compose(a: Self, b: Self) -> Self {
+        Rot::<N>((a.0 + b.0) % N)
+    }
+    #[inline]
+    fn inverse(a: Self) -> Self {
+        Rot::<N>((N - (a.0 % N)) % N)
+    }
+}
+
+/// Dihedral group D_N (rotations + reflections); covers triangles (N=3) & quads (N=4).
+/// Element = r^k * s^f, with k∈[0,N), f∈{0,1}; law: (k,f)*(k',f') = (k + (-1)^f k' mod N, f xor f')
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct Dihedral<const N: u8> {
+    pub rot: u8,
+    pub flip: bool,
+}
+impl<const N: u8> Default for Dihedral<N> {
+    fn default() -> Self {
+        Self {
+            rot: 0,
+            flip: false,
+        }
+    }
+}
+impl<const N: u8> Debug for Dihedral<N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Dihedral")
+            .field("rot", &self.rot)
+            .field("flip", &self.flip)
+            .finish()
+    }
+}
+impl<const N: u8> Orientation for Dihedral<N> {
+    #[inline]
+    fn compose(a: Self, b: Self) -> Self {
+        let add = if a.flip {
+            (N - (b.rot % N)) % N
+        } else {
+            b.rot % N
+        };
+        let rot = (a.rot + add) % N;
+        let flip = a.flip ^ b.flip;
+        Self { rot, flip }
+    }
+    #[inline]
+    fn inverse(a: Self) -> Self {
+        if !a.flip {
+            Self {
+                rot: (N - (a.rot % N)) % N,
+                flip: false,
+            }
+        } else {
+            Self {
+                rot: a.rot % N,
+                flip: true,
+            }
+        }
+    }
+}
+
+/// Small, fixed-size permutation group S_K, represented as mapping [0..K) -> [0..K).
+/// Useful for faces (triangles => S3) or element-local permutations in 3D.
+/// Compose(p,q) = p ∘ q (apply q, then p).
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct Perm<const K: usize>(pub [u8; K]);
+impl<const K: usize> Default for Perm<K> {
+    fn default() -> Self {
+        let mut id = [0u8; K];
+        let mut i = 0;
+        while i < K {
+            id[i] = i as u8;
+            i += 1;
+        }
+        Perm(id)
+    }
+}
+impl<const K: usize> Debug for Perm<K> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Perm").field(&self.0).finish()
+    }
+}
+impl<const K: usize> Perm<K> {
+    #[inline]
+    pub fn new_unchecked(p: [u8; K]) -> Self {
+        Perm(p)
+    }
+    #[inline]
+    pub fn invert(&self) -> Self {
+        let mut inv = [0u8; K];
+        let mut i = 0;
+        while i < K {
+            inv[self.0[i] as usize] = i as u8;
+            i += 1;
+        }
+        Perm(inv)
+    }
+}
+impl<const K: usize> Orientation for Perm<K> {
+    #[inline]
+    fn compose(a: Self, b: Self) -> Self {
+        let mut out = [0u8; K];
+        let mut i = 0;
+        while i < K {
+            out[i] = a.0[b.0[i] as usize];
+            i += 1;
+        }
+        Perm(out)
+    }
+    #[inline]
+    fn inverse(a: Self) -> Self {
+        a.invert()
+    }
+}
+
+// Ergonomic aliases for meshes:
+/// Cheap sign-flip alias.
+pub use BitFlip as Sign; // 1D edge flip
+/// Triangle face orientation.
+pub type D3 = Dihedral<3>;
+/// Quad face orientation.
+pub type D4 = Dihedral<4>;
+/// Triangle vertex permutations.
+pub type S3 = Perm<3>;
+/// Tetra permutations.
+pub type S4 = Perm<4>;
+
+/// Accumulate a sequence of orientation steps along a path, left-to-right.
+/// Returns the total orientation from the seed to the end of the path.
+/// Identity is `O::default()`.
+#[inline]
+pub fn accumulate_path<O, I>(path: I) -> O
+where
+    O: Orientation,
+    I: IntoIterator<Item = O>,
+{
+    path.into_iter()
+        .fold(O::default(), |acc, step| O::compose(acc, step))
+}
+
+/// Extension for `OrientedSieve` call-sites (pure sugar).
+pub trait AccumulatePathExt: Sized {
+    fn accumulate_path<O, I>(path: I) -> O
+    where
+        O: Orientation,
+        I: IntoIterator<Item = O>,
+    {
+        accumulate_path(path)
+    }
+}
+impl<T> AccumulatePathExt for T {}

--- a/src/topology/sieve/in_memory_oriented.rs
+++ b/src/topology/sieve/in_memory_oriented.rs
@@ -5,15 +5,16 @@ use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::mutable::MutableSieve;
 use super::oriented::{Orientation, OrientedSieve};
 use super::sieve_trait::Sieve;
-use super::mutable::MutableSieve;
 use crate::mesh_error::MeshSieveError;
 use crate::topology::cache::InvalidateCache;
-use crate::topology::sieve::strata::{compute_strata, StrataCache};
+use crate::topology::orientation::Sign;
+use crate::topology::sieve::strata::{StrataCache, compute_strata};
 
 #[derive(Clone, Debug)]
-pub struct InMemoryOrientedSieve<P, T = (), O = i32>
+pub struct InMemoryOrientedSieve<P, T = (), O = Sign>
 where
     P: Ord + std::fmt::Debug,
     O: Orientation,
@@ -307,7 +308,6 @@ where
     fn chart_points(&mut self) -> Result<Vec<P>, MeshSieveError> {
         Ok(self.strata_cache()?.chart_points.clone())
     }
-
 }
 
 impl<P, T, O> MutableSieve for InMemoryOrientedSieve<P, T, O>

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -42,7 +42,18 @@ use std::sync::Arc;
 /// In-memory sieve storing `Arc<T>` payloads for shared ownership.
 pub type InMemorySieveArc<P, T> = in_memory::InMemorySieve<P, Arc<T>>;
 /// Oriented in-memory sieve storing `Arc<T>` payloads.
-pub type InMemoryOrientedSieveArc<P, T, O = i32> =
+pub type InMemoryOrientedSieveArc<P, T, O = crate::topology::orientation::Sign> =
     in_memory_oriented::InMemoryOrientedSieve<P, Arc<T>, O>;
 /// Vertical stack with `Arc<T>` payload sharing.
 pub type InMemoryStackArc<B, C, T> = crate::topology::stack::InMemoryStack<B, C, Arc<T>>;
+
+// Helpful aliases for common orientation groups
+pub type OrientedTriSieve<P, T> =
+    in_memory_oriented::InMemoryOrientedSieve<P, T, crate::topology::orientation::D3>;
+pub type OrientedQuadSieve<P, T> =
+    in_memory_oriented::InMemoryOrientedSieve<P, T, crate::topology::orientation::D4>;
+pub type OrientedSignSieve<P, T> =
+    in_memory_oriented::InMemoryOrientedSieve<P, T, crate::topology::orientation::Sign>;
+
+#[cfg(test)]
+mod tests;

--- a/src/topology/sieve/oriented.rs
+++ b/src/topology/sieve/oriented.rs
@@ -1,19 +1,38 @@
 //! Oriented variants of Sieve traversals in the spirit of PETSc DMPlex.
 //!
-//! - `Orientation` models a tiny group with `compose` and `inverse`,
-//!    so we can accumulate per-arrow orientations along transitive closure.
-//! - `OrientedSieve` extends `Sieve` with orientation-aware cone/support
-//!    and a constructor for arrows that includes an orientation.
+//! - [`Orientation`] models a finite group with `compose` and `inverse`,
+//!   so we can accumulate per-arrow orientations along transitive closure.
+//! - [`OrientedSieve`] extends [`Sieve`] with orientation-aware cone/support
+//!   and a constructor for arrows that includes an orientation.
 //!
-//! Default `closure_o`/`star_o` accumulate orientations via `compose`,
-//! and return a stable, point-sorted vector for deterministic behavior.
+//! `compose(a, b)` is interpreted as "do `a`, then `b`" while traversing a
+//! path (left-accumulating). `inverse(a)` is the orientation used when the
+//! same arrow is traversed in reverse.
+//!
+//! ## Choosing an orientation type
+//!
+//! | Use case                    | Type |
+//! |----------------------------|------|
+//! | 1D edge flip / sign        | [`Sign`](crate::topology::orientation::Sign) |
+//! | Triangle face orientation  | [`D3`](crate::topology::orientation::D3) |
+//! | Quad face orientation      | [`D4`](crate::topology::orientation::D4) |
+//! | Arbitrary k-permutation    | [`Perm<K>`](crate::topology::orientation::Perm) |
+//!
+//! Default [`closure_o`](OrientedSieve::closure_o)/[`star_o`](OrientedSieve::star_o)
+//! accumulate orientations via [`Orientation::compose`] and return a stable,
+//! point-sorted vector for deterministic behavior.
 
 use super::sieve_trait::Sieve;
 
-/// A minimal orientation "group".
-/// Implementations should satisfy:
-///   compose(id, a) = a, compose(a, id) = a, compose(a, inverse(a)) = id,
-///   and compose is associative.
+/// A finite group capturing per-arrow orientations/permutations.
+/// Implementations **must** satisfy for all `a`, `b`, `c`:
+///   - associativity: `compose(a, compose(b, c)) == compose(compose(a, b), c)`
+///   - identity:      `compose(id, a) == a == compose(a, id)` where `id = Default::default()`
+///   - inverse:       `compose(a, inverse(a)) == id == compose(inverse(a), a)`
+///
+/// Semantics:
+/// - `compose(a, b)` = "do `a`, then `b`" along a path (left-accumulating).
+/// - `inverse(a)`    = orientation used when traversing the same arrow in reverse.
 pub trait Orientation: Copy + Default + std::fmt::Debug + 'static {
     fn compose(a: Self, b: Self) -> Self;
     fn inverse(a: Self) -> Self;
@@ -21,23 +40,39 @@ pub trait Orientation: Copy + Default + std::fmt::Debug + 'static {
 
 /// Trivial orientation (no-op)
 impl Orientation for () {
-    #[inline] fn compose(_: (), _: ()) -> () { () }
-    #[inline] fn inverse(_: ()) -> () { () }
+    #[inline]
+    fn compose(_: (), _: ()) -> () {
+        ()
+    }
+    #[inline]
+    fn inverse(_: ()) -> () {
+        ()
+    }
 }
 
-/// Common integer orientation (e.g. flips/rotations encoded as ints).
-/// Default composition is additive; customize with your own type if needed.
+/// Legacy integer orientation (additive). Prefer explicit types from
+/// [`crate::topology::orientation`].
 impl Orientation for i32 {
-    #[inline] fn compose(a: i32, b: i32) -> i32 { a + b }
-    #[inline] fn inverse(a: i32) -> i32 { -a }
+    #[inline]
+    fn compose(a: i32, b: i32) -> i32 {
+        a + b
+    }
+    #[inline]
+    fn inverse(a: i32) -> i32 {
+        -a
+    }
 }
 
 /// Sieve extension with orientation-aware incidence.
 pub trait OrientedSieve: Sieve {
     type Orient: Orientation;
 
-    type ConeOIter<'a>: Iterator<Item = (Self::Point, Self::Orient)> where Self: 'a;
-    type SupportOIter<'a>: Iterator<Item = (Self::Point, Self::Orient)> where Self: 'a;
+    type ConeOIter<'a>: Iterator<Item = (Self::Point, Self::Orient)>
+    where
+        Self: 'a;
+    type SupportOIter<'a>: Iterator<Item = (Self::Point, Self::Orient)>
+    where
+        Self: 'a;
 
     /// Oriented outgoing incidence from `p`. Pairs `(dst, orient(p->dst))`.
     fn cone_o<'a>(&'a self, p: Self::Point) -> Self::ConeOIter<'a>;
@@ -51,8 +86,13 @@ pub trait OrientedSieve: Sieve {
     fn support_o<'a>(&'a self, p: Self::Point) -> Self::SupportOIter<'a>;
 
     /// Insert an oriented arrow `src -> dst` with payload and orientation.
-    fn add_arrow_o(&mut self, src: Self::Point, dst: Self::Point,
-                   payload: Self::Payload, orient: Self::Orient);
+    fn add_arrow_o(
+        &mut self,
+        src: Self::Point,
+        dst: Self::Point,
+        payload: Self::Payload,
+        orient: Self::Orient,
+    );
 
     /// Transitive closure with accumulated orientations (downward).
     ///
@@ -62,14 +102,18 @@ pub trait OrientedSieve: Sieve {
         I: IntoIterator<Item = Self::Point>,
     {
         use std::collections::HashMap;
-        let mut stack: Vec<(Self::Point, Self::Orient)> =
-            seeds.into_iter().map(|p| (p, Self::Orient::default())).collect();
+        let mut stack: Vec<(Self::Point, Self::Orient)> = seeds
+            .into_iter()
+            .map(|p| (p, Self::Orient::default()))
+            .collect();
 
         // first-arrival wins to keep deterministic, minimal composition
         let mut best: HashMap<Self::Point, Self::Orient> = HashMap::new();
 
         while let Some((p, acc)) = stack.pop() {
-            if best.contains_key(&p) { continue; }
+            if best.contains_key(&p) {
+                continue;
+            }
             best.insert(p, acc);
             for (q, o) in self.cone_o(p) {
                 let nxt = <Self::Orient as Orientation>::compose(acc, o);
@@ -93,12 +137,16 @@ pub trait OrientedSieve: Sieve {
         I: IntoIterator<Item = Self::Point>,
     {
         use std::collections::HashMap;
-        let mut stack: Vec<(Self::Point, Self::Orient)> =
-            seeds.into_iter().map(|p| (p, Self::Orient::default())).collect();
+        let mut stack: Vec<(Self::Point, Self::Orient)> = seeds
+            .into_iter()
+            .map(|p| (p, Self::Orient::default()))
+            .collect();
         let mut best: HashMap<Self::Point, Self::Orient> = HashMap::new();
 
         while let Some((p, acc)) = stack.pop() {
-            if best.contains_key(&p) { continue; }
+            if best.contains_key(&p) {
+                continue;
+            }
             best.insert(p, acc);
             for (q, o_src_p) in self.support_o(p) {
                 // Walking "up" the arrow means composing with the inverse
@@ -115,4 +163,3 @@ pub trait OrientedSieve: Sieve {
         out
     }
 }
-

--- a/src/topology/sieve/tests/mod.rs
+++ b/src/topology/sieve/tests/mod.rs
@@ -1,0 +1,1 @@
+mod orientation_tests;

--- a/src/topology/sieve/tests/orientation_tests.rs
+++ b/src/topology/sieve/tests/orientation_tests.rs
@@ -1,0 +1,86 @@
+use crate::topology::orientation::*;
+use crate::topology::sieve::oriented::Orientation;
+
+// Group laws for BitFlip
+#[test]
+fn bitflip_group_laws() {
+    let id = BitFlip::default();
+    let a = BitFlip(true);
+    // identity
+    assert_eq!(BitFlip::compose(id, a), a);
+    assert_eq!(BitFlip::compose(a, id), a);
+    // inverse
+    assert_eq!(BitFlip::compose(a, Orientation::inverse(a)), id);
+    // associativity (exhaustive: 2^3)
+    for &x in &[BitFlip(false), BitFlip(true)] {
+        for &y in &[BitFlip(false), BitFlip(true)] {
+            for &z in &[BitFlip(false), BitFlip(true)] {
+                assert_eq!(
+                    BitFlip::compose(x, BitFlip::compose(y, z)),
+                    BitFlip::compose(BitFlip::compose(x, y), z)
+                );
+            }
+        }
+    }
+}
+
+// D3 sanity
+#[test]
+fn d3_compose_inverse() {
+    let id = D3::default();
+    let r1 = D3 {
+        rot: 1,
+        flip: false,
+    };
+    let r2 = D3 {
+        rot: 2,
+        flip: false,
+    };
+    let s = D3 { rot: 0, flip: true };
+    // r1 * r2 = r3 mod 3 (i.e., rot 0)
+    assert_eq!(
+        D3::compose(r1, r2),
+        D3 {
+            rot: 0,
+            flip: false
+        }
+    );
+    // s*s = id
+    assert_eq!(D3::compose(s, s), id);
+    // (r * s) * (r * s) = id
+    let rs = D3::compose(r1, s);
+    assert_eq!(D3::compose(rs, rs), id);
+    // inverse law
+    for rot in 0..3 {
+        for &flip in &[false, true] {
+            let a = D3 { rot, flip };
+            assert_eq!(D3::compose(a, D3::inverse(a)), id);
+        }
+    }
+}
+
+// Perm<3> sanity
+#[test]
+fn s3_permutation_laws() {
+    let id = S3::default();
+    let p: S3 = Perm([1, 2, 0]); // 0->1,1->2,2->0
+    let q: S3 = Perm([0, 2, 1]); // swap 1,2
+    // associativity with id
+    assert_eq!(
+        Perm::<3>::compose(Perm::<3>::compose(p, q), id),
+        Perm::<3>::compose(p, Perm::<3>::compose(q, id))
+    );
+    // inverse
+    let pinv = p.invert();
+    let qinv = q.invert();
+    assert_eq!(Perm::<3>::compose(p, pinv), id);
+    assert_eq!(Perm::<3>::compose(q, qinv), id);
+}
+
+// Path accumulation
+#[test]
+fn accumulate_path_works() {
+    let steps = [BitFlip(true), BitFlip(true), BitFlip(false)];
+    let tot: BitFlip = accumulate_path(steps);
+    assert_eq!(tot, BitFlip(false)); // true ^ true ^ false = false
+}

--- a/src/topology/sieve/tests/remove_tests.rs
+++ b/src/topology/sieve/tests/remove_tests.rs
@@ -61,7 +61,7 @@ fn remove_cap_point_removes_incoming_and_cap_key() {
 
 #[test]
 fn oriented_remove_point_scrubs_both_sides_and_preserves_presence() {
-    let mut s = InMemoryOrientedSieve::<u32, (), i32>::default();
+    let mut s = InMemoryOrientedSieve::<u32, ()>::default();
 
     s.add_point(1);
     s.add_point(2);

--- a/src/topology/sieve/tests/upsert_tests.rs
+++ b/src/topology/sieve/tests/upsert_tests.rs
@@ -1,3 +1,4 @@
+use crate::topology::orientation::Sign;
 use crate::topology::sieve::in_memory_oriented::InMemoryOrientedSieve;
 use crate::topology::sieve::{InMemorySieve, Sieve};
 use crate::topology::stack::{InMemoryStack, Stack};
@@ -37,13 +38,13 @@ fn set_cone_last_wins_and_mirrors() {
 
 #[test]
 fn oriented_add_upserts_payload_and_orientation() {
-    let mut s = InMemoryOrientedSieve::<u32, i32, i32>::default();
-    s.add_arrow_o(1, 2, 10, 5);
-    s.add_arrow_o(1, 2, 20, -3);
+    let mut s = InMemoryOrientedSieve::<u32, i32>::default();
+    s.add_arrow_o(1, 2, 10, Sign(true));
+    s.add_arrow_o(1, 2, 20, Sign(false));
     let outs: Vec<_> = s.cone(1).collect();
     assert_eq!(outs, vec![(2, 20)]);
     let outs_o: Vec<_> = s.cone_o(1).collect();
-    assert_eq!(outs_o, vec![(2, -3)]);
+    assert_eq!(outs_o, vec![(2, Sign(false))]);
 }
 
 #[test]

--- a/tests/oriented_closure.rs
+++ b/tests/oriented_closure.rs
@@ -1,44 +1,70 @@
+use mesh_sieve::section::{Section, section_on_closure_o};
+use mesh_sieve::topology::orientation::Sign;
 use mesh_sieve::topology::sieve::InMemoryOrientedSieve;
 use mesh_sieve::topology::sieve::oriented::OrientedSieve;
-use mesh_sieve::section::{Section, section_on_closure_o};
 
 #[derive(Default)]
 struct ToySection;
 impl Section for ToySection {
     type Point = u32;
-    fn dof(&self, _p: u32) -> usize { 1 }
-    fn offset(&self, p: u32) -> usize { p as usize }
+    fn dof(&self, _p: u32) -> usize {
+        1
+    }
+    fn offset(&self, p: u32) -> usize {
+        p as usize
+    }
 }
 
 #[test]
 fn oriented_closure_accumulates() {
-    // Build: cell 0 -> edges 10,11 with orientations +1, -1; edge 10 -> vertex 20 with +1
-    // Accumulated orientation to 20 should be (+1 compose +1) = +2
-    let mut s = InMemoryOrientedSieve::<u32, (), i32>::new();
-    s.add_arrow_o(0, 10, (),  1);
-    s.add_arrow_o(0, 11, (), -1);
-    s.add_arrow_o(10, 20, (), 1);
+    // Build: cell 0 -> edges 10,11 with orientations flip=false, flip=true;
+    // edge 10 -> vertex 20 with flip=true. Accumulated orientation to 20
+    // should be false ^ true = true.
+    let mut s = InMemoryOrientedSieve::<u32, (), Sign>::new();
+    s.add_arrow_o(0, 10, (), Sign(false));
+    s.add_arrow_o(0, 11, (), Sign(true));
+    s.add_arrow_o(10, 20, (), Sign(true));
 
     let cl = s.closure_o([0]);
     // Points appear sorted: 0,10,11,20 with accumulated orientations from seed 0
-    assert_eq!(cl, vec![(0,0), (10,1), (11,-1), (20,2)]);
+    assert_eq!(
+        cl,
+        vec![
+            (0, Sign(false)),
+            (10, Sign(false)),
+            (11, Sign(true)),
+            (20, Sign(true)),
+        ]
+    );
 
     // Combine with Section helper
     let sec = ToySection::default();
     let spans: Vec<_> = section_on_closure_o(&s, &sec, 0).collect();
-    assert_eq!(spans, vec![(0,1,0), (10,1,1), (11,1,-1), (20,1,2)]);
+    assert_eq!(
+        spans,
+        vec![
+            (0, 1, Sign(false)),
+            (10, 1, Sign(false)),
+            (11, 1, Sign(true)),
+            (20, 1, Sign(true)),
+        ]
+    );
 }
 
 #[test]
 fn star_orientation_inverts_step() {
-    // Reverse traversal should invert the step orientation
-    let mut s = InMemoryOrientedSieve::<u32, (), i32>::new();
-    s.add_arrow_o(7, 3, (),  2); // ori(7->3)=+2
-    s.add_arrow_o(3, 1, (), -1); // ori(3->1)=-1
+    // Reverse traversal should compose with inverse at each step.
+    let mut s = InMemoryOrientedSieve::<u32, (), Sign>::new();
+    s.add_arrow_o(7, 3, (), Sign(true)); // ori(7->3)=flip
+    s.add_arrow_o(3, 1, (), Sign(true)); // ori(3->1)=flip
 
     // Star from leaf 1 should go up and compose inverses:
-    // inv(-1)=+1, then inv(+2)=-2 => total -1 at point 7
+    // inv(flip)=flip, so orientation at 3 is flip; then another flip gives
+    // identity at point 7.
     let st = s.star_o([1]);
-    // sorted by point: (1,0), (3,1), (7,-1)
-    assert_eq!(st, vec![(1,0), (3,1), (7,-1)]);
+    // sorted by point: (1,false), (3,true), (7,false)
+    assert_eq!(
+        st,
+        vec![(1, Sign(false)), (3, Sign(true)), (7, Sign(false))]
+    );
 }

--- a/tests/shared_payload.rs
+++ b/tests/shared_payload.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use mesh_sieve::topology::orientation::Sign;
 use mesh_sieve::topology::sieve::{
     InMemoryOrientedSieveArc, InMemorySieveArc, InMemoryStackArc, Sieve,
 };
@@ -31,10 +32,10 @@ fn add_arrow_val_wraps_once() {
 
 #[test]
 fn oriented_upsert_replaces_payload() {
-    let mut s = InMemoryOrientedSieveArc::<u32, i32, i32>::default();
-    s.add_arrow_o_val(1, 2, 10, 5);
+    let mut s = InMemoryOrientedSieveArc::<u32, i32>::default();
+    s.add_arrow_o_val(1, 2, 10, Sign(true));
     let (_, a1) = s.cone(1).next().unwrap();
-    s.add_arrow_o_val(1, 2, 20, -3);
+    s.add_arrow_o_val(1, 2, 20, Sign(false));
     let (_, a2) = s.cone(1).next().unwrap();
     assert_eq!((*a1, *a2), (10, 20));
 }

--- a/tests/strata_cache.rs
+++ b/tests/strata_cache.rs
@@ -16,7 +16,7 @@ fn strata_single_cache_path() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn strata_consistency_oriented() -> Result<(), Box<dyn std::error::Error>> {
-    let mut s = InMemoryOrientedSieve::<u32, (), i32>::default();
+    let mut s = InMemoryOrientedSieve::<u32, ()>::default();
     s.add_arrow(1, 2, ());
     s.add_arrow(2, 3, ());
     assert_eq!(s.diameter()?, 2);


### PR DESCRIPTION
## Summary
- add `topology::orientation` module with BitFlip, Dihedral, permutation groups and `accumulate_path`
- document orientation semantics and update defaults to `Sign`
- provide oriented sieve aliases and accompanying tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b8fb3e43f08329984fd6f2f729aacd