### PR TITLE
Decouple overlap structure from remote mapping

### DIFF
--- a/API_Guide.md
+++ b/API_Guide.md
@@ -281,12 +281,12 @@ let got = recv.wait().unwrap();
 ### 9.2. Overlap
 
 An `Overlap` is a `Sieve<PointId, Remote>` describing sharing:
-`local_point ──(Remote{rank, remote_point})──▶ partition_point(rank)`
+`local_point ──(Remote{rank, remote_point: Option<PointId>})──▶ partition_point(rank)`
 
 ```rust
 use mesh_sieve::overlap::overlap::{Overlap, Remote};
 let mut ovlp = Overlap::default();
-ovlp.add_arrow(local_p, remote_partition_pt, Remote { rank: nbr, remote_point: remote_p });
+ovlp.add_arrow(local_p, remote_partition_pt, Remote { rank: nbr, remote_point: Some(remote_p) });
 ```
 
 ### 9.3. Completion Algorithms
@@ -295,7 +295,7 @@ ovlp.add_arrow(local_p, remote_partition_pt, Remote { rank: nbr, remote_point: r
 
   * `complete_sieve(&mut overlap, &overlap_clone, &comm, my_rank)`
   * `complete_sieve_until_converged(..)`
-  * Preserves `Remote { rank, remote_point }` exactly.
+  * Preserves `Remote { rank, remote_point: Some(id) }` exactly.
 
 * **Section completion (data):**
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Other examples:
 
 ## Correctness Improvements
 
-* Preserve the **remote mesh point id** in overlap completion wires; reconstruct `Remote { rank, remote_point }` exactly on receive.
+* Preserve the **remote mesh point id** in overlap completion wires; reconstruct `Remote { rank, remote_point: Some(id) }` exactly on receive.
 * Tighten `Overlap::add_link` to respect closure-of-support and avoid duplicate links efficiently.
 * Enforce **minimality** in `meet`/`join` (return only minimal shared faces / minimal cofaces).
 

--- a/examples/mpi_complete_multiple_neighbors.rs
+++ b/examples/mpi_complete_multiple_neighbors.rs
@@ -2,21 +2,21 @@
 // cargo mpirun -n 3 --features mpi-support --example mpi_complete_multiple_neighbors
 // Version 1.2.0: passing
 //! This example tests the `complete_section` function with multiple neighbors.
- //! It ensures that a Section can be completed correctly when multiple ranks have neighbors
- //! that share the same point, and that the Section is correctly completed
- //! with values from all ranks.
- //! 
- #[cfg(feature = "mpi-support")]
+//! It ensures that a Section can be completed correctly when multiple ranks have neighbors
+//! that share the same point, and that the Section is correctly completed
+//! with values from all ranks.
+//!
+#[cfg(feature = "mpi-support")]
 pub fn main() {
     use mesh_sieve::algs::communicator::MpiComm;
-    use mpi::topology::Communicator;
-    use mesh_sieve::topology::point::PointId;
-    use mesh_sieve::overlap::overlap::{Overlap, Remote};
+    use mesh_sieve::algs::completion::complete_section;
     use mesh_sieve::data::atlas::Atlas;
     use mesh_sieve::data::section::Section;
     use mesh_sieve::overlap::delta::CopyDelta;
-    use mesh_sieve::algs::completion::complete_section;
+    use mesh_sieve::overlap::overlap::{Overlap, Remote};
+    use mesh_sieve::topology::point::PointId;
     use mesh_sieve::topology::sieve::sieve_trait::Sieve;
+    use mpi::topology::Communicator;
     let comm = MpiComm::default();
     let world = &comm.world;
     let size = world.size() as usize;
@@ -42,7 +42,7 @@ pub fn main() {
                 PointId::new(2).unwrap(), // partition_point(1)
                 Remote {
                     rank: 1,
-                    remote_point: PointId::new(101).unwrap(),
+                    remote_point: Some(PointId::new(101).unwrap()),
                 },
             );
             Sieve::add_arrow(
@@ -51,33 +51,33 @@ pub fn main() {
                 PointId::new(3).unwrap(), // partition_point(2)
                 Remote {
                     rank: 2,
-                    remote_point: PointId::new(201).unwrap(),
+                    remote_point: Some(PointId::new(201).unwrap()),
                 },
             );
         }
         1 => {
             atlas.try_insert(PointId::new(101).unwrap(), 1).unwrap(); // local
-            atlas.try_insert(PointId::new(1).unwrap(), 1).unwrap();   // remote (from rank 0)
+            atlas.try_insert(PointId::new(1).unwrap(), 1).unwrap(); // remote (from rank 0)
             Sieve::add_arrow(
                 &mut ovlp,
                 PointId::new(101).unwrap(),
                 PointId::new(1).unwrap(), // partition_point(0)
                 Remote {
                     rank: 0,
-                    remote_point: PointId::new(1).unwrap(),
+                    remote_point: Some(PointId::new(1).unwrap()),
                 },
             );
         }
         2 => {
             atlas.try_insert(PointId::new(201).unwrap(), 1).unwrap(); // local
-            atlas.try_insert(PointId::new(2).unwrap(), 1).unwrap();   // remote (from rank 0)
+            atlas.try_insert(PointId::new(2).unwrap(), 1).unwrap(); // remote (from rank 0)
             Sieve::add_arrow(
                 &mut ovlp,
                 PointId::new(201).unwrap(),
                 PointId::new(1).unwrap(), // partition_point(0)
                 Remote {
                     rank: 0,
-                    remote_point: PointId::new(2).unwrap(),
+                    remote_point: Some(PointId::new(2).unwrap()),
                 },
             );
         }
@@ -86,27 +86,39 @@ pub fn main() {
     // Now construct Section after all atlas.insert
     let mut sec = Section::<u32>::new(atlas);
     if rank == 0 {
-        sec.try_set(PointId::new(1).unwrap(), &[1]).expect("Failed to set value for PointId 1");
-        sec.try_set(PointId::new(2).unwrap(), &[2]).expect("Failed to set value for PointId 2");
+        sec.try_set(PointId::new(1).unwrap(), &[1])
+            .expect("Failed to set value for PointId 1");
+        sec.try_set(PointId::new(2).unwrap(), &[2])
+            .expect("Failed to set value for PointId 2");
     }
     let delta = CopyDelta;
     let _ = complete_section(&mut sec, &mut ovlp, &comm, &delta, rank, size);
     match rank {
         0 => {
-            assert_eq!(sec.try_restrict(PointId::new(1).unwrap()).expect("Point 1 missing")[0], 1);
-            assert_eq!(sec.try_restrict(PointId::new(2).unwrap()).expect("Point 2 missing")[0], 2);
+            assert_eq!(
+                sec.try_restrict(PointId::new(1).unwrap())
+                    .expect("Point 1 missing")[0],
+                1
+            );
+            assert_eq!(
+                sec.try_restrict(PointId::new(2).unwrap())
+                    .expect("Point 2 missing")[0],
+                2
+            );
             println!("[rank 0] complete_section_multiple_neighbors passed");
         }
         1 => {
             assert_eq!(
-                sec.try_restrict(PointId::new(101).unwrap()).expect("Point 101 missing")[0],
+                sec.try_restrict(PointId::new(101).unwrap())
+                    .expect("Point 101 missing")[0],
                 1
             );
             println!("[rank 1] complete_section_multiple_neighbors passed");
         }
         2 => {
             assert_eq!(
-                sec.try_restrict(PointId::new(201).unwrap()).expect("Point 201 missing")[0],
+                sec.try_restrict(PointId::new(201).unwrap())
+                    .expect("Point 201 missing")[0],
                 2
             );
             println!("[rank 2] complete_section_multiple_neighbors passed");

--- a/src/mesh_error.rs
+++ b/src/mesh_error.rs
@@ -133,6 +133,22 @@ pub enum MeshSieveError {
         expected: usize,
         got: usize,
     },
+
+    #[error("Overlap link not found for (local={0}, rank={1})")]
+    OverlapLinkMissing(crate::topology::point::PointId, usize),
+
+    #[error("Overlap invariant: payload.rank ({found}) != rank node ({expected})")]
+    OverlapRankMismatch { expected: usize, found: usize },
+
+    #[error(
+        "Overlap resolution conflict for (local={local}, rank={rank}): existing={existing:?}, new={new:?}"
+    )]
+    OverlapResolutionConflict {
+        local: crate::topology::point::PointId,
+        rank: usize,
+        existing: Option<crate::topology::point::PointId>,
+        new: crate::topology::point::PointId,
+    },
 }
 
 impl PartialEq for MeshSieveError {
@@ -251,6 +267,31 @@ impl PartialEq for MeshSieveError {
                 },
             ) => n1 == n2 && e1 == e2 && g1 == g2,
             (Communication(a), Communication(b)) => a == b,
+            (OverlapLinkMissing(a1, b1), OverlapLinkMissing(a2, b2)) => a1 == a2 && b1 == b2,
+            (
+                OverlapRankMismatch {
+                    expected: e1,
+                    found: f1,
+                },
+                OverlapRankMismatch {
+                    expected: e2,
+                    found: f2,
+                },
+            ) => e1 == e2 && f1 == f2,
+            (
+                OverlapResolutionConflict {
+                    local: l1,
+                    rank: r1,
+                    existing: ex1,
+                    new: n1,
+                },
+                OverlapResolutionConflict {
+                    local: l2,
+                    rank: r2,
+                    existing: ex2,
+                    new: n2,
+                },
+            ) => l1 == l2 && r1 == r2 && ex1 == ex2 && n1 == n2,
             _ => false,
         }
     }

--- a/src/overlap/overlap.rs
+++ b/src/overlap/overlap.rs
@@ -12,6 +12,15 @@
 //! invariants for all mutation routes (`add_arrow`, `set_cone`, etc.).
 //! This design avoids ID collisions, keeps algorithms branch-light, and makes
 //! later phases (closure completion, remote resolution) straightforward.
+//!
+//! ## Typical lifecycle
+//! 1. Seed structure: for each shared local mesh point `p`, call
+//!    [`Overlap::add_link_structural`].
+//! 2. Complete structure: call [`ensure_closure_of_support`] with the mesh.
+//! 3. Discover mapping via neighbor exchange (e.g., global IDs).
+//! 4. Resolve: call [`Overlap::resolve_remote_point`] (or the batch variant)
+//!    for each `(local, neighbor_rank, remote)` triple.
+//! 5. Assert [`Overlap::is_fully_resolved`] before constructing on-wire buffers.
 
 use crate::mesh_error::MeshSieveError;
 use crate::topology::cache::InvalidateCache;
@@ -20,16 +29,7 @@ use crate::topology::sieve::{InMemorySieve, Sieve};
 
 /// Overlap vertex identifier: either a local mesh point, or a partition node.
 #[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    Ord,
-    PartialOrd,
-    Debug,
-    serde::Serialize,
-    serde::Deserialize,
+    Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug, serde::Serialize, serde::Deserialize,
 )]
 pub enum OvlId {
     /// Real mesh entity on this rank
@@ -52,14 +52,14 @@ impl OvlId {
     pub fn expect_local(self) -> PointId {
         match self {
             OvlId::Local(p) => p,
-            _ => panic!("expected Local(_)")
+            _ => panic!("expected Local(_)"),
         }
     }
     #[inline]
     pub fn expect_part(self) -> usize {
         match self {
             OvlId::Part(r) => r,
-            _ => panic!("expected Part(_)")
+            _ => panic!("expected Part(_)"),
         }
     }
 }
@@ -73,12 +73,14 @@ pub fn part(r: usize) -> OvlId {
     OvlId::Part(r)
 }
 
-/// Remote: (rank, remote_point) is exactly SF leaf→root as in PETSc SF.
+/// Remote link: `rank` identifies the neighbor; `remote_point` is filled once
+/// the mapping is known.  This mirrors PETSc’s SF: build structure first, then
+/// resolve remote IDs after an exchange.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Remote {
     pub rank: usize,
-    pub remote_point: PointId,
+    pub remote_point: Option<PointId>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -104,11 +106,99 @@ impl Overlap {
         part(rank)
     }
 
-    /// Add a typed link: Local(p) -> Part(r) with payload {rank:r, remote_point}.
+    /// Add a typed link: `Local(p) -> Part(r)` with known `remote` ID.
     ///
-    /// This is the primary constructor for edges and enforces invariants.
+    /// This is the primary constructor for edges when the remote mapping is
+    /// already known.  For structure-only insertion, use
+    /// [`add_link_structural`].
     pub fn add_link(&mut self, p: PointId, r: usize, remote: PointId) {
-        self.add_arrow(local(p), part(r), Remote { rank: r, remote_point: remote });
+        self.add_arrow(
+            local(p),
+            part(r),
+            Remote {
+                rank: r,
+                remote_point: Some(remote),
+            },
+        );
+    }
+
+    /// Insert `Local(p) -> Part(r)` if missing; leaves `remote_point = None`.
+    pub fn add_link_structural(&mut self, p: PointId, r: usize) {
+        let src = local(p);
+        let dst = part(r);
+        if self.inner.cone(src).any(|(q, _)| q == dst) {
+            return;
+        }
+        self.inner.reserve_cone(src, 1);
+        self.inner.reserve_support(dst, 1);
+        self.add_arrow(
+            src,
+            dst,
+            Remote {
+                rank: r,
+                remote_point: None,
+            },
+        );
+        // add_arrow already enforces Local->Part and rank equality
+    }
+
+    /// Resolve the remote ID for `(Local(local) -> Part(rank))`.
+    ///
+    /// Idempotent: resolving to the same ID twice is a no-op.  Conflicting
+    /// resolutions return an error.
+    pub fn resolve_remote_point(
+        &mut self,
+        local_pt: PointId,
+        rank: usize,
+        remote: PointId,
+    ) -> Result<(), MeshSieveError> {
+        use MeshSieveError::*;
+        let src = local(local_pt);
+        let dst = part(rank);
+
+        if let Some(vec) = self.inner.adjacency_out.get_mut(&src) {
+            if let Some((_, rem)) = vec.iter_mut().find(|(d, _)| *d == dst) {
+                if rem.rank != rank {
+                    return Err(OverlapRankMismatch {
+                        expected: rank,
+                        found: rem.rank,
+                    });
+                }
+                match rem.remote_point {
+                    None => {
+                        rem.remote_point = Some(remote);
+                        if let Some(vec_in) = self.inner.adjacency_in.get_mut(&dst) {
+                            if let Some((_, rem_in)) = vec_in.iter_mut().find(|(s, _)| *s == src) {
+                                rem_in.remote_point = Some(remote);
+                            }
+                        }
+                        self.invalidate_cache();
+                        return Ok(());
+                    }
+                    Some(existing) if existing == remote => return Ok(()),
+                    Some(existing) => {
+                        return Err(OverlapResolutionConflict {
+                            local: local_pt,
+                            rank,
+                            existing: Some(existing),
+                            new: remote,
+                        });
+                    }
+                }
+            }
+        }
+        Err(OverlapLinkMissing(local_pt, rank))
+    }
+
+    /// Resolve many `(local, rank, remote)` triples; stops at first error.
+    pub fn resolve_remote_points<I>(&mut self, triples: I) -> Result<(), MeshSieveError>
+    where
+        I: IntoIterator<Item = (PointId, usize, PointId)>,
+    {
+        for (p, r, rp) in triples {
+            self.resolve_remote_point(p, r, rp)?;
+        }
+        Ok(())
     }
 
     /// Debug/feature-gated invariant checker.
@@ -117,19 +207,26 @@ impl Overlap {
         for src in self.inner.base_points() {
             if !matches!(src, OvlId::Local(_)) {
                 return Err(E::MeshError(Box::new(E::UnsupportedStackOperation(
-                    "Overlap invariant: base_points must be Local(_)"))) );
+                    "Overlap invariant: base_points must be Local(_)",
+                ))));
             }
             for (dst, rem) in self.inner.cone(src) {
                 match (src, dst) {
                     (OvlId::Local(_), OvlId::Part(r)) => {
                         if rem.rank != r {
-                            return Err(E::MeshError(Box::new(E::UnsupportedStackOperation(
-                                "Overlap invariant: payload.rank != Part(r)"))));
+                            return Err(MeshSieveError::OverlapRankMismatch {
+                                expected: r,
+                                found: rem.rank,
+                            });
+                        }
+                        if let Some(rp) = rem.remote_point {
+                            let _ = rp; // hook for external validators
                         }
                     }
                     _ => {
                         return Err(E::MeshError(Box::new(E::UnsupportedStackOperation(
-                            "Overlap invariant: only Local->Part edges allowed"))));
+                            "Overlap invariant: only Local->Part edges allowed",
+                        ))));
                     }
                 }
             }
