### PR TITLE
Add fallible map helpers and customizable bundle assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,11 @@
 - Added optional invariant checking for `Atlas` and `Section` via the
   `DebugInvariants` trait. Enable the `check-invariants` feature to run these
   validations in release builds.
+- Introduced `FallibleMap` and `try_restrict_*` helpers for error-aware data
+  access. Legacy `restrict_*` helpers remain but now document their panicking
+  behavior.
+- Added `Reducer` and `Bundle::assemble_with` to customize how cap slices
+  are merged into base slices. `Bundle::assemble` now performs element-wise
+  averaging via `AverageReducer`.
+- Renamed `data::refine::delta::Delta` to `SliceDelta`; `Delta` remains as a
+  deprecated alias.

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -1,0 +1,17 @@
+## Fallible data access
+
+- Old: `restrict_closure(&sieve, &map, seeds)` (panics on missing points).
+- New (preferred): `try_restrict_closure(&sieve, &map, seeds)` returning `Result<_, MeshSieveError>`.
+- Implement `FallibleMap<V>` for your map types to enable the `try_*` APIs.
+
+## Bundle assembly
+
+- Old: `bundle.assemble(bases)` (previously under-specified).
+- New: `bundle.assemble(bases)` now **averages element-wise**.
+- Prefer: `bundle.assemble_with(bases, &AverageReducer)` or a custom reducer implementing `Reducer<V>`.
+
+## Delta rename
+
+- Old: `data::refine::delta::Delta`.
+- New: `data::refine::delta::SliceDelta` (old `Delta` is a deprecated alias).
+- Behavior unchanged.

--- a/src/data/refine/delta.rs
+++ b/src/data/refine/delta.rs
@@ -3,9 +3,13 @@
 //! This module defines the [`SliceDelta`] trait for slice-level transformations and
 //! provides an implementation for [`Orientation`] to permute or reverse slices.
 //!
+//! # Naming
+//! [`SliceDelta`] is the preferred name. A deprecated [`Delta`] alias is provided
+//! for backward compatibility and will be removed in a future release.
+//!
 //! # Choosing the right `Delta`
-//! - [`crate::data::refine::delta::SliceDelta`] (re-exported as [`Delta`]):
-//!   transforms one *slice* into another (e.g. reverse for orientation).
+//! - [`crate::data::refine::delta::SliceDelta`]: transforms one *slice* into another
+//!   (e.g. reverse for orientation).
 //! - [`crate::overlap::delta::Delta`]: describes *communication/merge semantics*
 //!   for overlap/exchange between parts.
 //!
@@ -29,6 +33,7 @@ pub trait SliceDelta<V: Clone>: Sync {
 }
 
 /// Backward-compatible re-export: external code can still name this trait `Delta`.
+#[deprecated(note = "Renamed to SliceDelta; Delta will be removed in a future major release")]
 pub use SliceDelta as Delta;
 
 impl<V: Clone> SliceDelta<V> for Orientation {

--- a/src/data/refine/helpers.rs
+++ b/src/data/refine/helpers.rs
@@ -13,6 +13,10 @@ use crate::topology::sieve::Sieve;
 /// Restrict a map along the closure of the given seed points.
 ///
 /// Returns an iterator over `(PointId, &[V])` for all points in the closure.
+///
+/// # Migration
+/// Prefer [`try_restrict_closure`] with [`FallibleMap`] for robust error handling;
+/// this helper panics if a point is missing.
 pub fn restrict_closure<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -27,6 +31,10 @@ where
 /// Restrict a map along the star of the given seed points.
 ///
 /// Returns an iterator over `(PointId, &[V])` for all points in the star.
+///
+/// # Migration
+/// Prefer [`try_restrict_star`] with [`FallibleMap`] for robust error handling;
+/// this helper panics if a point is missing.
 pub fn restrict_star<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -39,6 +47,10 @@ where
 }
 
 /// Restrict a map along the closure of the given seed points, collecting results into a vector.
+///
+/// # Migration
+/// Prefer [`try_restrict_closure_vec`] with [`FallibleMap`] for robust error handling;
+/// this helper panics if a point is missing.
 pub fn restrict_closure_vec<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -51,6 +63,10 @@ where
 }
 
 /// Restrict a map along the star of the given seed points, collecting results into a vector.
+///
+/// # Migration
+/// Prefer [`try_restrict_star_vec`] with [`FallibleMap`] for robust error handling;
+/// this helper panics if a point is missing.
 pub fn restrict_star_vec<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -63,6 +79,12 @@ where
 }
 
 /// Restrict a map along the closure of the given seed points, propagating errors.
+///
+/// # Errors
+/// Returns [`MeshSieveError`] if any point is missing in the underlying map.
+///
+/// # Complexity
+/// **O(n)** in the size of the closure.
 pub fn try_restrict_closure<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -77,6 +99,12 @@ where
 }
 
 /// Restrict a map along the star of the given seed points, propagating errors.
+///
+/// # Errors
+/// Returns [`MeshSieveError`] if any point is missing in the underlying map.
+///
+/// # Complexity
+/// **O(n)** in the size of the star.
 pub fn try_restrict_star<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -91,6 +119,9 @@ where
 }
 
 /// Collects the closure restriction into a vector, short-circuiting on error.
+///
+/// # Errors
+/// Propagates the first error encountered while traversing the closure.
 pub fn try_restrict_closure_vec<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,
@@ -103,6 +134,9 @@ where
 }
 
 /// Collects the star restriction into a vector, short-circuiting on error.
