### PR TITLE
Add overlap invariants checker

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,14 +70,28 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Build docs
-      run: cargo doc --no-deps
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build docs
+        run: cargo doc --no-deps
+
+  check-invariants:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build with invariant checks
+        run: cargo build --release --verbose --features "check-invariants"
+      - name: Run tests with invariant checks
+        run: cargo test --release --verbose --features "check-invariants"
 
   # Separate job for benchmarks and integration tests
   benchmarks:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ metis-support = ["metis", "metis-sys", "libffi-sys","bindgen","pkg-config"]
 sieve_ref_fast_dag = []
 strict-invariants = []
 check-invariants = []
+check-empty-part = []
 
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- add thorough overlap invariants and error types
- implement clone-free validator with debug gating
- run validator after mutators and add CI job for check-invariants

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba2829e13c8329abd5d110c0b9dbc3