### PR TITLE
Honor reserve hints across in-memory structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Other examples:
 * Add **point-only adapters** (`cone_points`, `support_points`) to eliminate payload clones during traversal.
 * Provide **deterministic traversal order** via a height-major **chart** (index ↔ point) and **bitset** visited sets.
 * Make `InMemorySieve` mutators **degree-local** and **prealloc-aware**: `reserve_cone`, `reserve_support`, and incremental mirror updates for `set_cone`/`set_support` (no global rebuilds).
+* Extend the same reserve hints to `InMemoryOrientedSieve` and `InMemoryStack`; add bulk helpers (`reserve_from_edges`, `reserve_from_edge_counts`) and `shrink_to_fit` to reclaim memory.
 
 ## Correctness Improvements
 

--- a/src/topology/sieve/in_memory_oriented.rs
+++ b/src/topology/sieve/in_memory_oriented.rs
@@ -182,6 +182,53 @@ where
             }
         }
     }
+
+    /// Pre-size cone/support capacities from `(src, dst, count)` tuples.
+    pub fn reserve_from_edge_counts(
+        &mut self,
+        counts: impl IntoIterator<Item = (P, P, usize)>,
+    ) {
+        use std::collections::HashMap;
+        let mut by_src: HashMap<P, usize> = HashMap::new();
+        let mut by_dst: HashMap<P, usize> = HashMap::new();
+        for (src, dst, k) in counts {
+            *by_src.entry(src).or_default() += k;
+            *by_dst.entry(dst).or_default() += k;
+        }
+        for (src, k) in by_src {
+            MutableSieve::reserve_cone(self, src, k);
+        }
+        for (dst, k) in by_dst {
+            MutableSieve::reserve_support(self, dst, k);
+        }
+    }
+
+    /// Convenience helper to preallocate from a raw edge list.
+    pub fn reserve_from_edges(&mut self, edges: impl IntoIterator<Item = (P, P)>) {
+        use std::collections::HashMap;
+        let mut by_src: HashMap<P, usize> = HashMap::new();
+        let mut by_dst: HashMap<P, usize> = HashMap::new();
+        for (s, d) in edges {
+            *by_src.entry(s).or_default() += 1;
+            *by_dst.entry(d).or_default() += 1;
+        }
+        for (s, k) in by_src {
+            MutableSieve::reserve_cone(self, s, k);
+        }
+        for (d, k) in by_dst {
+            MutableSieve::reserve_support(self, d, k);
+        }
+    }
+
+    /// Optional: compact any excess capacity after bulk construction.
+    pub fn shrink_to_fit(&mut self) {
+        for v in self.adjacency_out.values_mut() {
+            v.shrink_to_fit();
+        }
+        for v in self.adjacency_in.values_mut() {
+            v.shrink_to_fit();
+        }
+    }
 }
 
 // ----------- Sieve (payload-only view) -----------
@@ -376,6 +423,188 @@ where
         self.invalidate_cache();
         #[cfg(debug_assertions)]
         self.debug_assert_consistent();
