### PR TITLE
Implement adjacency-aware bin packing with retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ deterministic-order = []
 deterministic-owners = []
 check-graph-edges = []
 expensive-checks = []
+binpack-retry = []
+log = []
 
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- replace greedy bin packing with adjacency-aware FFD that enforces balance thresholds and deterministic tie-breaking
- rework cluster merge logic to only perform admissible merges and fall back to lightest feasible part
- add optional `binpack-retry` helper with feature-gated logging and unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bb21467f788329803f7ce02e17cfbd