### PR TITLE
Refactor Bundle::refine to apply slice deltas in-place

### DIFF
--- a/tests/bundle_refine.rs
+++ b/tests/bundle_refine.rs
@@ -1,0 +1,55 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::bundle::Bundle;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::overlap::delta::CopyDelta;
+use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::stack::{InMemoryStack, Stack};
+
+#[test]
+fn refine_disjoint_slices_no_allocations() -> Result<(), Box<dyn std::error::Error>> {
+    let b = PointId::new(1)?;
+    let c = PointId::new(2)?;
+    let mut atlas = Atlas::default();
+    atlas.try_insert(b, 3)?;
+    atlas.try_insert(c, 3)?;
+    let mut section = Section::<i32>::new(atlas);
+    section.try_set(b, &[10, 20, 30])?;
+
+    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
+    stack.add_arrow(b, c, Orientation::Forward)?;
+
+    let mut bundle = Bundle {
+        stack,
+        section,
+        delta: CopyDelta,
+    };
+    bundle.refine([b])?;
+
+    let cap_vals = bundle.section.try_restrict(c)?;
+    assert_eq!(cap_vals, &[10, 20, 30]);
+    Ok(())
+}
+
+#[test]
+fn refine_overlapping_slices_safe_reverse() -> Result<(), Box<dyn std::error::Error>> {
+    let p = PointId::new(42)?;
+    let mut atlas = Atlas::default();
+    atlas.try_insert(p, 4)?;
+    let mut section = Section::<i32>::new(atlas);
+    section.try_set(p, &[1, 2, 3, 4])?;
+
+    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
+    stack.add_arrow(p, p, Orientation::Reverse)?;
+
+    let mut bundle = Bundle {
+        stack,
+        section,
+        delta: CopyDelta,
+    };
+    bundle.refine([p])?;
+
+    let vals = bundle.section.try_restrict(p)?;
+    assert_eq!(vals, &[4, 3, 2, 1]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `Section::try_apply_delta_between_points` for safe in-place slice updates
- rewrite `Bundle::refine` to stream arrows and delegate to the new helper
- cover disjoint and overlapping slice cases with new tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b920195db48329a42c4edbc479a381