+    }
+
+    fn set_cone(&mut self, p: P, chain: impl IntoIterator<Item = (P, T)>) {
+        let mut new_cone: Vec<(P, T)> = chain.into_iter().collect();
+
+        // Dedup by destination, last wins
+        {
+            use std::collections::HashSet;
+            let mut seen = HashSet::new();
+            let mut dedup = Vec::with_capacity(new_cone.len());
+            for (dst, pay) in new_cone.into_iter().rev() {
+                if seen.insert(dst) {
+                    dedup.push((dst, pay));
+                }
+            }
+            dedup.reverse();
+            new_cone = dedup;
+        }
+
+        self.adjacency_out.entry(p).or_default().reserve(new_cone.len());
+        {
+            use std::collections::HashMap;
+            let mut dst_counts: HashMap<P, usize> = HashMap::new();
+            for (dst, _) in &new_cone {
+                *dst_counts.entry(*dst).or_default() += 1;
+            }
+            for (dst, cnt) in dst_counts {
+                MutableSieve::reserve_support(self, dst, cnt);
+            }
+        }
+
+        let old_cone: Vec<(P, T, O)> = std::mem::take(self.adjacency_out.entry(p).or_default());
+        for (dst, _, _) in &old_cone {
+            if let Some(ins) = self.adjacency_in.get_mut(dst) {
+                ins.retain(|(src, _, _)| *src != p);
+            }
+        }
+
+        let out = self.adjacency_out.entry(p).or_default();
+        *out = new_cone
+            .iter()
+            .map(|(d, pay)| (*d, pay.clone(), O::default()))
+            .collect();
+        for (dst, pay) in new_cone {
+            self.adjacency_in
+                .entry(dst)
+                .or_default()
+                .push((p, pay, O::default()));
+        }
+
+        self.invalidate_cache();
+
+        #[cfg(debug_assertions)]
+        {
+            self.debug_assert_consistent();
+            self.debug_assert_no_parallel_edges_src(p);
+        }
+    }
+
+    fn add_cone(&mut self, p: P, chain: impl IntoIterator<Item = (P, T)>) {
+        let add: Vec<(P, T)> = chain.into_iter().collect();
+
+        self.adjacency_out.entry(p).or_default().reserve(add.len());
+        {
+            use std::collections::HashMap;
+            let mut dst_counts: HashMap<P, usize> = HashMap::new();
+            for (dst, _) in &add {
+                *dst_counts.entry(*dst).or_default() += 1;
+            }
+            for (dst, cnt) in dst_counts {
+                MutableSieve::reserve_support(self, dst, cnt);
+            }
+        }
+
+        let out = self.adjacency_out.entry(p).or_default();
+        for (dst, pay) in add {
+            if let Some(slot) = out.iter_mut().find(|(d, _, _)| *d == dst) {
+                slot.1 = pay.clone();
+                slot.2 = O::default();
+            } else {
+                out.push((dst, pay.clone(), O::default()));
+            }
+            let ins = self.adjacency_in.entry(dst).or_default();
+            if let Some(slot) = ins.iter_mut().find(|(s, _, _)| *s == p) {
+                slot.1 = pay.clone();
+                slot.2 = O::default();
+            } else {
+                ins.push((p, pay.clone(), O::default()));
+            }
+        }
+        self.invalidate_cache();
+    }
+
+    fn set_support(&mut self, q: P, chain: impl IntoIterator<Item = (P, T)>) {
+        let mut new_sup: Vec<(P, T)> = chain.into_iter().collect();
+
+        // Dedup by source, last wins
+        {
+            use std::collections::HashSet;
+            let mut seen = HashSet::new();
+            let mut dedup = Vec::with_capacity(new_sup.len());
+            for (src, pay) in new_sup.into_iter().rev() {
+                if seen.insert(src) {
+                    dedup.push((src, pay));
+                }
+            }
+            dedup.reverse();
+            new_sup = dedup;
+        }
+
+        self.adjacency_in.entry(q).or_default().reserve(new_sup.len());
+        {
+            use std::collections::HashMap;
+            let mut src_counts: HashMap<P, usize> = HashMap::new();
+            for (src, _) in &new_sup {
+                *src_counts.entry(*src).or_default() += 1;
+            }
+            for (src, cnt) in src_counts {
+                MutableSieve::reserve_cone(self, src, cnt);
+            }
+        }
+
+        let old_sup: Vec<(P, T, O)> = std::mem::take(self.adjacency_in.entry(q).or_default());
+        for (src, _, _) in &old_sup {
+            if let Some(outs) = self.adjacency_out.get_mut(src) {
+                outs.retain(|(dst, _, _)| *dst != q);
+            }
+        }
+
+        let ins = self.adjacency_in.entry(q).or_default();
+        *ins = new_sup
+            .iter()
+            .map(|(s, pay)| (*s, pay.clone(), O::default()))
+            .collect();
+        for (src, pay) in new_sup {
+            self.adjacency_out
+                .entry(src)
+                .or_default()
+                .push((q, pay, O::default()));
+        }
+
+        self.invalidate_cache();
+
+        #[cfg(debug_assertions)]
+        {
+            self.debug_assert_consistent();
+            self.debug_assert_no_parallel_edges_dst(q);
+        }
+    }
+
+    fn add_support(&mut self, q: P, chain: impl IntoIterator<Item = (P, T)>) {
+        let add: Vec<(P, T)> = chain.into_iter().collect();
+
+        self.adjacency_in.entry(q).or_default().reserve(add.len());
+        {
+            use std::collections::HashMap;
+            let mut src_counts: HashMap<P, usize> = HashMap::new();
+            for (src, _) in &add {
+                *src_counts.entry(*src).or_default() += 1;
+            }
+            for (src, cnt) in src_counts {
+                MutableSieve::reserve_cone(self, src, cnt);
+            }
+        }
+
+        let ins = self.adjacency_in.entry(q).or_default();
+        for (src, pay) in add {
+            if let Some(slot) = ins.iter_mut().find(|(s, _, _)| *s == src) {
+                slot.1 = pay.clone();
+                slot.2 = O::default();
+            } else {
+                ins.push((src, pay.clone(), O::default()));
+            }
+            let outs = self.adjacency_out.entry(src).or_default();
+            if let Some(slot) = outs.iter_mut().find(|(d, _, _)| *d == q) {
+                slot.1 = pay.clone();
+                slot.2 = O::default();
+            } else {
+                outs.push((q, pay.clone(), O::default()));
+            }
+        }
+        self.invalidate_cache();
     }
 }
 

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -23,6 +23,8 @@ pub mod sieve_ref;
 pub mod sieve_trait;
 /// Strata sieve implementation.
 pub mod strata;
