### PR TITLE
Improve atlas ergonomics and iteration utilities

### DIFF
--- a/src/data/atlas.rs
+++ b/src/data/atlas.rs
@@ -109,6 +109,48 @@ impl Atlas {
         self.map.get(&p).copied()
     }
 
+    /// Returns true iff `p` is registered in the atlas.
+    ///
+    /// # Complexity
+    /// **O(1)**.
+    ///
+    /// # Determinism
+    /// No side effects.
+    #[inline]
+    pub fn contains(&self, p: PointId) -> bool {
+        self.map.contains_key(&p)
+    }
+
+    /// Number of registered points.
+    ///
+    /// # Notes
+    /// `len()` counts points, not total DOFs; the total DOF count is
+    /// [`total_len`](Self::total_len).
+    ///
+    /// # Complexity
+    /// **O(1)**.
+    ///
+    /// # Determinism
+    /// No side effects.
+    #[inline]
+    pub fn len(&self) -> usize {
+        debug_assert_eq!(self.order.len(), self.map.len());
+        self.order.len()
+    }
+
+    /// Whether the atlas has zero points.
+    ///
+    /// # Complexity
+    /// **O(1)**.
+    ///
+    /// # Determinism
+    /// No side effects.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        debug_assert_eq!(self.order.is_empty(), self.map.is_empty());
+        self.order.is_empty()
+    }
+
     /// Total length of all registered slices.
     ///
     /// This is equal to the sum of lengths of each point’s slice,

--- a/tests/data/atlas_contains_len.rs
+++ b/tests/data/atlas_contains_len.rs
@@ -1,0 +1,17 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::topology::point::PointId;
+
+#[test]
+fn atlas_contains_and_len_work() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = Atlas::default();
+    let p1 = PointId::new(1)?;
+    let p2 = PointId::new(2)?;
+    assert_eq!(a.len(), 0);
+    assert!(!a.contains(p1));
+    a.try_insert(p1, 2)?;
+    a.try_insert(p2, 1)?;
+    assert!(a.contains(p1) && a.contains(p2));
+    assert_eq!(a.len(), 2);
+    assert!(!a.is_empty());
+    Ok(())
+}

--- a/tests/data/section_with_atlas_mut.rs
+++ b/tests/data/section_with_atlas_mut.rs
@@ -1,0 +1,20 @@
+use mesh_sieve::data::{atlas::Atlas, section::Section};
+use mesh_sieve::topology::point::PointId;
+
+#[test]
+fn section_with_atlas_mut_rebuilds_data() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = Atlas::default();
+    let p = PointId::new(10)?;
+    a.try_insert(p, 2)?;
+    let mut s = Section::<i32>::new(a);
+    s.try_set(p, &[7, 8])?;
+
+    // Add a new point and ensure it's defaulted
+    s.with_atlas_mut(|atlas| {
+        atlas.try_insert(PointId::new(11).unwrap(), 3).unwrap();
+    })?;
+    assert_eq!(s.atlas().total_len(), 5);
+    assert_eq!(s.try_restrict(p)?, &[7, 8]);
+    assert_eq!(s.try_restrict(PointId::new(11)?)?, &[0, 0, 0]);
+    Ok(())
+}

--- a/tests/data/sieved_array_iter_in_order.rs
+++ b/tests/data/sieved_array_iter_in_order.rs
@@ -1,0 +1,21 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::refine::sieved_array::SievedArray;
+use mesh_sieve::topology::point::PointId;
+
+#[test]
+fn iter_in_order_matches_slices() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = Atlas::default();
+    let p1 = PointId::new(1)?;
+    a.try_insert(p1, 2)?;
+    let p2 = PointId::new(2)?;
+    a.try_insert(p2, 3)?;
+    let mut arr = SievedArray::<PointId, i32>::new(a);
+    arr.try_set(p1, &[1, 2])?;
+    arr.try_set(p2, &[3, 4, 5])?;
+
+    let got: Vec<_> = arr.iter_in_order().collect();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0], (p1, &[1, 2][..]));
+    assert_eq!(got[1], (p2, &[3, 4, 5][..]));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `contains`, `len`, and `is_empty` helpers to `Atlas`
- expose read-only `atlas` view and safe `with_atlas_mut` rebuild in `Section`
- provide `try_iter_in_order`/`iter_in_order` for `SievedArray`
- add unit tests for new APIs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b9372ba47883299585766c1370956e