### PR TITLE
doc: add complexity notes and meet/join tests

### DIFF
--- a/src/topology/sieve/frozen_csr.rs
+++ b/src/topology/sieve/frozen_csr.rs
@@ -1,8 +1,9 @@
 //! Frozen CSR (Compressed Sparse Row) representation of a [`Sieve`] topology.
 //!
 //! Immutable, cache-friendly adjacency structure with deterministic iteration
-//! order.  Built from any [`Sieve`] implementation and intended for read-only
-//! traversal workloads.
+//! order. All neighbor lists and the global chart are sorted; `cone`/`support`
+//! walk contiguous slices, and global iteration is deterministic. Built from
+//! any [`Sieve`] implementation and intended for read-only traversal workloads.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/topology/sieve/strata.rs
+++ b/src/topology/sieve/strata.rs
@@ -65,9 +65,13 @@ impl<P: Copy + Eq + std::hash::Hash + Ord> StrataCache<P> {
     }
 }
 
-/// Compute strata information for any sieve instance on-the-fly (no cache).
+/// Compute strata information on-the-fly (no cache).
 ///
 /// Returns a [`StrataCache`] containing height, depth, strata, and diameter information for all points.
+///
+/// ## Complexity
+/// - Time: **O(|V| + |E|)** (Kahn topological sort + forward/backward passes)
+/// - Space: **O(|V| + |E|)** for intermediate degree maps and result vectors.
 ///
 /// # Errors
 /// Returns `Err(MeshSieveError::MissingPointInCone(p))` if a `cone` points to `p` not in `points()`,


### PR DESCRIPTION
## Summary
- document per-backend complexity for core `Sieve` APIs and strata helpers
- clarify meet/join semantics and add deterministic doc tests
- add backend notes for in-memory and CSR implementations

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b90dfc1b908329aeb3fca496f03c71