### PR TITLE
Resolve Delta naming conflict by adding SliceDelta alias

### DIFF
--- a/src/data/bundle.rs
+++ b/src/data/bundle.rs
@@ -8,16 +8,18 @@
 //! This abstraction supports push (refine) and pull (assemble) of data
 //! across mesh hierarchy levels, as described in Knepley & Karpeev (2009).
 
-use crate::topology::point::PointId;
-use crate::topology::stack::{InMemoryStack, Stack};
 use crate::data::section::Section;
 use crate::overlap::delta::CopyDelta;
+use crate::topology::point::PointId;
 use crate::topology::sieve::Sieve;
+use crate::topology::stack::{InMemoryStack, Stack};
 
 /// `Bundle<V, D>` packages a mesh‐to‐DOF stack, a data section, and a `Delta`-type.
 ///
 /// - `V`: underlying data type stored at each DOF (e.g., `f64`, `i32`, …).
-/// - `D`: `Delta<V>` implementation guiding how data moves (defaults to `CopyDelta`).
+/// - `D`: overlap [`Delta`](crate::overlap::delta::Delta)<V> implementation guiding how
+///   values are reduced/merged across parts (defaults to [`CopyDelta`]).
+///   For per-slice permutation/orientation, see [`crate::data::refine::delta::SliceDelta`].
 ///
 /// # Fields
 /// - `stack`: vertical arrows from base mesh points → cap (DOF) points,
@@ -42,7 +44,10 @@ where
     ///
     /// # Errors
     /// Returns an error if any point is missing in the underlying Section.