+/// Bulk preallocation helpers.
+pub mod reserve;
 /// Concrete traversal iterators without dynamic dispatch.
 pub mod traversal_iter;
 /// Frozen CSR representation for deterministic, cache-friendly traversal.
@@ -35,6 +37,7 @@ pub use mutable::MutableSieve;
 pub use oriented::{Orientation, OrientedSieve};
 pub use sieve_ref::SieveRef;
 pub use sieve_trait::Sieve;
+pub use reserve::SieveReserveExt;
 pub use traversal_iter::{
     ClosureBothIter, ClosureBothIterRef, ClosureIter, ClosureIterRef, StarIter, StarIterRef,
 };

--- a/src/topology/sieve/reserve.rs
+++ b/src/topology/sieve/reserve.rs
@@ -1,0 +1,42 @@
+//! Extension trait providing bulk preallocation helpers for sieves.
+
+use super::{InMemoryOrientedSieve, InMemorySieve};
+
+/// Helpers for bulk preallocation based on edge lists or counts.
+pub trait SieveReserveExt<P> {
+    /// Pre-size cone and support capacities given `(src, dst, count)` tuples.
+    fn reserve_from_edge_counts(&mut self, counts: impl IntoIterator<Item = (P, P, usize)>);
+
+    /// Convenience: preallocate from raw `(src, dst)` edge lists.
+    fn reserve_from_edges(&mut self, edges: impl IntoIterator<Item = (P, P)>);
+}
+
+impl<P, T> SieveReserveExt<P> for InMemorySieve<P, T>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+{
+    fn reserve_from_edge_counts(&mut self, counts: impl IntoIterator<Item = (P, P, usize)>) {
+        InMemorySieve::reserve_from_edge_counts(self, counts);
+    }
+
+    fn reserve_from_edges(&mut self, edges: impl IntoIterator<Item = (P, P)>) {
+        InMemorySieve::reserve_from_edges(self, edges);
+    }
+}
+
+impl<P, T, O> SieveReserveExt<P> for InMemoryOrientedSieve<P, T, O>
+where
+    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    T: Clone,
+    O: super::oriented::Orientation,
+{
+    fn reserve_from_edge_counts(&mut self, counts: impl IntoIterator<Item = (P, P, usize)>) {
+        InMemoryOrientedSieve::reserve_from_edge_counts(self, counts);
+    }
+
+    fn reserve_from_edges(&mut self, edges: impl IntoIterator<Item = (P, P)>) {
+        InMemoryOrientedSieve::reserve_from_edges(self, edges);
+    }
+}
+