+///
+/// # Errors
+/// Propagates the first error encountered while traversing the star.
 pub fn try_restrict_star_vec<'s, M, V: 's>(
     sieve: &'s impl Sieve<Point = PointId>,
     map: &'s M,

--- a/src/data/refine/mod.rs
+++ b/src/data/refine/mod.rs
@@ -8,7 +8,7 @@ pub mod helpers;
 pub mod sieved_array;
 
 // re-export the main pieces at the top level:
-pub use delta::Delta;
+pub use delta::{SliceDelta, Delta};
 pub use helpers::{
     restrict_closure, restrict_closure_vec, restrict_star, restrict_star_vec, try_restrict_closure,
     try_restrict_closure_vec, try_restrict_star, try_restrict_star_vec,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,16 @@
 //!
 //! For a complete API reference and usage guide, see [API_Guide.md](API_Guide.md).
 //!
+//! ## Migration highlights
+//! See [docs/MIGRATING.md](docs/MIGRATING.md) for more details on recent API
+//! changes:
+//! - Fallible map access via `try_restrict_*` helpers and the [`FallibleMap`]
+//!   trait.
+//! - [`Bundle::assemble`] now averages element-wise; use
+//!   [`Bundle::assemble_with`] with a [`Reducer`](crate::data::bundle::Reducer)
+//!   for custom behavior.
+//! - `data::refine::delta::SliceDelta` replaces the deprecated `Delta` alias.
+//!
 //! ## Shared payloads
 //! When payloads are large or shared across many arrows, instantiate a sieve with `Payload = Arc<T>`.
 //! Traversal and algorithms will clone the `Arc` handle (cheap) without copying `T`.

--- a/tests/data/bundle_assemble_with_sum.rs
+++ b/tests/data/bundle_assemble_with_sum.rs
@@ -1,0 +1,66 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::bundle::{Bundle, Reducer};
+use mesh_sieve::data::section::Section;
+use mesh_sieve::overlap::delta::CopyDelta;
+use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::stack::InMemoryStack;
+use mesh_sieve::mesh_error::MeshSieveError;
+
+#[derive(Copy, Clone, Default)]
+struct SumReducer;
+
+impl<V> Reducer<V> for SumReducer
+where
+    V: Clone + Default + core::ops::AddAssign,
+{
+    fn reduce_into(&self, base: &mut [V], caps: &[&[V]]) -> Result<(), MeshSieveError> {
+        if caps.is_empty() {
+            return Ok(());
+        }
+        let k = base.len();
+        for c in caps {
+            if c.len() != k {
+                return Err(MeshSieveError::SliceLengthMismatch {
+                    point: unsafe { PointId::new_unchecked(1) },
+                    expected: k,
+                    found: c.len(),
+                });
+            }
+        }
+        for v in base.iter_mut() {
+            *v = V::default();
+        }
+        for c in caps {
+            for (dst, src) in base.iter_mut().zip(c.iter()) {
+                *dst += src.clone();
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn bundle_assemble_with_sum() -> Result<(), Box<dyn std::error::Error>> {
+    let b = PointId::new(30)?;
+    let c1 = PointId::new(31)?;
+    let c2 = PointId::new(32)?;
+    let mut atlas = Atlas::default();
+    atlas.try_insert(b, 3)?;
+    atlas.try_insert(c1, 3)?;
+    atlas.try_insert(c2, 3)?;
+    let mut section = Section::<i32>::new(atlas.clone());
+
+    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
+    stack.add_arrow(b, c1, Orientation::Forward)?;
+    stack.add_arrow(b, c2, Orientation::Forward)?;
+    let mut bundle = Bundle { stack, section, delta: CopyDelta };
+
+    bundle.section.try_set(c1, &[2, 4, 6])?;
+    bundle.section.try_set(c2, &[6, 8, 10])?;
+
+    bundle.assemble_with([b], &SumReducer::default())?;
+
+    assert_eq!(bundle.section.try_restrict(b)?, &[8, 12, 16]);
+    Ok(())
+}

--- a/tests/helpers_try_restrict_ok_err.rs
+++ b/tests/helpers_try_restrict_ok_err.rs
@@ -1,0 +1,27 @@
+use mesh_sieve::data::refine::helpers::{restrict_closure_vec, try_restrict_closure_vec};
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::mesh_error::MeshSieveError;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::in_memory::InMemorySieve;
+
+fn v(i: u64) -> PointId { PointId::new(i).unwrap() }
+
+#[test]
+#[should_panic]
+fn restrict_closure_panics_on_missing_point() {
+    let sieve = InMemorySieve::<PointId, ()>::default();
+    let atlas = Atlas::default();
+    let section = Section::<i32>::new(atlas);
+    // legacy helper panics when point is missing
+    let _ = restrict_closure_vec(&sieve, &section, [v(1)]);
+}
+
+#[test]
+fn try_restrict_closure_err_on_missing_point() {
+    let sieve = InMemorySieve::<PointId, ()>::default();
+    let atlas = Atlas::default();
+    let section = Section::<i32>::new(atlas);
+    let err = try_restrict_closure_vec(&sieve, &section, [v(1)]).unwrap_err();
+    assert!(matches!(err, MeshSieveError::PointNotInAtlas(pid) if pid == v(1)));
+}


### PR DESCRIPTION
## Summary
- add Reducer trait with AverageReducer and assemble_with for custom bundle reduction
- document fallible restrict helpers and add MIGRATING guide
- deprecate data::refine::delta::Delta in favor of SliceDelta

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68b9dd389bb083298d72c9e65013ae13