### PR TITLE
Refactor overlap link queries

### DIFF
--- a/src/algs/completion/neighbour_links.rs
+++ b/src/algs/completion/neighbour_links.rs
@@ -56,7 +56,7 @@ where
             if nbr == my_rank {
                 continue;
             }
-            for (local_pt, remote_pt) in ovlp.links_to(nbr) {
+            for (local_pt, remote_pt) in ovlp.links_to_resolved(nbr) {
                 out.entry(nbr).or_default().push((remote_pt, local_pt));
             }
         }

--- a/src/algs/distribute.rs
+++ b/src/algs/distribute.rs
@@ -36,7 +36,7 @@ use crate::algs::communicator::Communicator;
 /// assert_eq!(local.cone(PointId::new(1).unwrap()).count(), 0);
 /// assert_eq!(local.cone(PointId::new(2).unwrap()).count(), 0);
 /// assert_eq!(local.cone(PointId::new(3).unwrap()).count(), 0);
-/// let ghosts: Vec<_> = overlap.links_to(1).collect();
+/// let ghosts: Vec<_> = overlap.links_to_resolved(1).collect();
 /// assert!(ghosts.contains(&(PointId::new(3).unwrap(), PointId::new(3).unwrap())));
 /// ```
 /// # Example (MPI)

--- a/tests/distribute_serial.rs
+++ b/tests/distribute_serial.rs
@@ -17,7 +17,7 @@ fn distribute_mesh_serial() {
     assert_eq!(local.cone(PointId::new(2).unwrap()).count(), 0);
     assert_eq!(local.cone(PointId::new(3).unwrap()).count(), 0);
     // Overlap should contain remote links for ghost points
-    let ghosts: Vec<_> = overlap.links_to(1).collect();
+    let ghosts: Vec<_> = overlap.links_to_resolved(1).collect();
     println!("ghosts for rank 1: {:?}", ghosts);
     // In this partition, point 3 is a ghost for rank 1, so overlap should contain (3, 3)
     assert!(ghosts.contains(&(PointId::new(3).unwrap(), PointId::new(3).unwrap())));


### PR DESCRIPTION
## Summary
- expose `links_to` returning optional remote point and add resolved and sorted variants
- add per-rank unresolved counts and document neighbor/link queries
- update algorithms and tests for new API

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba232d3cb08329b08f6a54ac40362f