### PR TITLE
refactor: add serial neighbors and edge iterator

### DIFF
--- a/benches/partition_bench.rs
+++ b/benches/partition_bench.rs
@@ -32,18 +32,26 @@ impl PartitionableGraph for RandomGraph {
     type VertexId = usize;
     type VertexParIter<'a> = rayon::vec::IntoIter<usize> where Self: 'a;
     type NeighParIter<'a>   = rayon::vec::IntoIter<usize> where Self: 'a;
+    type NeighIter<'a>      = std::vec::IntoIter<usize> where Self: 'a;
+    type EdgeParIter<'a>    = rayon::vec::IntoIter<(usize, usize)> where Self: 'a;
 
     fn vertices(&self) -> Self::VertexParIter<'_> {
         (0..self.n).collect::<Vec<_>>().into_par_iter()
     }
     fn neighbors(&self, u: usize) -> Self::NeighParIter<'_> {
+        self.neighbors_seq(u).collect::<Vec<_>>().into_par_iter()
+    }
+    fn neighbors_seq(&self, u: usize) -> Self::NeighIter<'_> {
         let nbrs: Vec<_> = self.edges.iter()
             .filter_map(|&(a,b)| if a==u { Some(b) } else if b==u { Some(a) } else { None })
             .collect();
-        nbrs.into_par_iter()
+        nbrs.into_iter()
     }
     fn degree(&self, u: usize) -> usize {
-        self.neighbors(u).count()
+        self.neighbors_seq(u).count()
+    }
+    fn edges(&self) -> Self::EdgeParIter<'_> {
+        self.edges.clone().into_par_iter()
     }
 }
 

--- a/src/partitioning/louvain.rs
+++ b/src/partitioning/louvain.rs
@@ -223,10 +223,16 @@ mod tests {
         type VertexId = usize;
         type VertexParIter<'a> = rayon::vec::IntoIter<usize>;
         type NeighParIter<'a> = rayon::vec::IntoIter<usize>;
+        type NeighIter<'a> = std::vec::IntoIter<usize>;
+        type EdgeParIter<'a> = rayon::vec::IntoIter<(usize, usize)>;
+
         fn vertices(&self) -> Self::VertexParIter<'_> {
             (0..self.n).collect::<Vec<_>>().into_par_iter()
         }
         fn neighbors(&self, v: usize) -> Self::NeighParIter<'_> {
+            self.neighbors_seq(v).collect::<Vec<_>>().into_par_iter()
+        }
+        fn neighbors_seq(&self, v: usize) -> Self::NeighIter<'_> {
             let mut neigh = Vec::new();
             if v > 0 {
                 neigh.push(v - 1);
@@ -234,24 +240,16 @@ mod tests {
             if v + 1 < self.n {
                 neigh.push(v + 1);
             }
-            neigh.into_par_iter()
+            neigh.into_iter()
         }
         fn degree(&self, v: usize) -> usize {
-            self.neighbors(v).count()
+            self.neighbors_seq(v).count()
         }
-    }
-    impl PathGraph {
-        fn edges_serial(&self) -> Vec<(usize, usize)> {
-            let mut edges = Vec::with_capacity((self.n - 1) * 2);
-            for i in 0..(self.n - 1) {
-                edges.push((i, i + 1));
-                edges.push((i + 1, i));
-            }
-            edges
-        }
-        fn edges(&self) -> impl ParallelIterator<Item = (usize, usize)> {
-            let e = self.edges_serial();
-            e.into_par_iter()
+        fn edges(&self) -> Self::EdgeParIter<'_> {
+            (0..self.n.saturating_sub(1))
+                .map(|i| (i, i + 1))
+                .collect::<Vec<_>>()
+                .into_par_iter()
         }
     }
     #[test]
@@ -319,14 +317,23 @@ mod tests {
         type VertexId = usize;
         type VertexParIter<'a> = rayon::vec::IntoIter<usize>;
         type NeighParIter<'a> = rayon::vec::IntoIter<usize>;
+        type NeighIter<'a> = std::vec::IntoIter<usize>;
+        type EdgeParIter<'a> = rayon::vec::IntoIter<(usize, usize)>;
+
         fn vertices(&self) -> Self::VertexParIter<'_> {
             (0..self.n).collect::<Vec<_>>().into_par_iter()
         }
         fn neighbors(&self, _v: usize) -> Self::NeighParIter<'_> {
             Vec::new().into_par_iter()
         }
