### PR TITLE
Refine bundle assembly to avoid cap copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Introduced `FallibleMap` and `try_restrict_*` helpers for error-aware data
   access. Legacy `restrict_*` helpers remain but now document their panicking
   behavior.
-- Added `Reducer` and `Bundle::assemble_with` to customize how cap slices
+- Added `SliceReducer` and `Bundle::assemble_with` to customize how cap slices
   are merged into base slices. `Bundle::assemble` now performs element-wise
   averaging via `AverageReducer`.
 - Renamed `data::refine::delta::Delta` to `SliceDelta`; `Delta` remains as a

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -8,7 +8,7 @@
 
 - Old: `bundle.assemble(bases)` (previously under-specified).
 - New: `bundle.assemble(bases)` now **averages element-wise**.
-- Prefer: `bundle.assemble_with(bases, &AverageReducer)` or a custom reducer implementing `Reducer<V>`.
+- Prefer: `bundle.assemble_with(bases, &AverageReducer)` or a custom reducer implementing `SliceReducer<V>`.
 
 ## Delta rename
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! - Fallible map access via `try_restrict_*` helpers and the [`FallibleMap`]
 //!   trait.
 //! - [`Bundle::assemble`] now averages element-wise; use
-//!   [`Bundle::assemble_with`] with a [`Reducer`](crate::data::bundle::Reducer)
+//!   [`Bundle::assemble_with`] with a [`SliceReducer`](crate::data::bundle::SliceReducer)
 //!   for custom behavior.
 //! - `data::refine::delta::SliceDelta` replaces the deprecated `Delta` alias.
 //!


### PR DESCRIPTION
## Summary
- introduce `SliceReducer` trait for slice-wise reductions
- implement allocation-free `Bundle::assemble_with` using `SliceReducer`
- update docs and tests for the new reducer API

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1b8839483298dcb304d0c3f6dc6