-    pub fn refine(&mut self, bases: impl IntoIterator<Item = PointId>) -> Result<(), crate::mesh_error::MeshSieveError> {
+    pub fn refine(
+        &mut self,
+        bases: impl IntoIterator<Item = PointId>,
+    ) -> Result<(), crate::mesh_error::MeshSieveError> {
         let mut actions = Vec::new();
         for b in self.stack.base().closure(bases) {
             let base_vals = self.section.try_restrict(b)?.to_vec();
@@ -67,14 +72,17 @@ where
     ///
     /// # Errors
     /// Returns an error if any point is missing in the underlying Section.
-    pub fn assemble(&mut self, bases: impl IntoIterator<Item = PointId>) -> Result<(), crate::mesh_error::MeshSieveError> {
+    pub fn assemble(
+        &mut self,
+        bases: impl IntoIterator<Item = PointId>,
+    ) -> Result<(), crate::mesh_error::MeshSieveError> {
         let mut actions = Vec::new();
         for b in self.stack.base().closure(bases) {
             let caps: Vec<_> = self.stack.lift(b).map(|(cap, _)| cap).collect();
             let cap_vals: Vec<_> = caps
                 .iter()
                 .map(|&cap| self.section.try_restrict(cap).map(|sl| sl.to_vec()))
-                .collect::<Result<_,_>>()?;
+                .collect::<Result<_, _>>()?;
             actions.push((b, cap_vals));
         }
         for (b, cap_vals_vec) in actions {
@@ -94,20 +102,21 @@ where
     /// Returns an error for any cap point missing in the underlying Section.
     pub fn dofs<'a>(
         &'a self,
-        p: PointId
-    ) -> impl Iterator<Item = Result<(PointId, &'a [V]), crate::mesh_error::MeshSieveError>> + 'a {
-        self.stack.lift(p)
+        p: PointId,
+    ) -> impl Iterator<Item = Result<(PointId, &'a [V]), crate::mesh_error::MeshSieveError>> + 'a
+    {
+        self.stack
+            .lift(p)
             .map(move |(cap, _)| self.section.try_restrict(cap).map(|sl| (cap, sl)))
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::topology::arrow::Orientation;
-    use crate::overlap::delta::CopyDelta;
     use crate::data::atlas::Atlas;
+    use crate::overlap::delta::CopyDelta;
+    use crate::topology::arrow::Orientation;
     #[test]
     fn bundle_basic_refine_and_assemble() {
         let mut atlas = Atlas::default();
@@ -119,26 +128,76 @@ mod tests {
         section.try_set(PointId::new(1).unwrap(), &[10]).unwrap();
         section.try_set(PointId::new(2).unwrap(), &[20]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(101).unwrap(), Orientation::Forward);
-        let _ = stack.add_arrow(PointId::new(2).unwrap(), PointId::new(102).unwrap(), Orientation::Forward);
-        let mut bundle = Bundle { stack, section, delta: CopyDelta };
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(101).unwrap(),
+            Orientation::Forward,
+        );
+        let _ = stack.add_arrow(
+            PointId::new(2).unwrap(),
+            PointId::new(102).unwrap(),
+            Orientation::Forward,
+        );
+        let mut bundle = Bundle {
+            stack,
+            section,
+            delta: CopyDelta,
+        };
         // Refine: push base values to cap
-        bundle.refine([PointId::new(1).unwrap(), PointId::new(2).unwrap()]).unwrap();
-        assert_eq!(bundle.section.try_restrict(PointId::new(101).unwrap()).unwrap(), &[10]);
-        assert_eq!(bundle.section.try_restrict(PointId::new(102).unwrap()).unwrap(), &[20]);
+        bundle
+            .refine([PointId::new(1).unwrap(), PointId::new(2).unwrap()])
+            .unwrap();
+        assert_eq!(
+            bundle
+                .section
+                .try_restrict(PointId::new(101).unwrap())
+                .unwrap(),
+            &[10]
+        );
+        assert_eq!(
+            bundle
+                .section
+                .try_restrict(PointId::new(102).unwrap())
+                .unwrap(),
+            &[20]
+        );
         // Assemble: pull cap values back to base
-        bundle.section.try_set(PointId::new(101).unwrap(), &[30]).unwrap();
-        bundle.section.try_set(PointId::new(102).unwrap(), &[40]).unwrap();
-        bundle.assemble([PointId::new(1).unwrap(), PointId::new(2).unwrap()]).unwrap();
-        assert_eq!(bundle.section.try_restrict(PointId::new(1).unwrap()).unwrap(), &[30]);
-        assert_eq!(bundle.section.try_restrict(PointId::new(2).unwrap()).unwrap(), &[40]);
+        bundle
+            .section
+            .try_set(PointId::new(101).unwrap(), &[30])
+            .unwrap();
+        bundle
+            .section
+            .try_set(PointId::new(102).unwrap(), &[40])
+            .unwrap();
+        bundle
+            .assemble([PointId::new(1).unwrap(), PointId::new(2).unwrap()])
+            .unwrap();
+        assert_eq!(
+            bundle
+                .section
+                .try_restrict(PointId::new(1).unwrap())
+                .unwrap(),
+            &[30]
+        );
+        assert_eq!(
+            bundle
+                .section
+                .try_restrict(PointId::new(2).unwrap())
+                .unwrap(),
+            &[40]
+        );
     }
     #[test]
     fn empty_bundle_noop() {
         let atlas = Atlas::default();
         let section = Section::<i32>::new(atlas.clone());
-        let stack = InMemoryStack::<PointId,PointId,Orientation>::new();
-        let mut bundle = Bundle { stack, section, delta: CopyDelta };
+        let stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut bundle = Bundle {
+            stack,
+            section,
+            delta: CopyDelta,
+        };
         // Should not panic, nothing to do
         bundle.refine(std::iter::empty::<PointId>()).unwrap();
         bundle.assemble(std::iter::empty::<PointId>()).unwrap();
@@ -150,12 +209,25 @@ mod tests {
         atlas.try_insert(PointId::new(1).unwrap(), 2).unwrap();
         atlas.try_insert(PointId::new(101).unwrap(), 2).unwrap();
         let mut section = Section::<i32>::new(atlas.clone());
-        section.try_set(PointId::new(1).unwrap(), &[10,20]).unwrap();
-        let mut stack = InMemoryStack::<PointId,PointId,Orientation>::new();
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(101).unwrap(), Orientation::Forward);
-        let mut bundle = Bundle { stack, section, delta: CopyDelta };
+        section
+            .try_set(PointId::new(1).unwrap(), &[10, 20])
+            .unwrap();
+        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(101).unwrap(),
+            Orientation::Forward,
+        );
+        let mut bundle = Bundle {
+            stack,
+            section,
+            delta: CopyDelta,
+        };
         bundle.refine([PointId::new(1).unwrap()]).unwrap();
-        let vals = bundle.section.try_restrict(PointId::new(101).unwrap()).unwrap();
+        let vals = bundle
+            .section
+            .try_restrict(PointId::new(101).unwrap())
+            .unwrap();
         // Both slots should be copied
         assert_eq!(vals, &[10, 20]);
     }
@@ -166,13 +238,27 @@ mod tests {
         atlas.try_insert(PointId::new(1).unwrap(), 2).unwrap();
         atlas.try_insert(PointId::new(101).unwrap(), 2).unwrap();
         let mut section = Section::<i32>::new(atlas.clone());
-        section.try_set(PointId::new(1).unwrap(), &[1,2]).unwrap();
-        let mut stack = InMemoryStack::<PointId,PointId,Orientation>::new();
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(101).unwrap(), Orientation::Reverse);
-        let mut bundle = Bundle { stack, section, delta: CopyDelta };
+        section.try_set(PointId::new(1).unwrap(), &[1, 2]).unwrap();
+        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(101).unwrap(),
+            Orientation::Reverse,
+        );
+        let mut bundle = Bundle {
+            stack,
+            section,
+            delta: CopyDelta,
+        };
         bundle.refine([PointId::new(1).unwrap()]).unwrap();
         // Should get reversed [2,1]
-        assert_eq!(bundle.section.try_restrict(PointId::new(101).unwrap()).unwrap(), &[2,1]);
+        assert_eq!(
+            bundle
+                .section
+                .try_restrict(PointId::new(101).unwrap())
+                .unwrap(),
+            &[2, 1]
+        );
     }
 
     #[test]
@@ -185,13 +271,31 @@ mod tests {
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(101).unwrap(), &[5]).unwrap();
         section.try_set(PointId::new(102).unwrap(), &[7]).unwrap();
-        let mut stack = InMemoryStack::<PointId,PointId,Orientation>::new();
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(101).unwrap(), Orientation::Forward);
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(102).unwrap(), Orientation::Forward);
-        let mut bundle = Bundle { stack, section, delta: AddDelta };
+        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(101).unwrap(),
+            Orientation::Forward,
+        );
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(102).unwrap(),
+            Orientation::Forward,
+        );
+        let mut bundle = Bundle {
+            stack,
+            section,
+            delta: AddDelta,
+        };
         bundle.assemble([PointId::new(1).unwrap()]).unwrap();
         // base receives sum 5+7
-        assert_eq!(bundle.section.try_restrict(PointId::new(1).unwrap()).unwrap(), &[12]);
+        assert_eq!(
+            bundle
+                .section
+                .try_restrict(PointId::new(1).unwrap())
+                .unwrap(),
+            &[12]
+        );
     }
 
     #[test]