+        fn neighbors_seq(&self, _v: usize) -> Self::NeighIter<'_> {
+            Vec::new().into_iter()
+        }
         fn degree(&self, _v: usize) -> usize {
             0
+        }
+        fn edges(&self) -> Self::EdgeParIter<'_> {
+            Vec::new().into_par_iter()
         }
     }
 

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -182,14 +182,7 @@ where
     // ————————————————————————————————————————————————
     // 1. Gather all undirected edges u<v
     // ————————————————————————————————————————————————
-    let all_edges: Vec<(usize, usize)> = graph
-        .vertices()
-        .flat_map(|u| {
-            graph
-                .neighbors(u)
-                .filter_map(move |v| if u < v { Some((u, v)) } else { None })
-        })
-        .collect();
+    let all_edges: Vec<(usize, usize)> = graph.edges().collect();
 
     // ————————————————————————————————————————————————
     // 2. Build a map (cid_a, cid_b) → number of edges between them
@@ -278,14 +271,23 @@ mod tests {
         type VertexId = usize;
         type VertexParIter<'a> = rayon::vec::IntoIter<usize>;
         type NeighParIter<'a> = rayon::vec::IntoIter<usize>;
+        type NeighIter<'a> = std::vec::IntoIter<usize>;
+        type EdgeParIter<'a> = rayon::vec::IntoIter<(usize, usize)>;
+
         fn vertices(&self) -> Self::VertexParIter<'_> {
             vec![0, 1, 2, 3].into_par_iter()
         }
         fn neighbors(&self, _v: Self::VertexId) -> Self::NeighParIter<'_> {
             Vec::new().into_par_iter()
         }
+        fn neighbors_seq(&self, _v: Self::VertexId) -> Self::NeighIter<'_> {
+            Vec::new().into_iter()
+        }
         fn degree(&self, _v: Self::VertexId) -> usize {
             0
+        }
+        fn edges(&self) -> Self::EdgeParIter<'_> {
+            Vec::new().into_par_iter()
         }
     }
     #[test]

--- a/src/partitioning/vertex_cut.rs
+++ b/src/partitioning/vertex_cut.rs
@@ -175,18 +175,26 @@ mod tests {
         type VertexId = usize;
         type VertexParIter<'a> = rayon::vec::IntoIter<usize> where Self: 'a;
         type NeighParIter<'a> = rayon::vec::IntoIter<usize> where Self: 'a;
+        type NeighIter<'a> = std::vec::IntoIter<usize> where Self: 'a;
+        type EdgeParIter<'a> = rayon::vec::IntoIter<(usize, usize)> where Self: 'a;
 
         fn vertices(&self) -> Self::VertexParIter<'_> {
             (0..self.n).collect::<Vec<_>>().into_par_iter()
         }
         fn neighbors(&self, v: usize) -> Self::NeighParIter<'_> {
+            self.neighbors_seq(v).collect::<Vec<_>>().into_par_iter()
+        }
+        fn neighbors_seq(&self, v: usize) -> Self::NeighIter<'_> {
             let ns = self.edges.iter()
                 .filter_map(|&(a,b)| if a==v { Some(b) } else if b==v { Some(a) } else { None })
                 .collect::<Vec<_>>();
-            ns.into_par_iter()
+            ns.into_iter()
         }
         fn degree(&self, v: usize) -> usize {
-            self.neighbors(v).count()
+            self.neighbors_seq(v).count()
+        }
+        fn edges(&self) -> Self::EdgeParIter<'_> {
+            self.edges.clone().into_par_iter()
         }
     }
 


### PR DESCRIPTION
## Summary
- extend `PartitionableGraph` with serial neighbors and customizable edge iterator
- rewrite default `edges()` to flat-map serial neighbors without per-vertex allocations
- simplify edge cut to use graph-provided edges

## Testing
- `cargo check`
- `cargo test --features mpi-support` *(fails: Could not find MPI library)*

------
https://chatgpt.com/codex/tasks/task_e_68ba719031a88329b73f199772d30c7f