### PR TITLE
refactor: minimize data trait bounds and document behavior

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,18 @@ jobs:
     # Note: MPI-specific examples are executed in the separate `mpi-tests` job
     # below which installs MPI and runs a curated, smaller set to avoid timeouts.
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Build docs
+      run: cargo doc --no-deps
+
   # Separate job for benchmarks and integration tests
   benchmarks:
     runs-on: ubuntu-latest

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,10 +1,11 @@
 //! Data module: section and atlas
+#![warn(missing_docs)]
 
 pub mod atlas;
-pub mod section;
 pub mod bundle;
+pub mod section;
 
-pub mod refine;
 mod _debug_invariants;
+pub mod refine;
 
 pub(crate) use _debug_invariants::DebugInvariants;

--- a/src/data/refine/delta.rs
+++ b/src/data/refine/delta.rs
@@ -21,7 +21,7 @@ use crate::topology::arrow::Orientation;
 /// Trait for applying a transformation (delta) from a source slice to a destination slice.
 ///
 /// Implementors define how to map or permute values from `src` to `dest`.
-pub trait SliceDelta<V: Clone + Default>: Sync {
+pub trait SliceDelta<V: Clone>: Sync {
     /// Apply the transformation from `src` to `dest`.
     ///
     /// Returns an error if lengths differ.
@@ -31,7 +31,7 @@ pub trait SliceDelta<V: Clone + Default>: Sync {
 /// Backward-compatible re-export: external code can still name this trait `Delta`.
 pub use SliceDelta as Delta;
 
-impl<V: Clone + Default> SliceDelta<V> for Orientation {
+impl<V: Clone> SliceDelta<V> for Orientation {
     fn apply(&self, src: &[V], dest: &mut [V]) -> Result<(), MeshSieveError> {
         let expected = src.len();
         let found = dest.len();


### PR DESCRIPTION
## Summary
- loosen section and sieved array trait bounds to only require Clone or Default where needed
- standardize slice writes on `clone_from_slice`
- document complexity and determinism for atlas, section, bundle, and sieved array APIs
- add doc build to CI and warn on missing docs in data module

## Testing
- `cargo test --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b92cd38d188329b1aedabf41d929c8