--- a/src/topology/sieve/sieve_trait.rs
+++ b/src/topology/sieve/sieve_trait.rs
@@ -652,6 +652,16 @@ where
     }
 
     /// Hint to preallocate additional space in the cone (outgoing) adjacency of `p`.
+    ///
+    /// # Contract
+    /// - Pure performance hint; **must not** change topology or payloads.
+    /// - **Must not** invalidate derived caches; it has no logical effect on the mesh.
+    /// - Implementations may over-allocate but must not shrink.
+    /// - Safe to call redundantly.
+    ///
+    /// Use this before bulk [`add_arrow`](Sieve::add_arrow) / [`add_cone`](Sieve::add_cone)
+    /// when the number of outgoing arrows to be appended for `p` is known or can be
+    /// estimated (e.g. during mesh construction).
     fn reserve_cone(&mut self, p: Self::Point, additional: usize)
     where
         Self: super::mutable::MutableSieve,
@@ -660,6 +670,9 @@ where
     }
 
     /// Hint to preallocate additional space in the support (incoming) adjacency of `q`.
+    ///
+    /// Mirrors [`reserve_cone`](Sieve::reserve_cone); use when you know/estimate how many
+    /// incoming arrows will end at `q`.
     fn reserve_support(&mut self, q: Self::Point, additional: usize)
     where
         Self: super::mutable::MutableSieve,

--- a/src/topology/stack.rs
+++ b/src/topology/stack.rs
@@ -130,6 +130,28 @@ where
             down: HashMap::new(),
         }
     }
+
+    /// Hint: preallocate additional upward slots for `base`.
+    #[inline]
+    pub fn reserve_lift(&mut self, base: B, additional: usize) {
+        self.up.entry(base).or_default().reserve(additional);
+    }
+
+    /// Hint: preallocate additional downward slots for `cap`.
+    #[inline]
+    pub fn reserve_drop(&mut self, cap: C, additional: usize) {
+        self.down.entry(cap).or_default().reserve(additional);
+    }
+
+    /// Optionally release excess capacity after bulk construction.
+    pub fn shrink_to_fit(&mut self) {
+        for v in self.up.values_mut() {
+            v.shrink_to_fit();
+        }
+        for v in self.down.values_mut() {
+            v.shrink_to_fit();
+        }
+    }
 }
 
 /// Provides a default implementation for `InMemoryStack`.

--- a/tests/prealloc_and_incremental.rs
+++ b/tests/prealloc_and_incremental.rs
@@ -25,6 +25,14 @@ fn reserve_cone_and_support_do_not_change_topology() {
     s2_after.sort_unstable();
     assert_eq!(c1, c1_after);
     assert_eq!(s2, s2_after);
+
+    // Cache is untouched by reserve
+    let d1 = s.diameter().unwrap();
+    let ptr_before = s.strata.get().unwrap() as *const _;
+    let d2 = s.diameter().unwrap();
+    let ptr_after = s.strata.get().unwrap() as *const _;
+    assert_eq!(d1, d2);
+    assert_eq!(ptr_before, ptr_after);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- document explicit contract for reserve hints in `Sieve`
- honor reserve hints across oriented sieves and stacks
- add bulk preallocation helpers and tests ensuring cache stability

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b90105bfdc83299cfdf7005f6413de