### PR TITLE
Refactor vertex cut assignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ check-invariants = []
 check-empty-part = []
 fast-hash = ["ahash"]
 deterministic-order = []
+deterministic-owners = []
 
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- rebuild vertex cut logic to assign a single primary owner per vertex using histograms and salted tie-breaking
- generate replica lists from cross-part edges with deterministic load-aware owner selection
- add `deterministic-owners` feature flag

## Testing
- `cargo test --features mpi-support` *(fails: `*mut ompi_communicator_t` cannot be sent/shared between threads)*

------
https://chatgpt.com/codex/tasks/task_e_68ba74c5900883298996b1e319f861f0