### PR TITLE
Rename overlap delta to ValueDelta and clarify docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@
   averaging via `AverageReducer`.
 - Renamed `data::refine::delta::Delta` to `SliceDelta`; `Delta` remains as a
   deprecated alias.
+- Renamed `overlap::delta::Delta` to `ValueDelta`; `Delta` remains as a
+  deprecated alias.

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -15,3 +15,7 @@
 - Old: `data::refine::delta::Delta`.
 - New: `data::refine::delta::SliceDelta` (old `Delta` is a deprecated alias).
 - Behavior unchanged.
+
+- Old: `overlap::delta::Delta`.
+- New: `overlap::delta::ValueDelta` (old `Delta` is a deprecated alias).
+- Behavior unchanged.

--- a/examples/comprehensive_mesh_workflow.rs
+++ b/examples/comprehensive_mesh_workflow.rs
@@ -32,7 +32,7 @@ fn main() {
     };
     use mesh_sieve::data::refine::sieved_array::SievedArray;
     use mesh_sieve::data::section::Section;
-    use mesh_sieve::overlap::delta::{AddDelta, CopyDelta, Delta, ZeroDelta};
+    use mesh_sieve::overlap::delta::{AddDelta, CopyDelta, ValueDelta, ZeroDelta};
     // use mesh_sieve::overlap::overlap::{Overlap, Remote};
     use mesh_sieve::algs::dual_graph::build_dual;
     use mesh_sieve::prelude::*;
@@ -677,9 +677,9 @@ fn test_error_handling_robustness(rank: usize) {
 
     // 5. Test Delta trait behavior
     let mut val = 42;
-    let part = <ZeroDelta as Delta<i32>>::restrict(&val);
+    let part = <ZeroDelta as ValueDelta<i32>>::restrict(&val);
     assert_eq!(part, 0, "ZeroDelta restrict should return 0");
-    <ZeroDelta as Delta<i32>>::fuse(&mut val, 999);
+    <ZeroDelta as ValueDelta<i32>>::fuse(&mut val, 999);
     assert_eq!(val, 42, "ZeroDelta fuse should not change value");
 
     println!("[rank {}] Error handling robustness test passed", rank);

--- a/src/algs/completion/data_exchange.rs
+++ b/src/algs/completion/data_exchange.rs
@@ -18,7 +18,7 @@ pub fn exchange_data<V, D, C>(
 ) -> Result<(), MeshSieveError>
 where
     V: Clone + Default + Send + 'static,
-    D: crate::overlap::delta::Delta<V> + Send + Sync + 'static,
+    D: crate::overlap::delta::ValueDelta<V> + Send + Sync + 'static,
     D::Part: bytemuck::Pod + Default,
     C: crate::algs::communicator::Communicator + Sync,
 {
@@ -113,7 +113,7 @@ pub fn exchange_data_symmetric<V, D, C>(
 ) -> Result<(), MeshSieveError>
 where
     V: Clone + Default + Send + 'static,
-    D: crate::overlap::delta::Delta<V> + Send + Sync + 'static,
+    D: crate::overlap::delta::ValueDelta<V> + Send + Sync + 'static,
     D::Part: bytemuck::Pod + Default,
     C: crate::algs::communicator::Communicator + Sync,
 {
@@ -221,7 +221,7 @@ mod tests {
 
     // Dummy Delta implementation
     struct DummyDelta;
-    impl crate::overlap::delta::Delta<DummyValue> for DummyDelta {
+    impl crate::overlap::delta::ValueDelta<DummyValue> for DummyDelta {
         type Part = i32;
         fn restrict(v: &DummyValue) -> i32 {
             v.0

--- a/src/algs/completion/section_completion.rs
+++ b/src/algs/completion/section_completion.rs
@@ -13,7 +13,7 @@ use crate::algs::completion::{
     size_exchange::exchange_sizes_symmetric,
 };
 use crate::data::section::Section;
-use crate::overlap::delta::Delta;
+use crate::overlap::delta::ValueDelta;
 use crate::overlap::overlap::Overlap;
 
 pub fn complete_section<V, D, C>(
@@ -26,7 +26,7 @@ pub fn complete_section<V, D, C>(
 ) -> Result<(), MeshSieveError>
 where
     V: Clone + Default + Send + PartialEq + 'static,
-    D: Delta<V> + Send + Sync + 'static,
+    D: ValueDelta<V> + Send + Sync + 'static,
     D::Part: bytemuck::Pod + Default,
     C: Communicator + Sync,
 {

--- a/src/data/bundle.rs
+++ b/src/data/bundle.rs
@@ -94,10 +94,10 @@ where
     }
 }
 
-/// `Bundle<V, D>` packages a mesh‐to‐DOF stack, a data section, and a `Delta`-type.
+/// `Bundle<V, D>` packages a mesh‐to‐DOF stack, a data section, and a `ValueDelta`-type.
 ///
 /// - `V`: underlying data type stored at each DOF (e.g., `f64`, `i32`, …).
-/// - `D`: overlap [`Delta`](crate::overlap::delta::Delta)<V> implementation guiding how
+/// - `D`: overlap [`ValueDelta`](crate::overlap::delta::ValueDelta)<V> implementation guiding how
 ///   values are reduced/merged across parts (defaults to [`CopyDelta`]).
 ///   For per-slice permutation/orientation, see [`crate::data::refine::delta::SliceDelta`].
 ///
@@ -118,7 +118,7 @@ pub struct Bundle<V, D = CopyDelta> {
 impl<V, D> Bundle<V, D>
 where
     V: Clone + Default,
-    D: crate::overlap::delta::Delta<V, Part = V>,
+    D: crate::overlap::delta::ValueDelta<V, Part = V>,
 {
     /// **Refine**: push data *down* the stack (base → cap) using per-arrow orientation.
     ///

--- a/src/data/refine/delta.rs
+++ b/src/data/refine/delta.rs
@@ -10,13 +10,13 @@
 //! # Choosing the right `Delta`
 //! - [`crate::data::refine::delta::SliceDelta`]: transforms one *slice* into another
 //!   (e.g. reverse for orientation).
-//! - [`crate::overlap::delta::Delta`]: describes *communication/merge semantics*
+//! - [`crate::overlap::delta::ValueDelta`]: describes *communication/merge semantics*
 //!   for overlap/exchange between parts.
 //!
 //! ## Disambiguation tip
 //! ```rust
 //! use mesh_sieve::data::refine::delta::SliceDelta;            // slice semantics
-//! use mesh_sieve::overlap::delta::Delta as OverlapDelta;      // communication semantics
+//! use mesh_sieve::overlap::delta::ValueDelta as OverlapDelta; // communication semantics
 //! ```
 
 use crate::mesh_error::MeshSieveError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub mod prelude {
     pub use crate::topology::bounds::{PointLike, PayloadLike};
     pub use crate::data::atlas::Atlas;
     pub use crate::data::section::{Section, Map};
-    pub use crate::overlap::delta::{Delta, CopyDelta, AddDelta};
+    pub use crate::overlap::delta::{ValueDelta, CopyDelta, AddDelta};
     pub use crate::overlap::overlap::Overlap;
     pub use crate::algs::communicator::Communicator;
     #[cfg(feature="mpi-support")]


### PR DESCRIPTION
## Summary
- rename overlap::delta::Delta trait to ValueDelta with deprecated alias
- document distinction from SliceDelta and update code examples
- add String-based ZeroDelta test and refresh migration notes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ba4a69e5a083299caaf902e13de090