### PR TITLE
feat: consolidate topology bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ mesh-sieve is a modular, high-performance Rust library for mesh and data managem
 - **Partitioning**: Built-in support for graph partitioning (Metis, custom algorithms).
 - **MPI Integration**: Examples and tests for distributed mesh and data exchange using MPI.
 - **Extensive Testing**: Serial, parallel, and property-based tests.
+- **Ergonomic bounds**: `PointLike` and `PayloadLike` marker traits reduce repeated `Copy + Eq + Hash + Ord + Debug` bounds.
 
 ## Getting Started
 

--- a/src/algs/traversal.rs
+++ b/src/algs/traversal.rs
@@ -7,6 +7,7 @@ use crate::topology::sieve::strata::compute_strata;
 use crate::topology::sieve::Sieve;
 use crate::topology::cache::InvalidateCache;
 use std::collections::{HashMap, HashSet, VecDeque};
+use crate::topology::bounds::PointLike;
 
 pub type Point = PointId;
 
@@ -386,7 +387,7 @@ where
 pub fn closure_ordered<I, S>(sieve: &mut S, seeds: I) -> Result<Vec<S::Point>, MeshSieveError>
 where
     S: Sieve,
-    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    S::Point: PointLike,
     I: IntoIterator<Item = S::Point>,
 {
     let cache = compute_strata(&*sieve)?;
@@ -437,7 +438,7 @@ where
 pub fn star_ordered<I, S>(sieve: &mut S, seeds: I) -> Result<Vec<S::Point>, MeshSieveError>
 where
     S: Sieve,
-    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    S::Point: PointLike,
     I: IntoIterator<Item = S::Point>,
 {
     let cache = compute_strata(&*sieve)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod prelude {
     };
     pub use crate::topology::stack::{InMemoryStack, Stack};
     pub use crate::topology::point::PointId;
+    pub use crate::topology::bounds::{PointLike, PayloadLike};
     pub use crate::data::atlas::Atlas;
     pub use crate::data::section::{Section, Map};
     pub use crate::overlap::delta::{Delta, CopyDelta, AddDelta};

--- a/src/topology/bounds.rs
+++ b/src/topology/bounds.rs
@@ -1,0 +1,20 @@
+//! Common bound aliases used across topology code.
+//!
+//! These traits have blanket impls, so any type satisfying the underlying
+//! bounds will automatically implement them. They are zero-cost and only
+//! reduce duplication in `where` clauses.
+
+/// Canonical bound set for point identifiers.
+///
+/// Rationale:
+/// - `Copy` for cheap pass-by-value in tight loops
+/// - `Eq + Hash` for `HashMap`-backed adjacencies
+/// - `Ord` to allow deterministic ordering (sort strata/neighbors)
+/// - `Debug` for diagnostics and invariant checks
+pub trait PointLike: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug {}
+impl<T> PointLike for T where T: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug {}
+
+/// Minimal bound we expect for per-arrow payloads in in-memory backends.
+/// Keep this deliberately small to avoid over-constraining higher layers.
+pub trait PayloadLike: Clone {}
+impl<T: Clone> PayloadLike for T {}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod arrow;
 pub mod cache;
+pub mod bounds;
 pub mod orientation;
 pub mod point;
 pub mod sieve;

--- a/src/topology/sieve/frozen_csr.rs
+++ b/src/topology/sieve/frozen_csr.rs
@@ -11,12 +11,13 @@ use std::sync::Arc;
 use super::sieve_ref::SieveRef;
 use super::sieve_trait::Sieve;
 use crate::topology::cache::InvalidateCache;
+use crate::topology::bounds::{PointLike, PayloadLike};
 
 /// Immutable sieve backed by a pair of CSR adjacency graphs.
 #[derive(Clone, Debug)]
 pub struct FrozenSieveCsr<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     /// Dense index → point mapping in deterministic order.
     pub point_of: Arc<[P]>,
@@ -36,7 +37,7 @@ where
 
 impl<P, T> Default for FrozenSieveCsr<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     fn default() -> Self {
         Self {
@@ -54,15 +55,15 @@ where
 
 impl<P, T> InvalidateCache for FrozenSieveCsr<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     fn invalidate_cache(&mut self) {}
 }
 
 impl<P, T> FrozenSieveCsr<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     /// Build from any [`Sieve`], enforcing deterministic order.
     pub fn from_sieve<S>(mut s: S) -> Self
@@ -148,8 +149,8 @@ where
 pub fn freeze_csr<S, P, T>(s: S) -> FrozenSieveCsr<P, T>
 where
     S: Sieve<Point = P, Payload = T>,
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     FrozenSieveCsr::from_sieve(s)
 }
@@ -158,8 +159,8 @@ where
 
 pub struct ConeIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     sieve: &'a FrozenSieveCsr<P, T>,
     pos: usize,
@@ -168,8 +169,8 @@ where
 
 impl<'a, P, T> Iterator for ConeIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     type Item = (P, T);
     fn next(&mut self) -> Option<Self::Item> {
@@ -186,7 +187,7 @@ where
 
 pub struct ConeRefIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     sieve: &'a FrozenSieveCsr<P, T>,
     pos: usize,
@@ -195,7 +196,7 @@ where
 
 impl<'a, P, T> Iterator for ConeRefIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     type Item = (P, &'a T);
     fn next(&mut self) -> Option<Self::Item> {
@@ -212,8 +213,8 @@ where
 
 pub struct SupportIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     sieve: &'a FrozenSieveCsr<P, T>,
     pos: usize,
@@ -222,8 +223,8 @@ where
 
 impl<'a, P, T> Iterator for SupportIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     type Item = (P, T);
     fn next(&mut self) -> Option<Self::Item> {
@@ -240,7 +241,7 @@ where
 
 pub struct SupportRefIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     sieve: &'a FrozenSieveCsr<P, T>,
     pos: usize,
@@ -249,7 +250,7 @@ where
 
 impl<'a, P, T> Iterator for SupportRefIter<'a, P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
 {
     type Item = (P, &'a T);
     fn next(&mut self) -> Option<Self::Item> {
@@ -268,8 +269,8 @@ where
 
 impl<P, T> Sieve for FrozenSieveCsr<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     type Point = P;
     type Payload = T;
@@ -338,8 +339,8 @@ where
 
 impl<P, T> SieveRef for FrozenSieveCsr<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     type ConeRefIter<'a>
         = ConeRefIter<'a, P, T>

--- a/src/topology/sieve/in_memory_oriented.rs
+++ b/src/topology/sieve/in_memory_oriented.rs
@@ -13,11 +13,12 @@ use crate::topology::cache::InvalidateCache;
 use crate::topology::orientation::Sign;
 use crate::topology::sieve::strata::{StrataCache, compute_strata};
 use crate::topology::_debug_invariants::debug_invariants;
+use crate::topology::bounds::{PointLike, PayloadLike};
 
 #[derive(Clone, Debug)]
 pub struct InMemoryOrientedSieve<P, T = (), O = Sign>
 where
-    P: Ord + std::fmt::Debug,
+    P: PointLike,
     O: Orientation,
 {
     pub adjacency_out: HashMap<P, Vec<(P, T, O)>>,
@@ -27,7 +28,7 @@ where
 
 impl<P, T, O> InMemoryOrientedSieve<P, Arc<T>, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
     O: super::oriented::Orientation + PartialEq + std::fmt::Debug,
 {
     /// Insert by value; wraps once into `Arc<T>`.
@@ -45,7 +46,7 @@ where
 
 impl<P, T, O> Default for InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    P: PointLike,
     O: Orientation + PartialEq + std::fmt::Debug,
 {
     fn default() -> Self {
@@ -59,8 +60,8 @@ where
 
 impl<P, T, O> InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
     O: Orientation + PartialEq + std::fmt::Debug,
 {
     pub fn new() -> Self {
@@ -208,7 +209,7 @@ where
 
         fn check_orient<P, T, O>(s: &InMemoryOrientedSieve<P, T, O>)
         where
-            P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+            P: PointLike,
             O: super::oriented::Orientation + PartialEq + std::fmt::Debug,
         {
             use std::collections::HashMap;
@@ -294,8 +295,8 @@ type MapOOut<'a, P, T, O> =
 
 impl<P, T, O> Sieve for InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
     O: Orientation + PartialEq + std::fmt::Debug,
 {
     type Point = P;
@@ -412,8 +413,8 @@ where
 
 impl<P, T, O> MutableSieve for InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
     O: Orientation + PartialEq + std::fmt::Debug,
 {
     fn reserve_cone(&mut self, p: P, additional: usize) {
@@ -648,8 +649,8 @@ where
 
 impl<P, T, O> OrientedSieve for InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
     O: Orientation + PartialEq + std::fmt::Debug,
 {
     type Orient = O;
@@ -710,8 +711,8 @@ where
 
 impl<P, T, O> InvalidateCache for InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
     O: Orientation + PartialEq + std::fmt::Debug,
 {
     #[inline]

--- a/src/topology/sieve/reserve.rs
+++ b/src/topology/sieve/reserve.rs
@@ -1,6 +1,7 @@
 //! Extension trait providing bulk preallocation helpers for sieves.
 
 use super::{InMemoryOrientedSieve, InMemorySieve};
+use crate::topology::bounds::{PointLike, PayloadLike};
 
 /// Helpers for bulk preallocation based on edge lists or counts.
 pub trait SieveReserveExt<P> {
@@ -13,8 +14,8 @@ pub trait SieveReserveExt<P> {
 
 impl<P, T> SieveReserveExt<P> for InMemorySieve<P, T>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
 {
     fn reserve_from_edge_counts(&mut self, counts: impl IntoIterator<Item = (P, P, usize)>) {
         InMemorySieve::reserve_from_edge_counts(self, counts);
@@ -27,8 +28,8 @@ where
 
 impl<P, T, O> SieveReserveExt<P> for InMemoryOrientedSieve<P, T, O>
 where
-    P: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    T: Clone,
+    P: PointLike,
+    T: PayloadLike,
     O: super::oriented::Orientation + PartialEq + std::fmt::Debug,
 {
     fn reserve_from_edge_counts(&mut self, counts: impl IntoIterator<Item = (P, P, usize)>) {

--- a/src/topology/sieve/strata.rs
+++ b/src/topology/sieve/strata.rs
@@ -11,6 +11,7 @@
 use crate::mesh_error::MeshSieveError;
 use crate::topology::sieve::Sieve;
 use std::collections::HashMap;
+use crate::topology::bounds::PointLike;
 
 /// Precomputed stratum information for a sieve.
 ///
@@ -33,7 +34,7 @@ pub struct StrataCache<P> {
     pub chart_index: HashMap<P, usize>, // point -> index
 }
 
-impl<P: Copy + Eq + std::hash::Hash + Ord> StrataCache<P> {
+impl<P: PointLike> StrataCache<P> {
     /// Create a new, empty `StrataCache`.
     pub fn new() -> Self {
         Self {
@@ -79,7 +80,7 @@ impl<P: Copy + Eq + std::hash::Hash + Ord> StrataCache<P> {
 pub fn compute_strata<S>(s: &S) -> Result<StrataCache<S::Point>, MeshSieveError>
 where
     S: Sieve,
-    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    S::Point: PointLike,
 {
     // 1) collect in-degrees over s.points()
     let mut in_deg = HashMap::new();

--- a/src/topology/stack.rs
+++ b/src/topology/stack.rs
@@ -11,6 +11,7 @@ use crate::topology::cache::InvalidateCache;
 use std::collections::HashMap;
 use std::sync::Arc;
 use crate::topology::_debug_invariants::debug_invariants;
+use crate::topology::bounds::{PointLike, PayloadLike};
 
 /// A `Stack` links a *base* Sieve to a *cap* Sieve via vertical arrows.
 /// Each arrow carries a payload (e.g., orientation or permutation).
@@ -103,8 +104,8 @@ pub trait Stack {
 /// Also embeds two `InMemorySieve`s to represent the base and cap topologies themselves.
 #[derive(Clone, Debug)]
 pub struct InMemoryStack<
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    B: PointLike,
+    C: PointLike,
     P = (),
 > {
     /// Underlying base sieve (e.g., mesh connectivity).
@@ -119,8 +120,8 @@ pub struct InMemoryStack<
 
 impl<B, C, P> InMemoryStack<B, C, P>
 where
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    B: PointLike,
+    C: PointLike,
 {
     /// Creates an empty `InMemoryStack` with no arrows.
     pub fn new() -> Self {
@@ -156,10 +157,10 @@ where
 }
 
 /// Provides a default implementation for `InMemoryStack`.
-impl<B, C, P: Clone> Default for InMemoryStack<B, C, P>
+impl<B, C, P: PayloadLike> Default for InMemoryStack<B, C, P>
 where
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    B: PointLike,
+    C: PointLike,
 {
     /// Returns an empty `InMemoryStack`.
     fn default() -> Self {
@@ -174,9 +175,9 @@ where
 
 impl<B, C, P> Stack for InMemoryStack<B, C, P>
 where
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    P: Clone,
+    B: PointLike,
+    C: PointLike,
+    P: PayloadLike,
 {
     type Point = B;
     type CapPt = C;
@@ -287,8 +288,8 @@ where
 
 impl<B, C, T> InMemoryStack<B, C, Arc<T>>
 where
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    B: PointLike,
+    C: PointLike,
 {
     /// Insert by value; wraps once into `Arc<T>`.
     #[inline]
@@ -300,9 +301,9 @@ where
 /// Provides accessors for base and cap points for testability.
 impl<B, C, P> InMemoryStack<B, C, P>
 where
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    P: Clone,
+    B: PointLike,
+    C: PointLike,
+    P: PayloadLike,
 {
     /// Returns an iterator over all base points with at least one upward arrow.
     pub fn base_points(&self) -> impl Iterator<Item = B> + '_ {
@@ -462,9 +463,9 @@ fn composed_stack_no_leak() {
 
 impl<B, C, P> InvalidateCache for InMemoryStack<B, C, P>
 where
-    B: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    C: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
-    P: Clone,
+    B: PointLike,
+    C: PointLike,
+    P: PayloadLike,
 {
     fn invalidate_cache(&mut self) {
         self.base.invalidate_cache();

--- a/src/topology/utils.rs
+++ b/src/topology/utils.rs
@@ -2,6 +2,7 @@
 use crate::mesh_error::MeshSieveError;
 use crate::topology::sieve::Sieve;
 use std::collections::{HashMap, VecDeque};
+use crate::topology::bounds::PointLike;
 
 /// Generic DAG check for any `S: Sieve`.
 ///
@@ -13,7 +14,7 @@ use std::collections::{HashMap, VecDeque};
 pub fn check_dag<S>(s: &S) -> Result<(), MeshSieveError>
 where
     S: Sieve,
-    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    S::Point: PointLike,
 {
     // 1) Build in-degree map over all points we know about,
     //    and insert any cone destinations that were not listed by `points()`.
@@ -59,7 +60,7 @@ where
 pub fn check_dag_ref<S>(s: &S) -> Result<(), MeshSieveError>
 where
     S: Sieve + crate::topology::sieve::SieveRef,
-    S::Point: Copy + Eq + std::hash::Hash + Ord + std::fmt::Debug,
+    S::Point: PointLike,
 {
     use std::collections::{HashMap, VecDeque};
     let mut in_deg: HashMap<S::Point, usize> = HashMap::new();


### PR DESCRIPTION
## Summary
- add `PointLike` and `PayloadLike` marker traits to cut down on repeated bounds
- refactor in-memory sieves, stacks and helpers to use the new aliases
- document and re-export the aliases in the prelude

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b91187322883298e18387b0c1b348e