@@ -203,26 +307,47 @@ mod tests {
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(101).unwrap(), &[8]).unwrap();
         section.try_set(PointId::new(102).unwrap(), &[9]).unwrap();
-        let mut stack = InMemoryStack::<PointId,PointId,Orientation>::new();
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(101).unwrap(), Orientation::Forward);
-        let _ = stack.add_arrow(PointId::new(1).unwrap(), PointId::new(102).unwrap(), Orientation::Forward);
-        let bundle = Bundle { stack, section, delta: CopyDelta };
+        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(101).unwrap(),
+            Orientation::Forward,
+        );
+        let _ = stack.add_arrow(
+            PointId::new(1).unwrap(),
+            PointId::new(102).unwrap(),
+            Orientation::Forward,
+        );
+        let bundle = Bundle {
+            stack,
+            section,
+            delta: CopyDelta,
+        };
         let vec: Vec<_> = bundle.dofs(PointId::new(1).unwrap()).collect();
         let mut vec = vec.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
-        vec.sort_by_key(|(cap,_)| cap.get());
-        assert_eq!(vec, vec![
-            (PointId::new(101).unwrap(), &[8][..]),
-            (PointId::new(102).unwrap(), &[9][..]),
-        ]);
+        vec.sort_by_key(|(cap, _)| cap.get());
+        assert_eq!(
+            vec,
+            vec![
+                (PointId::new(101).unwrap(), &[8][..]),
+                (PointId::new(102).unwrap(), &[9][..]),
+            ]
+        );
     }
 
     #[test]
     fn refine_unknown_base_errors() {
         let atlas = Atlas::default();
         let section = Section::<i32>::new(atlas.clone());
-        let stack = InMemoryStack::<PointId,PointId,Orientation>::new();
-        let mut bundle = Bundle { stack, section, delta: CopyDelta };
+        let stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut bundle = Bundle {
+            stack,
+            section,
+            delta: CopyDelta,
+        };
         let err = bundle.refine([PointId::new(999).unwrap()]).unwrap_err();
-        assert!(matches!(err, crate::mesh_error::MeshSieveError::PointNotInAtlas(pid) if pid.get() == 999));
+        assert!(
+            matches!(err, crate::mesh_error::MeshSieveError::PointNotInAtlas(pid) if pid.get() == 999)
+        );
     }
 }

--- a/tests/delta_name_compat.rs
+++ b/tests/delta_name_compat.rs
@@ -1,0 +1,20 @@
+use mesh_sieve::data::refine::delta::{Delta, SliceDelta};
+use mesh_sieve::topology::arrow::Orientation;
+
+#[test]
+fn impls_satisfy_both_names() {
+    fn needs_slice_delta<T: SliceDelta<u8>>() {}
+    fn needs_delta<T: Delta<u8>>() {}
+
+    needs_slice_delta::<Orientation>();
+    needs_delta::<Orientation>();
+}
+
+#[test]
+fn call_apply_via_reexport() {
+    let src = [1u8, 2, 3];
+    let mut dst = [0u8; 3];
+    let o = Orientation::Reverse;
+    <Orientation as Delta<u8>>::apply(&o, &src, &mut dst).unwrap();
+    assert_eq!(&dst, &[3, 2, 1]);
+}


### PR DESCRIPTION
## Summary
- rename data refinement `Delta` trait to internal `SliceDelta` and re-export as `Delta`
- update internal imports and document difference from overlap `Delta`
- add tests ensuring `SliceDelta` and re-exported `Delta` behave identically

## Testing
- `cargo test`
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_e_68b91e6cbee083299e9e8739931f576b