### PR TITLE
Add fallible map trait and error-aware helpers

### DIFF
--- a/examples/comprehensive_mesh_workflow.rs
+++ b/examples/comprehensive_mesh_workflow.rs
@@ -4,17 +4,20 @@
 //! This example demonstrates a complete mesh workflow including:
 //! - Hierarchical mesh construction (tetrahedral with refinement)
 //! - Lattice operations (meet/join) for mesh analysis
-//! - Refinement helpers (restrict_closure/star) 
+//! - Refinement helpers (try_restrict_closure/star)
 //! - Bundle operations with orientation handling
 //! - SievedArray refinement and assembly
-//! - METIS partitioning integration 
+//! - METIS partitioning integration
 //! - Distributed mesh completion with complex overlaps
 //! - Stratum computation and mesh validation
 //! - Error handling and robustness testing
 
-#[cfg(feature = "mpi-support")]
-use mesh_sieve::{data::bundle::Bundle, prelude::{InMemorySieve, MpiComm, PointId, Section}};
 use mesh_sieve::algs::dual_graph::build_dual;
+#[cfg(feature = "mpi-support")]
+use mesh_sieve::{
+    data::bundle::Bundle,
+    prelude::{InMemorySieve, MpiComm, PointId, Section},
+};
 #[cfg(feature = "metis-support")]
 fn main() {
     use mesh_sieve::algs::communicator::{Communicator, MpiComm};
@@ -23,22 +26,25 @@ fn main() {
     use mesh_sieve::algs::lattice::adjacent;
     use mesh_sieve::data::atlas::Atlas;
     use mesh_sieve::data::bundle::Bundle;
-    use mesh_sieve::data::refine::helpers::{restrict_closure, restrict_star, restrict_closure_vec, restrict_star_vec};
+    use mesh_sieve::data::refine::helpers::{
+        restrict_closure, restrict_closure_vec, restrict_star, restrict_star_vec,
+        try_restrict_closure, try_restrict_star,
+    };
     use mesh_sieve::data::refine::sieved_array::SievedArray;
     use mesh_sieve::data::section::Section;
-    use mesh_sieve::overlap::delta::{CopyDelta, AddDelta, ZeroDelta, Delta};
+    use mesh_sieve::overlap::delta::{AddDelta, CopyDelta, Delta, ZeroDelta};
     // use mesh_sieve::overlap::overlap::{Overlap, Remote};
+    use mesh_sieve::algs::dual_graph::build_dual;
+    use mesh_sieve::prelude::*;
     use mesh_sieve::topology::arrow::Orientation;
     use mesh_sieve::topology::point::PointId;
     use mesh_sieve::topology::sieve::{InMemorySieve, Sieve};
     use mesh_sieve::topology::stack::{InMemoryStack, Stack};
-    use mesh_sieve::algs::dual_graph::build_dual;
-    use mesh_sieve::prelude::*;
 
     let comm = MpiComm::default();
     let size = comm.size();
     let rank = comm.rank();
-    
+
     if size != 4 {
         if rank == 0 {
             eprintln!("This comprehensive test requires exactly 4 MPI ranks");
@@ -55,8 +61,16 @@ fn main() {
     let (global_mesh, cells, _refined_mesh, bundle) = if rank == 0 {
         build_hierarchical_tetrahedral_mesh()
     } else {
-        (InMemorySieve::default(), Vec::new(), InMemorySieve::default(), 
-         Bundle { stack: InMemoryStack::new(), section: Section::new(Atlas::default()), delta: CopyDelta })
+        (
+            InMemorySieve::default(),
+            Vec::new(),
+            InMemorySieve::default(),
+            Bundle {
+                stack: InMemoryStack::new(),
+                section: Section::new(Atlas::default()),
+                delta: CopyDelta,
+            },
+        )
     };
 
     comm.barrier();
@@ -134,16 +148,21 @@ fn main() {
 
 /// Build a complex tetrahedral mesh with refinement hierarchy
 #[cfg(feature = "mpi-support")]
-fn build_hierarchical_tetrahedral_mesh() -> (InMemorySieve<PointId, ()>, Vec<PointId>, InMemorySieve<PointId, ()>, Bundle<f64>) {
-    use mesh_sieve::prelude::*;
+fn build_hierarchical_tetrahedral_mesh() -> (
+    InMemorySieve<PointId, ()>,
+    Vec<PointId>,
+    InMemorySieve<PointId, ()>,
+    Bundle<f64>,
+) {
     use mesh_sieve::prelude::Stack;
+    use mesh_sieve::prelude::*;
     use mesh_sieve::topology::arrow::Orientation;
 
     println!("[rank 0] Building hierarchical tetrahedral mesh...");
-    
+
     let mut mesh = InMemorySieve::<PointId, ()>::default();
     let mut atlas = Atlas::default();
-    
+
     // Create two tetrahedra sharing a face
     // Tet 1: vertices 1,2,3,4 -> faces 10,11,12,13
     // Tet 2: vertices 2,3,4,5 -> faces 11,14,15,16 (shares face 11)
@@ -151,22 +170,30 @@ fn build_hierarchical_tetrahedral_mesh() -> (InMemorySieve<PointId, ()>, Vec<Poi
         PointId::new(100).unwrap(), // tet 1
         PointId::new(101).unwrap(), // tet 2
     ];
-    
-    let faces = (10..=16).map(|i| PointId::new(i).unwrap()).collect::<Vec<_>>();
-    let edges = (20..=35).map(|i| PointId::new(i).unwrap()).collect::<Vec<_>>();
-    let verts = (1..=5).map(|i| PointId::new(i).unwrap()).collect::<Vec<_>>();
-    
+
+    let faces = (10..=16)
+        .map(|i| PointId::new(i).unwrap())
+        .collect::<Vec<_>>();
+    let edges = (20..=35)
+        .map(|i| PointId::new(i).unwrap())
+        .collect::<Vec<_>>();
+    let verts = (1..=5)
+        .map(|i| PointId::new(i).unwrap())
+        .collect::<Vec<_>>();
+
     // Build tet 1 topology
-    for &face in &faces[0..4] { // faces 10,11,12,13
+    for &face in &faces[0..4] {
+        // faces 10,11,12,13
         mesh.add_arrow(cells[0], face, ());
     }
-    
+
     // Build tet 2 topology (shares face 11)
     mesh.add_arrow(cells[1], faces[1], ()); // shared face 11
-    for &face in &faces[4..7] { // faces 14,15,16
+    for &face in &faces[4..7] {
+        // faces 14,15,16
         mesh.add_arrow(cells[1], face, ());
     }
-    
+
     // Face to edge topology (simplified)
     for (i, &face) in faces.iter().enumerate() {
         for j in 0..3 {
@@ -174,7 +201,7 @@ fn build_hierarchical_tetrahedral_mesh() -> (InMemorySieve<PointId, ()>, Vec<Poi
             mesh.add_arrow(face, edges[edge_idx], ());
         }
     }
-    
+
     // Edge to vertex topology (simplified)
     for (i, &edge) in edges.iter().enumerate() {
         let v1 = verts[i % verts.len()];
@@ -182,17 +209,15 @@ fn build_hierarchical_tetrahedral_mesh() -> (InMemorySieve<PointId, ()>, Vec<Poi
         mesh.add_arrow(edge, v1, ());
         mesh.add_arrow(edge, v2, ());
     }
-    
+
     // Create refined mesh with DOF hierarchy
     let mut refined_mesh = mesh.clone();
     let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
-    
+
     // Add refinement: each face gets 3 DOF points
     for (i, &face) in faces.iter().enumerate() {
         atlas.try_insert(face, 1).unwrap();
         for j in 0..3 {
-
-
             let dof_id = PointId::new(1000 + i as u64 * 10 + j as u64).unwrap();
             atlas.try_insert(dof_id, 1).unwrap();
             let orientation = if j % 2 == 0 {
@@ -204,18 +229,27 @@ fn build_hierarchical_tetrahedral_mesh() -> (InMemorySieve<PointId, ()>, Vec<Poi
             mesh_sieve::topology::Sieve::add_point(&mut refined_mesh, dof_id);
         }
     }
-    
+
     // Create section with test data
     let mut section = Section::<f64>::new(atlas);
     for (i, &face) in faces.iter().enumerate() {
         section.try_set(face, &[(i as f64 + 1.0) * 10.0]).unwrap();
     }
-    
-    let bundle = Bundle { stack, section, delta: CopyDelta };
-    
-    println!("[rank 0] Built mesh with {} cells, {} faces, {} edges, {} vertices", 
-             cells.len(), faces.len(), edges.len(), verts.len());
-    
+
+    let bundle = Bundle {
+        stack,
+        section,
+        delta: CopyDelta,
+    };
+
+    println!(
+        "[rank 0] Built mesh with {} cells, {} faces, {} edges, {} vertices",
+        cells.len(),
+        faces.len(),
+        edges.len(),
+        verts.len()
+    );
+
     (mesh, cells, refined_mesh, bundle)
 }
 
@@ -231,18 +265,23 @@ fn test_lattice_operations(mesh: &InMemorySieve<PointId, ()>, cells: &[PointId])
         use mesh_sieve::algs::adjacent;
         let meet_result: Vec<_> = mesh.meet(cells[0], cells[1]).collect();
         println!("  meet({:?}, {:?}) = {:?}", cells[0], cells[1], meet_result);
-        
+
         // Test join operation
         let join_result: Vec<_> = mesh.join(cells[0], cells[1]).collect();
-        println!("  join({:?}, {:?}) = {} elements", cells[0], cells[1], join_result.len());
-        
+        println!(
+            "  join({:?}, {:?}) = {} elements",
+            cells[0],
+            cells[1],
+            join_result.len()
+        );
+
         // Test adjacency
         let mut mesh_mut = mesh.clone();
         let adj1 = adjacent(&mut mesh_mut, cells[0]);
         let adj2 = adjacent(&mut mesh_mut, cells[1]);
         println!("  adjacent to {:?}: {:?}", cells[0], adj1);
         println!("  adjacent to {:?}: {:?}", cells[1], adj2);
-        
+
         // Note: Adjacency may be empty if cells don't share elements directly
         // This is expected for the simplified test mesh topology
         if !adj1.is_empty() && !adj2.is_empty() {
@@ -252,58 +291,63 @@ fn test_lattice_operations(mesh: &InMemorySieve<PointId, ()>, cells: &[PointId])
             println!("  Note: No direct adjacency found (expected for simplified mesh)");
         }
     }
-    
+
     println!("[rank 0] Lattice operations test passed");
 }
 
 /// Test refinement helpers (restrict_closure, restrict_star)
 #[cfg(feature = "mpi-support")]
 fn test_refinement_helpers(mesh: &InMemorySieve<PointId, ()>, _section: &Section<f64>) {
-    use mesh_sieve::prelude::*;
     use mesh_sieve::data::refine::*;
+    use mesh_sieve::prelude::*;
 
     println!("[rank 0] Testing refinement helpers...");
-    
+
     // Create a comprehensive test section that covers all mesh points
     let mut test_atlas = Atlas::default();
     let all_points: Vec<_> = mesh.points().collect();
-    
+
     // Add all mesh points to the test atlas
     for &point in &all_points {
         test_atlas.try_insert(point, 1).unwrap();
     }
-    
+
     let mut test_section = Section::<f64>::new(test_atlas);
-    
+
     // Set test data for all points
     for (i, &point) in all_points.iter().enumerate() {
-        test_section.try_set(point, &[(i as f64 + 1.0) * 10.0]).unwrap();
+        test_section
+            .try_set(point, &[(i as f64 + 1.0) * 10.0])
+            .unwrap();
     }
-    
+
     // Now test with points that should work
     let test_points: Vec<_> = all_points.into_iter().take(3).collect();
-    
+
     if test_points.is_empty() {
         println!("  No points available in mesh, skipping refinement helpers test");
     } else {
         for &point in &test_points {
             // Test closure restriction
 
-            
             let closure_data: Vec<_> = restrict_closure(mesh, &test_section, [point]).collect();
             let closure_vec = restrict_closure_vec(mesh, &test_section, [point]);
             assert_eq!(closure_data, closure_vec, "Closure variants should match");
-            
-            // Test star restriction  
+
+            // Test star restriction
             let star_data: Vec<_> = restrict_star(mesh, &test_section, [point]).collect();
             let star_vec = restrict_star_vec(mesh, &test_section, [point]);
             assert_eq!(star_data, star_vec, "Star variants should match");
-            
-            println!("  Point {:?}: closure={} elements, star={} elements", 
-                     point, closure_data.len(), star_data.len());
+
+            println!(
+                "  Point {:?}: closure={} elements, star={} elements",
+                point,
+                closure_data.len(),
+                star_data.len()
+            );
         }
     }
-    
+
     println!("[rank 0] Refinement helpers test passed");
 }
 
@@ -312,76 +356,87 @@ fn test_refinement_helpers(mesh: &InMemorySieve<PointId, ()>, _section: &Section
 fn test_stratum_computation(mesh: &InMemorySieve<PointId, ()>) {
     println!("[rank 0] Testing stratum computation...");
     use mesh_sieve::prelude::*;
-    
+
     // Test height and depth computations
     let test_points: Vec<_> = mesh.points().take(5).collect();
     let mut mesh_clone = mesh.clone(); // Need mutable reference for height/depth
-    
+
     for &point in &test_points {
         match mesh_clone.height(point) {
-            Ok(h) => {
-                match mesh_clone.depth(point) {
-                    Ok(d) => {
-                        println!("  Point {:?}: height={}, depth={}", point, h, d);
-                    }
-                    Err(e) => println!("  Point {:?}: depth computation failed: {:?}", point, e),
+            Ok(h) => match mesh_clone.depth(point) {
+                Ok(d) => {
+                    println!("  Point {:?}: height={}, depth={}", point, h, d);
                 }
-            }
+                Err(e) => println!("  Point {:?}: depth computation failed: {:?}", point, e),
+            },
             Err(e) => println!("  Point {:?}: height computation failed: {:?}", point, e),
         }
     }
-    
+
     // Test strata computation (simplified without compute_strata method)
     let all_points: Vec<_> = mesh.points().collect();
     println!("  Total mesh points: {}", all_points.len());
-    
+
     // Test manual stratum-like computation by grouping by height
-    let mut height_groups: std::collections::HashMap<u32, Vec<PointId>> = std::collections::HashMap::new();
+    let mut height_groups: std::collections::HashMap<u32, Vec<PointId>> =
+        std::collections::HashMap::new();
     for &point in &test_points {
         if let Ok(height) = mesh_clone.height(point) {
             height_groups.entry(height).or_default().push(point);
         }
     }
-    
+
     for (height, points) in height_groups {
         println!("  Height {}: {} points", height, points.len());
     }
-    
+
     println!("[rank 0] Stratum computation test passed");
 }
 
 /// Test METIS partitioning integration
 #[cfg(feature = "metis-support")]
-fn test_metis_partitioning(mesh: &InMemorySieve<PointId, ()>, cells: &[PointId], n_parts: usize) -> Vec<usize> {
+fn test_metis_partitioning(
+    mesh: &InMemorySieve<PointId, ()>,
+    cells: &[PointId],
+    n_parts: usize,
+) -> Vec<usize> {
     println!("[rank 0] Testing METIS partitioning...");
-    
+
     // METIS requires at least as many cells as partitions
     if cells.len() < n_parts {
-        println!("  Not enough cells ({}) for {} partitions, using simple round-robin", cells.len(), n_parts);
+        println!(
+            "  Not enough cells ({}) for {} partitions, using simple round-robin",
+            cells.len(),
+            n_parts
+        );
         return (0..cells.len()).map(|i| i % n_parts).collect();
     }
-    
+
     // Build dual graph
     let dual_graph = build_dual(mesh, cells.to_vec());
-    
+
     // Partition with METIS
     let partition = dual_graph.metis_partition(n_parts.try_into().unwrap());
     println!("  Partitioned {} cells into {} parts", cells.len(), n_parts);
-    
+
     // Validate partition balance
     let mut part_sizes = vec![0; n_parts];
     for &part in &partition.part {
         part_sizes[part as usize] += 1;
     }
     println!("  Partition sizes: {:?}", part_sizes);
-    
+
     println!("[rank 0] METIS partitioning test passed");
     partition.part.into_iter().map(|p| p as usize).collect()
 }
 
 #[cfg(not(feature = "metis-support"))]
 #[cfg(feature = "mpi-support")]
-fn test_metis_partitioning(_mesh: &InMemorySieve<PointId, ()>, cells: &[PointId], n_parts: usize) -> Vec<usize> {
+fn test_metis_partitioning(
+    _mesh: &InMemorySieve<PointId, ()>,
+    cells: &[PointId],
+    n_parts: usize,
+) -> Vec<usize> {
     println!("[rank 0] METIS not available, using round-robin partitioning...");
     (0..cells.len()).map(|i| i % n_parts).collect()
 }
@@ -399,38 +454,44 @@ fn test_distributed_completion(
     use mesh_sieve::prelude::*;
 
     println!("[rank {}] Testing distributed completion...", rank);
-    
+
     // Distribute the mesh
     if let Ok((local_mesh, mut overlap)) = distribute_mesh(global_mesh, partition, comm) {
-        println!("[rank {}] Received local mesh with {} points", rank, local_mesh.points().count());
-        
+        println!(
+            "[rank {}] Received local mesh with {} points",
+            rank,
+            local_mesh.points().count()
+        );
+
         // Create test section for completion
         let mut atlas = Atlas::default();
         let local_points: Vec<_> = local_mesh.points().take(5).collect();
-        
+
         for &point in &local_points {
             atlas.try_insert(point, 1).unwrap();
         }
-        
+
         let mut section = Section::<i32>::new(atlas);
-        
+
         // Set unique values per rank
         for (i, &point) in local_points.iter().enumerate() {
             let value = (rank as i32 + 1) * 1000 + i as i32;
             section.try_set(point, &[value]).unwrap();
         }
-        
+
         // Test sieve completion (skip due to type mismatch - would need proper overlap with Remote payload)
-        println!("[rank {}] Skipping sieve completion test (requires Remote payload)", rank);
-        
-        // Test section completion  
+        println!(
+            "[rank {}] Skipping sieve completion test (requires Remote payload)",
+            rank
+        );
+
+        // Test section completion
         let delta = CopyDelta;
         if let Err(e) = complete_section(&mut section, &mut overlap, comm, &delta, rank, size) {
             println!("[rank {}] Section completion failed: {:?}", rank, e);
         } else {
             println!("[rank {}] Section completion succeeded", rank);
         }
-        
     } else {
         println!("[rank {}] Mesh distribution failed", rank);
     }
@@ -442,54 +503,69 @@ fn test_bundle_operations(rank: usize) {
     println!("[rank {}] Testing Bundle operations...", rank);
     use mesh_sieve::prelude::*;
     use mesh_sieve::topology::arrow::Orientation;
-    
+
     // Create test bundle
     let mut atlas = Atlas::default();
     let base1 = PointId::new(10 + rank as u64).unwrap();
     let cap1 = PointId::new(110 + rank as u64).unwrap();
     let cap2 = PointId::new(120 + rank as u64).unwrap();
-    
+
     atlas.try_insert(base1, 2).unwrap(); // 2 DOFs
     atlas.try_insert(cap1, 2).unwrap();
     atlas.try_insert(cap2, 2).unwrap();
-    
+
     let mut section = Section::<f64>::new(atlas);
     section.try_set(base1, &[1.0, 2.0]).unwrap();
-    
+
     let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
     let _ = stack.add_arrow(base1, cap1, Orientation::Forward);
     let _ = stack.add_arrow(base1, cap2, Orientation::Reverse);
-    
-    let mut bundle = Bundle { stack, section, delta: CopyDelta };
-    
+
+    let mut bundle = Bundle {
+        stack,
+        section,
+        delta: CopyDelta,
+    };
+
     // Test refinement
     if let Err(e) = bundle.refine([base1]) {
         println!("[rank {}] Bundle refine failed: {:?}", rank, e);
         return;
     }
-    
+
     // Check orientations
     let cap1_vals = bundle.section.try_restrict(cap1).unwrap();
     let cap2_vals = bundle.section.try_restrict(cap2).unwrap();
-    
-    println!("[rank {}] Forward cap: {:?}, Reverse cap: {:?}", rank, cap1_vals, cap2_vals);
-    
+
+    println!(
+        "[rank {}] Forward cap: {:?}, Reverse cap: {:?}",
+        rank, cap1_vals, cap2_vals
+    );
+
     // Verify reverse orientation
-    assert_eq!(cap1_vals, &[1.0, 2.0], "Forward orientation should preserve order");
-    assert_eq!(cap2_vals, &[2.0, 1.0], "Reverse orientation should reverse order");
-    
+    assert_eq!(
+        cap1_vals,
+        &[1.0, 2.0],
+        "Forward orientation should preserve order"
+    );
+    assert_eq!(
+        cap2_vals,
+        &[2.0, 1.0],
+        "Reverse orientation should reverse order"
+    );
+
     // Test assembly with AddDelta
-    let mut add_bundle = Bundle { 
-        stack: bundle.stack.clone(), 
-        section: bundle.section.clone(), 
-        delta: AddDelta 
+    let mut add_bundle = Bundle {
+        stack: bundle.stack.clone(),
+        section: bundle.section.clone(),
+        delta: AddDelta,
     };
-    
+
     if let Err(e) = add_bundle.assemble([base1]) {
         println!("[rank {}] Bundle assemble failed: {:?}", rank, e);
         return;
     }
-    
+
     println!("[rank {}] Bundle operations test passed", rank);
 }
 
@@ -499,106 +575,120 @@ fn test_sieved_array_operations(rank: usize) {
     use mesh_sieve::{data::refine::SievedArray, prelude::Atlas};
 
     println!("[rank {}] Testing SievedArray operations...", rank);
-    
+
     // Create coarse and fine arrays
     let mut coarse_atlas = Atlas::default();
     let mut fine_atlas = Atlas::default();
-    
+
     let pt1 = PointId::new(50 + rank as u64).unwrap();
     let pt2 = PointId::new(60 + rank as u64).unwrap();
-    
+
     coarse_atlas.try_insert(pt1, 2).unwrap();
     coarse_atlas.try_insert(pt2, 2).unwrap(); // Add pt2 to coarse atlas too
     fine_atlas.try_insert(pt1, 2).unwrap();
     fine_atlas.try_insert(pt2, 2).unwrap();
-    
+
     let mut coarse = SievedArray::<PointId, f32>::new(coarse_atlas);
     let mut fine = SievedArray::<PointId, f32>::new(fine_atlas);
-    
+
     // Set test data
     coarse.try_set(pt1, &[10.0, 20.0]).unwrap();
     coarse.try_set(pt2, &[30.0, 40.0]).unwrap(); // Set data for pt2 in coarse
     fine.try_set(pt1, &[1.0, 2.0]).unwrap();
     fine.try_set(pt2, &[3.0, 4.0]).unwrap();
-    
+
     // Test refinement using correct signature
     let refinement_map = vec![(pt1, vec![pt1]), (pt2, vec![pt2])];
-    
+
     if let Err(e) = fine.try_refine(&mut coarse, &refinement_map) {
         println!("[rank {}] SievedArray refine failed: {:?}", rank, e);
         return;
     }
-    
-    // Test assembly (coarse -> fine) 
+
+    // Test assembly (coarse -> fine)
     let assembly_map = vec![(pt1, vec![pt1, pt2])];
     if let Err(e) = coarse.try_assemble(&mut fine, &assembly_map) {
         println!("[rank {}] SievedArray assemble failed: {:?}", rank, e);
         return;
     }
-    
+
     println!("[rank {}] SievedArray operations test passed", rank);
 }
 
 /// Test error handling and robustness
 #[cfg(feature = "mpi-support")]
 fn test_error_handling_robustness(rank: usize) {
-    use mesh_sieve::{overlap::delta::ZeroDelta, prelude::{Atlas, Delta, Section, Sieve}};
+    use mesh_sieve::{
+        overlap::delta::ZeroDelta,
+        prelude::{Atlas, Delta, Section, Sieve},
+    };
 
     println!("[rank {}] Testing error handling robustness...", rank);
-    
+
     let mut atlas = Atlas::default();
     let pt = PointId::new(999).unwrap();
     atlas.try_insert(pt, 1).unwrap();
     let mut section = Section::<i32>::new(atlas);
-    
+
     // Test various error conditions
-    
+
     // 1. Point not in atlas
     let bad_pt = PointId::new(9999).unwrap();
     if let Ok(_) = section.try_restrict(bad_pt) {
         panic!("[rank {}] Should have failed for non-existent point", rank);
     }
-    
+
     // 2. Wrong slice length
     if let Ok(_) = section.try_set(pt, &[1, 2, 3]) {
         panic!("[rank {}] Should have failed for wrong slice length", rank);
     }
-    
+
     // 3. Empty sieve operations
     let empty_sieve = InMemorySieve::<PointId, ()>::default();
     let non_existent_pt = PointId::new(99999).unwrap(); // Use a point not in the sieve
     let closure_empty: Vec<_> = empty_sieve.closure([non_existent_pt]).collect();
     // Note: closure may include the point itself even if not in sieve, so check if it's minimal
-    println!("  Empty sieve closure result: {} elements", closure_empty.len());
-    
+    println!(
+        "  Empty sieve closure result: {} elements",
+        closure_empty.len()
+    );
+
     // 4. Cycle detection in stratum computation
     let mut cyclic_sieve = InMemorySieve::<PointId, ()>::default();
     let p1 = PointId::new(1).unwrap();
     let p2 = PointId::new(2).unwrap();
     cyclic_sieve.add_arrow(p1, p2, ());
     cyclic_sieve.add_arrow(p2, p1, ()); // Creates cycle
-    
+
     match cyclic_sieve.height(p1) {
         Err(mesh_sieve::mesh_error::MeshSieveError::CycleDetected) => {
-            println!("[rank {}] Correctly detected cycle in height computation", rank);
+            println!(
+                "[rank {}] Correctly detected cycle in height computation",
+                rank
+            );
         }
         _ => {
-            println!("[rank {}] WARNING: Cycle detection may not be working properly", rank);
+            println!(
+                "[rank {}] WARNING: Cycle detection may not be working properly",
+                rank
+            );
         }
     }
-    
+
     // 5. Test Delta trait behavior
     let mut val = 42;
     let part = <ZeroDelta as Delta<i32>>::restrict(&val);
     assert_eq!(part, 0, "ZeroDelta restrict should return 0");
     <ZeroDelta as Delta<i32>>::fuse(&mut val, 999);
     assert_eq!(val, 42, "ZeroDelta fuse should not change value");
-    
+
     println!("[rank {}] Error handling robustness test passed", rank);
 }
 
 #[cfg(not(feature = "metis-support"))]
 fn main() {
     println!("This example requires the 'metis-support' feature enabled.");
-    println!("Run with: cargo mpirun -n 4 --features mpi-support,metis-support --example comprehensive_mesh_workflow");
+    println!(
+        "Run with: cargo mpirun -n 4 --features mpi-support,metis-support --example comprehensive_mesh_workflow"
+    );
 }

--- a/src/data/refine/helpers.rs
+++ b/src/data/refine/helpers.rs
@@ -5,18 +5,19 @@
 //! associated with points in a mesh, following closure or star traversals
 //! of a [`Sieve`]. It also provides a read-only wrapper for section data.
 
-use crate::data::section::Map;
+use crate::data::section::{FallibleMap, Map};
+use crate::mesh_error::MeshSieveError;
 use crate::topology::point::PointId;
 use crate::topology::sieve::Sieve;
 
 /// Restrict a map along the closure of the given seed points.
 ///
 /// Returns an iterator over `(PointId, &[V])` for all points in the closure.
-pub fn restrict_closure<'s, M, V: Clone + Default + 's>(
-    sieve: &impl Sieve<Point = PointId>,
+pub fn restrict_closure<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
     seeds: impl IntoIterator<Item = PointId>,
-) -> impl Iterator<Item = (PointId, &'s [V])>
+) -> impl Iterator<Item = (PointId, &'s [V])> + 's
 where
     M: Map<V> + 's,
 {
@@ -26,11 +27,11 @@ where
 /// Restrict a map along the star of the given seed points.
 ///
 /// Returns an iterator over `(PointId, &[V])` for all points in the star.
-pub fn restrict_star<'s, M, V: Clone + Default + 's>(
-    sieve: &impl Sieve<Point = PointId>,
+pub fn restrict_star<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
     seeds: impl IntoIterator<Item = PointId>,
-) -> impl Iterator<Item = (PointId, &'s [V])>
+) -> impl Iterator<Item = (PointId, &'s [V])> + 's
 where
     M: Map<V> + 's,
 {
@@ -38,8 +39,8 @@ where
 }
 
 /// Restrict a map along the closure of the given seed points, collecting results into a vector.
-pub fn restrict_closure_vec<'s, M, V: Clone + Default + 's>(
-    sieve: &impl Sieve<Point = PointId>,
+pub fn restrict_closure_vec<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
     seeds: impl IntoIterator<Item = PointId>,
 ) -> Vec<(PointId, &'s [V])>
@@ -50,8 +51,8 @@ where
 }
 
 /// Restrict a map along the star of the given seed points, collecting results into a vector.
-pub fn restrict_star_vec<'s, M, V: Clone + Default + 's>(
-    sieve: &impl Sieve<Point = PointId>,
+pub fn restrict_star_vec<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
     seeds: impl IntoIterator<Item = PointId>,
 ) -> Vec<(PointId, &'s [V])>
@@ -61,14 +62,117 @@ where
     restrict_star(sieve, map, seeds).collect()
 }
 
-/// Read-only wrapper for a section, implementing the [`Map`] trait.
-pub struct ReadOnlyMap<'a, V: Clone + Default> {
+/// Restrict a map along the closure of the given seed points, propagating errors.
+pub fn try_restrict_closure<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
+    map: &'s M,
+    seeds: impl IntoIterator<Item = PointId>,
+) -> impl Iterator<Item = Result<(PointId, &'s [V]), MeshSieveError>> + 's
+where
+    M: FallibleMap<V> + 's,
+{
+    sieve
+        .closure(seeds)
+        .map(move |p| map.try_get(p).map(|sl| (p, sl)))
+}
+
+/// Restrict a map along the star of the given seed points, propagating errors.
+pub fn try_restrict_star<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
+    map: &'s M,
+    seeds: impl IntoIterator<Item = PointId>,
+) -> impl Iterator<Item = Result<(PointId, &'s [V]), MeshSieveError>> + 's
+where
+    M: FallibleMap<V> + 's,
+{
+    sieve
+        .star(seeds)
+        .map(move |p| map.try_get(p).map(|sl| (p, sl)))
+}
+
+/// Collects the closure restriction into a vector, short-circuiting on error.
+pub fn try_restrict_closure_vec<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
+    map: &'s M,
+    seeds: impl IntoIterator<Item = PointId>,
+) -> Result<Vec<(PointId, &'s [V])>, MeshSieveError>
+where
+    M: FallibleMap<V> + 's,
+{
+    try_restrict_closure(sieve, map, seeds).collect()
+}
+
+/// Collects the star restriction into a vector, short-circuiting on error.
+pub fn try_restrict_star_vec<'s, M, V: 's>(
+    sieve: &'s impl Sieve<Point = PointId>,
+    map: &'s M,
+    seeds: impl IntoIterator<Item = PointId>,
+) -> Result<Vec<(PointId, &'s [V])>, MeshSieveError>
+where
+    M: FallibleMap<V> + 's,
+{
+    try_restrict_star(sieve, map, seeds).collect()
+}
+
+#[cfg(feature = "rayon")]
+pub fn try_restrict_closure_vec_parallel<'s, M, V: Send + Sync + 's>(
+    sieve: &impl Sieve<Point = PointId>,
+    map: &'s M,
+    seeds: impl IntoIterator<Item = PointId>,
+) -> Result<Vec<(PointId, &'s [V])>, MeshSieveError>
+where
+    M: FallibleMap<V> + Sync + 's,
+{
+    use rayon::prelude::*;
+    let pts: Vec<_> = sieve.closure(seeds).collect();
+    pts.par_iter()
+        .map(|&p| map.try_get(p).map(|sl| (p, sl)))
+        .try_collect()
+}
+
+#[cfg(feature = "rayon")]
+pub fn try_restrict_star_vec_parallel<'s, M, V: Send + Sync + 's>(
+    sieve: &impl Sieve<Point = PointId>,
+    map: &'s M,
+    seeds: impl IntoIterator<Item = PointId>,
+) -> Result<Vec<(PointId, &'s [V])>, MeshSieveError>
+where
+    M: FallibleMap<V> + Sync + 's,
+{
+    use rayon::prelude::*;
+    let pts: Vec<_> = sieve.star(seeds).collect();
+    pts.par_iter()
+        .map(|&p| map.try_get(p).map(|sl| (p, sl)))
+        .try_collect()
+}
+
+/// Read-only wrapper for a section.
+pub struct ReadOnlyMap<'a, V> {
     pub section: &'a crate::data::section::Section<V>,
 }
 
-impl<'a, V: Clone + Default> crate::data::section::Map<V> for ReadOnlyMap<'a, V> {
+impl<'a, V> FallibleMap<V> for ReadOnlyMap<'a, V> {
+    #[inline]
+    fn try_get(&self, p: crate::topology::point::PointId) -> Result<&[V], MeshSieveError> {
+        self.section.try_restrict(p)
+    }
+
+    #[inline]
+    fn try_get_mut(
+        &mut self,
+        _p: crate::topology::point::PointId,
+    ) -> Result<&mut [V], MeshSieveError> {
+        Err(MeshSieveError::UnsupportedStackOperation(
+            "ReadOnlyMap::try_get_mut",
+        ))
+    }
+}
+
+impl<'a, V> Map<V> for ReadOnlyMap<'a, V> {
     fn get(&self, p: crate::topology::point::PointId) -> &[V] {
-        self.section.try_restrict(p).unwrap_or(&[])
+        self.section
+            .try_restrict(p)
+            .unwrap_or_else(|e| panic!("ReadOnlyMap::get({p:?}) failed: {e}"))
     }
     // get_mut left as default (None)
 }
@@ -76,13 +180,14 @@ impl<'a, V: Clone + Default> crate::data::section::Map<V> for ReadOnlyMap<'a, V>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::topology::point::PointId;
     use crate::data::atlas::Atlas;
-    use crate::data::section::Section;
+    use crate::data::section::{FallibleMap, Map, Section};
+    use crate::topology::point::PointId;
     use crate::topology::sieve::in_memory::InMemorySieve;
-    use crate::data::section::Map;
 
-    fn v(i: u64) -> PointId { PointId::new(i).unwrap() }
+    fn v(i: u64) -> PointId {
+        PointId::new(i).unwrap()
+    }
 
     #[test]
     fn restrict_helpers_basic() {
@@ -91,27 +196,47 @@ mod tests {
         s.add_arrow(v(1), v(2), ());
         s.add_arrow(v(2), v(3), ());
         let mut atlas = Atlas::default();
-        atlas.try_insert(v(1),1).unwrap();
-        atlas.try_insert(v(2),1).unwrap();
-        atlas.try_insert(v(3),1).unwrap();
+        atlas.try_insert(v(1), 1).unwrap();
+        atlas.try_insert(v(2), 1).unwrap();
+        atlas.try_insert(v(3), 1).unwrap();
         let mut sec = Section::<i32>::new(atlas);
         sec.try_set(v(1), &[10]).unwrap();
         sec.try_set(v(2), &[20]).unwrap();
         sec.try_set(v(3), &[30]).unwrap();
         // restrict_closure
         let out: Vec<_> = restrict_closure(&s, &sec, [v(1)]).collect();
-        let expected: Vec<_> = s.closure([v(1)])
-            .map(|p| (p, sec.try_restrict(p).unwrap_or(&[])))
+        let expected: Vec<_> = s
+            .closure([v(1)])
+            .map(|p| (p, sec.try_restrict(p).unwrap()))
             .collect();
         assert_eq!(out, expected);
         // empty
         let empty: Vec<_> = restrict_star(&s, &sec, std::iter::empty()).collect();
         assert!(empty.is_empty());
         // vec variants match
-        assert_eq!(restrict_closure_vec(&s,&sec,[v(2)]), restrict_closure(&s,&sec,[v(2)]).collect::<Vec<_>>());
-        // ReadOnlyMap
+        assert_eq!(
+            restrict_closure_vec(&s, &sec, [v(2)]),
+            restrict_closure(&s, &sec, [v(2)]).collect::<Vec<_>>()
+        );
+        // fallible helpers succeed
+        assert_eq!(
+            try_restrict_closure_vec(&s, &sec, [v(1)]).unwrap(),
+            restrict_closure_vec(&s, &sec, [v(1)])
+        );
+        // fallible helpers return Err on missing point
+        assert!(matches!(
+            try_restrict_closure_vec(&s, &sec, [v(99)]),
+            Err(MeshSieveError::PointNotInAtlas(pid)) if pid == v(99)
+        ));
+        // legacy helper panics on missing point
+        assert!(std::panic::catch_unwind(|| restrict_closure_vec(&s, &sec, [v(99)])).is_err());
+        // ReadOnlyMap fallible
         let mut rom = ReadOnlyMap { section: &sec };
-        assert_eq!(rom.get(v(3)), sec.try_restrict(v(3)).unwrap_or(&[]));
+        assert_eq!(
+            <ReadOnlyMap<'_, i32> as FallibleMap<i32>>::try_get(&rom, v(3)).unwrap(),
+            sec.try_restrict(v(3)).unwrap()
+        );
+        assert!(<ReadOnlyMap<'_, i32> as FallibleMap<i32>>::try_get(&rom, v(99)).is_err());
         assert!(<ReadOnlyMap<'_, i32> as Map<i32>>::get_mut(&mut rom, v(3)).is_none());
     }
 }

--- a/src/data/refine/mod.rs
+++ b/src/data/refine/mod.rs
@@ -9,7 +9,12 @@ pub mod sieved_array;
 
 // re-export the main pieces at the top level:
 pub use delta::Delta;
-pub use helpers::{restrict_closure, restrict_closure_vec, restrict_star, restrict_star_vec};
+pub use helpers::{
+    restrict_closure, restrict_closure_vec, restrict_star, restrict_star_vec, try_restrict_closure,
+    try_restrict_closure_vec, try_restrict_star, try_restrict_star_vec,
+};
+#[cfg(feature = "rayon")]
+pub use helpers::{try_restrict_closure_vec_parallel, try_restrict_star_vec_parallel};
 pub use sieved_array::SievedArray;
 
 /// A sifter is a vector of (PointId, Orientation) pairs for refinement.


### PR DESCRIPTION
## Summary
- introduce `FallibleMap` trait and implement for `Section`
- add `try_restrict_*` helpers with error propagation and update `ReadOnlyMap`
- re-export fallible helpers and document in example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b92269624483298c952a324cca619b