@@ -137,7 +234,8 @@ impl Overlap {
         for q in self.inner.cap_points() {
             if !matches!(q, OvlId::Part(_)) {
                 return Err(E::MeshError(Box::new(E::UnsupportedStackOperation(
-                    "Overlap invariant: cap_points must be Part(_)"))));
+                    "Overlap invariant: cap_points must be Part(_)",
+                ))));
             }
         }
         Ok(())
@@ -156,12 +254,46 @@ impl Overlap {
         ranks.into_iter()
     }
 
-    /// Typed links to a neighbor rank (local -> remote_point).
-    pub fn links_to(&self, nbr: usize) -> impl Iterator<Item = (PointId, PointId)> + '_ {
-        self.support(part(nbr)).filter_map(move |(src, rem)| match src {
-            OvlId::Local(p) if rem.rank == nbr => Some((p, rem.remote_point)),
-            _ => None,
-        })
+    /// Pairs to neighbor `r` (`local`, `Option<remote>`). Includes unresolved links.
+    pub fn links_to_maybe(
+        &self,
+        r: usize,
+    ) -> impl Iterator<Item = (PointId, Option<PointId>)> + '_ {
+        self.support(part(r))
+            .filter_map(move |(src, rem)| match src {
+                OvlId::Local(p) if rem.rank == r => Some((p, rem.remote_point)),
+                _ => None,
+            })
+    }
+
+    /// Only resolved links (local, remote).
+    pub fn links_to_resolved(&self, r: usize) -> impl Iterator<Item = (PointId, PointId)> + '_ {
+        self.links_to_maybe(r)
+            .filter_map(|(p, opt)| opt.map(|rp| (p, rp)))
+    }
+
+    /// Backward-compatible helper returning only resolved links.
+    pub fn links_to(&self, r: usize) -> impl Iterator<Item = (PointId, PointId)> + '_ {
+        self.links_to_resolved(r)
+    }
+
+    /// Count edges whose remote_point is still unresolved.
+    pub fn unresolved_count(&self) -> usize {
+        self.cap_points()
+            .filter_map(|q| match q {
+                OvlId::Part(r) => Some(r),
+                _ => None,
+            })
+            .map(move |r| self.support(part(r)))
+            .flatten()
+            .filter(|(_, rem)| rem.remote_point.is_none())
+            .count()
+    }
+
+    /// Returns true if all links have resolved remote IDs.
+    #[inline]
+    pub fn is_fully_resolved(&self) -> bool {
+        self.unresolved_count() == 0
     }
 }
 
