### PR TITLE
Add debug invariant checks for topologies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,15 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,28 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "cargo-mpirun"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ef8a141344a81cc80e1f889257c78d620a9c958a1c0b0581299c3e194c0eef"
-dependencies = [
- "cargo_metadata",
- "clap 2.33.4",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
-dependencies = [
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,22 +249,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826bf7bc84f9435630275cb8e802a4a0ec792b615969934bd16d42ffed10f207"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
- "yaml-rust",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
@@ -303,7 +256,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
- "textwrap 0.16.2",
+ "textwrap",
 ]
 
 [[package]]
@@ -334,7 +287,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap",
  "criterion-plot",
  "itertools 0.10.5",
  "lazy_static",
@@ -744,14 +697,13 @@ dependencies = [
 
 [[package]]
 name = "mesh-sieve"
-version = "1.2.0"
+version = "1.2.4"
 dependencies = [
  "ahash",
  "bincode",
  "bindgen 0.65.1",
  "bytemuck",
  "bytes",
- "cargo-mpirun",
  "criterion",
  "dashmap",
  "hashbrown 0.14.5",
@@ -1233,22 +1185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,12 +1275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,15 +1296,6 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1444,18 +1365,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1689,12 +1598,6 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ default = []            # keep core lean
 mpi-support = ["mpi", "rayon", "rand", "ahash"]
 metis-support = ["metis", "metis-sys", "libffi-sys","bindgen","pkg-config"]
 sieve_ref_fast_dag = []
+strict-invariants = []
 
 
 [build-dependencies]

--- a/src/topology/_debug_invariants.rs
+++ b/src/topology/_debug_invariants.rs
@@ -1,0 +1,85 @@
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+
+#[inline]
+pub fn count_pairs<P: Copy + Eq + std::hash::Hash>(
+    it: impl IntoIterator<Item = (P, P)>,
+) -> HashMap<(P, P), u32> {
+    let mut m = HashMap::new();
+    for e in it {
+        *m.entry(e).or_insert(0) += 1;
+    }
+    m
+}
+
+#[inline]
+pub fn assert_no_dups_per_src<P, D>(out: &HashMap<P, Vec<(P, D)>>)
+where
+    P: Copy + Eq + std::hash::Hash + std::fmt::Debug,
+    D: std::fmt::Debug,
+{
+    for (src, vec) in out {
+        let mut seen = HashSet::with_capacity(vec.len());
+        for (dst, _) in vec {
+            let fresh = seen.insert(*dst);
+            debug_assert!(fresh, "duplicate edge detected: src={:?} dst={:?}", src, dst);
+        }
+    }
+}
+
+#[inline]
+pub fn counts_equal<P>(
+    a: &HashMap<(P, P), u32>,
+    b: &HashMap<(P, P), u32>,
+    label_a: &str,
+    label_b: &str,
+) where
+    P: Copy + Eq + std::hash::Hash + std::fmt::Debug,
+{
+    debug_assert_eq!(
+        a.len(),
+        b.len(),
+        "edge multiset cardinality mismatch ({} vs {})",
+        label_a,
+        label_b,
+    );
+    for (k, va) in a {
+        let Some(vb) = b.get(k) else {
+            debug_assert!(
+                false,
+                "edge present in {} but missing in {}: {:?}",
+                label_a,
+                label_b,
+                k
+            );
+            continue;
+        };
+        debug_assert_eq!(
+            va,
+            vb,
+            "edge multiplicity mismatch for {:?}: {}={}, {}={}",
+            k,
+            label_a,
+            va,
+            label_b,
+            vb
+        );
+    }
+}
+
+#[cfg(any(debug_assertions, feature = "strict-invariants"))]
+macro_rules! debug_invariants {
+    ($s:expr) => {
+        $s.debug_assert_invariants();
+    };
+}
+
+#[cfg(not(any(debug_assertions, feature = "strict-invariants")))]
+macro_rules! debug_invariants {
+    ($s:expr) => {
+        ()
+    };
+}
+
+pub(crate) use debug_invariants;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -8,6 +8,12 @@
 //!
 //! Most users will interact with the `Sieve` trait and the `InMemorySieve` implementation for building and traversing mesh topologies.
 
+//! ## Edge uniqueness
+//! A topology stores a *set* of arrows: for any `(src, dst)` pair there is at most one edge.
+//! Insertion behaves as an upsert, replacing existing payloads (and orientations) in place.
+//! Duplicate edges are forbidden; debug builds assert that the outgoing and incoming maps
+//! remain perfect mirrors and contain no parallel edges.
+
 pub mod arrow;
 pub mod cache;
 pub mod orientation;
@@ -15,6 +21,7 @@ pub mod point;
 pub mod sieve;
 pub mod stack;
 pub mod utils;
+mod _debug_invariants;
 
 pub use cache::InvalidateCache;
 pub use orientation::*;

--- a/src/topology/sieve/oriented.rs
+++ b/src/topology/sieve/oriented.rs
@@ -9,6 +9,11 @@
 //! path (left-accumulating). `inverse(a)` is the orientation used when the
 //! same arrow is traversed in reverse.
 //!
+//! ## Mirror rule
+//! The orientation stored on `src → dst` must match the orientation found in the
+//! mirror entry within `support(dst)`. Debug builds verify this when the orientation
+//! type implements `PartialEq`.
+//!
 //! ## Choosing an orientation type
 //!
 //! | Use case                    | Type |

--- a/src/topology/sieve/reserve.rs
+++ b/src/topology/sieve/reserve.rs
@@ -29,7 +29,7 @@ impl<P, T, O> SieveReserveExt<P> for InMemoryOrientedSieve<P, T, O>
 where
     P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
     T: Clone,
-    O: super::oriented::Orientation,
+    O: super::oriented::Orientation + PartialEq + std::fmt::Debug,
 {
     fn reserve_from_edge_counts(&mut self, counts: impl IntoIterator<Item = (P, P, usize)>) {
         InMemoryOrientedSieve::reserve_from_edge_counts(self, counts);

--- a/src/topology/sieve/sieve_trait.rs
+++ b/src/topology/sieve/sieve_trait.rs
@@ -26,6 +26,12 @@ pub use crate::topology::cache::InvalidateCache;
 /// incoming (`support`) adjacencies in perfect mirror, removing or updating both sides
 /// of the structure.
 ///
+/// ## Edge uniqueness (no multi-edges)
+/// A Sieve stores at most one arrow for any `(src, dst)` pair. [`add_arrow`] behaves as
+/// an upsert: inserting when missing and replacing payload (and orientation) when present.
+/// Debug builds verify this invariant and panic if parallel edges or mirror mismatches
+/// are detected.
+///
 /// # Associated Types
 /// - `Point`: The type of points in the sieve (must be `Copy`, `Eq`, `Hash`, and `Ord`).
 /// - `Payload`: The type of payloads associated with arrows.

--- a/src/topology/tests/debug_invariants.rs
+++ b/src/topology/tests/debug_invariants.rs
@@ -1,0 +1,33 @@
+use crate::topology::orientation::BitFlip;
+use crate::topology::sieve::{InMemoryOrientedSieve, InMemorySieve, Sieve, OrientedSieve};
+use crate::topology::stack::{InMemoryStack, Stack};
+
+#[test]
+#[should_panic]
+fn duplicate_edge_panics_in_debug() {
+    let mut s = InMemorySieve::<u32, ()>::default();
+    s.add_arrow(1, 2, ());
+    s.adjacency_out.get_mut(&1).unwrap().push((2, ())); // create duplicate
+    #[cfg(any(debug_assertions, feature = "strict-invariants"))]
+    s.debug_assert_invariants();
+}
+
+#[test]
+#[should_panic]
+fn orientation_mismatch_panics_in_debug() {
+    let mut s = InMemoryOrientedSieve::<u32, (), BitFlip>::default();
+    s.add_arrow_o(1, 2, (), BitFlip(true));
+    s.adjacency_in.get_mut(&2).unwrap()[0].2 = BitFlip(false);
+    #[cfg(any(debug_assertions, feature = "strict-invariants"))]
+    s.debug_assert_invariants();
+}
+
+#[test]
+#[should_panic]
+fn stack_mirror_missing_panics_in_debug() {
+    let mut st = InMemoryStack::<u32, u32, ()>::new();
+    st.add_arrow(1, 2, ()).unwrap();
+    st.down.get_mut(&2).unwrap().clear();
+    #[cfg(any(debug_assertions, feature = "strict-invariants"))]
+    st.debug_assert_invariants();
+}

--- a/src/topology/tests/mod.rs
+++ b/src/topology/tests/mod.rs
@@ -1,1 +1,2 @@
 mod utils_tests;
+mod debug_invariants;


### PR DESCRIPTION
## Summary
- add shared debug invariant helpers and macro
- enforce mirror and uniqueness invariants in memory sieves and stacks
- document edge uniqueness policy and orientation mirror rule

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90916d2108329b0028328cc8d91e4