@@ -176,10 +308,12 @@ impl Sieve for Overlap {
     type Point = OvlId;
     type Payload = Remote;
 
-    type ConeIter<'a> = <InMemorySieve<OvlId, Remote> as Sieve>::ConeIter<'a>
+    type ConeIter<'a>
+        = <InMemorySieve<OvlId, Remote> as Sieve>::ConeIter<'a>
     where
         Self: 'a;
-    type SupportIter<'a> = <InMemorySieve<OvlId, Remote> as Sieve>::SupportIter<'a>
+    type SupportIter<'a>
+        = <InMemorySieve<OvlId, Remote> as Sieve>::SupportIter<'a>
     where
         Self: 'a;
 
@@ -231,9 +365,47 @@ impl Sieve for Overlap {
     // default impls of set_cone/add_support/etc. will call our add_arrow
 }
 
+/// Ensure closure-of-support: for any `Local(p) -> Part(r)` edge already present,
+/// also link every `q` in `mesh.closure({p})` to `Part(r)`. New links are
+/// structural only (`remote_point = None`).
+pub fn ensure_closure_of_support<M: Sieve<Point = PointId>>(ov: &mut Overlap, mesh: &M) {
+    use std::collections::HashSet;
+
+    // Gather seed pairs from existing edges
+    let seeds: Vec<(PointId, usize)> = ov
+        .base_points()
+        .filter_map(|id| match id {
+            OvlId::Local(p) => Some(p),
+            _ => None,
+        })
+        .flat_map(|p| {
+            ov.cone(local(p)).filter_map(move |(dst, rem)| match dst {
+                OvlId::Part(r) => Some((p, r, rem.rank)),
+                _ => None,
+            })
+        })
+        .map(|(p, r, rr)| {
+            debug_assert_eq!(r, rr);
+            (p, r)
+        })
+        .collect();
+
+    let mut seen: HashSet<(PointId, usize)> = seeds.iter().copied().collect();
+    for (p, r) in seeds {
+        for q in mesh.closure(std::iter::once(p)) {
+            if seen.insert((q, r)) {
+                ov.add_link_structural(q, r);
+            }
+        }
+    }
+    ov.invalidate_cache();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mesh_error::MeshSieveError;
+    use crate::topology::sieve::InMemorySieve as Mesh;
 
     #[test]
     fn invariants_hold_for_basic_links() {
@@ -261,9 +433,65 @@ mod tests {
         assert_eq!(ranks, [1usize, 2usize].into_iter().collect());
 
         let pairs: Vec<_> = ov.links_to(1).collect();
-        assert!(
-            pairs.contains(&(PointId::new(1).unwrap(), PointId::new(101).unwrap()))
-        );
+        assert!(pairs.contains(&(PointId::new(1).unwrap(), PointId::new(101).unwrap())));
+    }
+
+    #[test]
+    fn structural_then_resolve() {
+        let mut ov = Overlap::new();
+        let p = PointId::new(1).unwrap();
+        ov.add_link_structural(p, 1);
+        let v_unresolved: Vec<_> = ov.links_to_maybe(1).collect();
+        assert_eq!(v_unresolved, vec![(p, None)]);
+        assert!(ov.links_to_resolved(1).next().is_none());
+
+        ov.resolve_remote_point(p, 1, PointId::new(10).unwrap())
+            .unwrap();
+        let v_resolved: Vec<_> = ov.links_to_resolved(1).collect();
+        assert_eq!(v_resolved, vec![(p, PointId::new(10).unwrap())]);
+    }
+
+    #[test]
+    fn resolve_idempotent_and_conflict() {
+        let mut ov = Overlap::new();
+        let p = PointId::new(1).unwrap();
+        ov.add_link_structural(p, 1);
+        ov.resolve_remote_point(p, 1, PointId::new(10).unwrap())
+            .unwrap();
+        // Idempotent
+        ov.resolve_remote_point(p, 1, PointId::new(10).unwrap())
+            .unwrap();
+        // Conflict
+        let err = ov
+            .resolve_remote_point(p, 1, PointId::new(11).unwrap())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MeshSieveError::OverlapResolutionConflict { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_missing_link() {
+        let mut ov = Overlap::new();
+        let p = PointId::new(1).unwrap();
+        let err = ov
+            .resolve_remote_point(p, 1, PointId::new(10).unwrap())
+            .unwrap_err();
+        assert!(matches!(err, MeshSieveError::OverlapLinkMissing(_, _)));
+    }
+
+    #[test]
+    fn closure_adds_structural_links() {
+        // mesh: 1 -> 2
+        let mut mesh = Mesh::<PointId, ()>::default();
+        mesh.add_arrow(PointId::new(1).unwrap(), PointId::new(2).unwrap(), ());
+        let mut ov = Overlap::new();
+        ov.add_link_structural(PointId::new(1).unwrap(), 7);
+        ensure_closure_of_support(&mut ov, &mesh);
+        let v: Vec<_> = ov.links_to_maybe(7).collect();
+        assert_eq!(v.len(), 2);
+        assert!(v.contains(&(PointId::new(1).unwrap(), None)));
+        assert!(v.contains(&(PointId::new(2).unwrap(), None)));
     }
 }
-

--- a/tests/mpi_complete.rs
+++ b/tests/mpi_complete.rs
@@ -25,7 +25,7 @@ fn two_rank_tetra_completion() {
         f0,
         Remote {
             rank: 0,
-            remote_point: f0,
+            remote_point: Some(f0),
         },
     );
     sieve0.add_arrow(
@@ -33,7 +33,7 @@ fn two_rank_tetra_completion() {
         f1,
         Remote {
             rank: 0,
-            remote_point: f1,
+            remote_point: Some(f1),
         },
     );
     sieve0.add_arrow(
@@ -41,7 +41,7 @@ fn two_rank_tetra_completion() {
         f2,
         Remote {
             rank: 0,
-            remote_point: f2,
+            remote_point: Some(f2),
         },
     );
     // Rank 1 sieve
@@ -51,7 +51,7 @@ fn two_rank_tetra_completion() {
         f3,
         Remote {
             rank: 1,
-            remote_point: f3,
+            remote_point: Some(f3),
         },
     );
     sieve1.add_arrow(
@@ -59,7 +59,7 @@ fn two_rank_tetra_completion() {
         f4,
         Remote {
             rank: 1,
-            remote_point: f4,
+            remote_point: Some(f4),
         },
     );
     sieve1.add_arrow(
@@ -67,7 +67,7 @@ fn two_rank_tetra_completion() {
         f5,
         Remote {
             rank: 1,
-            remote_point: f5,
+            remote_point: Some(f5),
         },
     );
     // Overlap: shared face mapping
@@ -92,7 +92,7 @@ fn two_rank_tetra_completion() {
             remote,
             Remote {
                 rank: 1,
-                remote_point: remote,
+                remote_point: Some(remote),
             },
         );
         // Add to sieve1: cell1 -> local
@@ -101,7 +101,7 @@ fn two_rank_tetra_completion() {
             local,
             Remote {
                 rank: 0,
-                remote_point: local,
+                remote_point: Some(local),
             },
         );
     }


### PR DESCRIPTION
## Summary
- Allow overlap links to be created structurally without remote IDs
- Add resolution APIs and validation errors for filling remote IDs later
- Provide queries for unresolved links and closure completion that respects structure

## Testing
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_68ba07d1a4848329878e7577d36f0c17