### PR TITLE
Add end-to-end showcase example with partition and overlap checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "conv"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,13 +427,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -539,7 +618,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -551,6 +630,12 @@ dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -584,6 +669,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -639,7 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -696,6 +805,7 @@ dependencies = [
  "bytes",
  "criterion",
  "dashmap",
+ "env_logger",
  "hashbrown 0.14.5",
  "itertools 0.14.0",
  "libffi-sys",
@@ -807,6 +917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,7 +954,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -891,6 +1007,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1104,7 +1235,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1117,7 +1248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1285,7 +1416,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1355,6 +1486,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1498,7 +1635,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1508,12 +1645,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1522,14 +1674,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1539,10 +1708,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1551,10 +1732,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1563,10 +1756,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1575,10 +1780,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,18 @@ serial_test = "3.2.0"
 proptest = "1.0"
 rand_chacha = "0.3"
 criterion = "0.4"
+env_logger = "0.11"
 
 [features]
 default = []            # keep core lean
-mpi-support = ["mpi", "rayon", "rand", "ahash"]
+mpi-support = ["dep:mpi", "rayon", "dep:rand", "dep:ahash"]
 mpi-derive = ["mpi/derive"]
 metis-support = ["metis", "metis-sys", "libffi-sys","bindgen","pkg-config"]
 sieve_ref_fast_dag = []
 strict-invariants = []
 check-invariants = []
 check-empty-part = []
-fast-hash = ["ahash"]
+fast-hash = ["dep:ahash"]
 deterministic-order = []
 deterministic-owners = []
 check-graph-edges = []
@@ -62,6 +63,7 @@ binpack-retry = []
 log = []
 exact-metrics = []
 mem-snapshot = []
+rayon = ["dep:rayon"]
 
 
 [build-dependencies]

--- a/examples/e2e_showcase.rs
+++ b/examples/e2e_showcase.rs
@@ -1,0 +1,201 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::refine::sieved_array::SievedArray;
+use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::Sieve;
+
+use mesh_sieve::overlap::overlap::*;
+
+#[cfg(feature = "mpi-support")]
+use mesh_sieve::partitioning::{
+    partition,
+    PartitionerConfig,
+    metrics::{edge_cut, replication_factor},
+};
+
+#[path = "support/tiny_mesh.rs"]
+mod tiny_mesh;
+#[cfg(feature = "mpi-support")]
+#[path = "support/test_graph_impl.rs"]
+mod test_graph;
+
+#[cfg(feature = "rayon")]
+fn check_parallel_refine_matches_serial(atlas: &Atlas, sec: &Section<f64>, q0: PointId, q1: PointId) {
+    use mesh_sieve::data::refine::sieved_array::SievedArray;
+    use mesh_sieve::topology::arrow::Orientation;
+
+    let mut src = SievedArray::<PointId, f64>::new(atlas.clone());
+    for (p, sl) in sec.iter() {
+        src.try_set(p, sl).unwrap();
+    }
+    let sifter = vec![
+        (q0, vec![(q0, Orientation::Forward)]),
+        (q1, vec![(q1, Orientation::Reverse)]),
+    ];
+
+    let mut serial = SievedArray::<PointId, f64>::new(atlas.clone());
+    let mut parallel = SievedArray::<PointId, f64>::new(atlas.clone());
+
+    serial.try_refine_with_sifter(&src, &sifter).unwrap();
+    parallel
+        .try_refine_with_sifter_parallel(&src, &sifter)
+        .unwrap();
+
+    for &p in &[q0, q1] {
+        assert_eq!(serial.try_get(p).unwrap(), parallel.try_get(p).unwrap());
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // ---------------------------------------------
+    // 1) Build tiny mesh + print closure/star sanity
+    // ---------------------------------------------
+    let mesh = tiny_mesh::tiny_oriented_mesh();
+    let q0 = PointId::new(200).unwrap();
+    let q1 = PointId::new(201).unwrap();
+
+    let c0: Vec<_> = mesh.closure(std::iter::once(q0)).collect();
+    let s0: Vec<_> = mesh.star(std::iter::once(q0)).collect();
+    println!("[mesh] closure(Q0)={:?}  star(Q0)={:?}", c0, s0);
+    assert!(!c0.is_empty() && !s0.is_empty());
+
+    // ---------------------------------------------
+    // 2) Atlas + Section: 1 DOF per cell edge (toy)
+    // ---------------------------------------------
+    let mut atlas = Atlas::default();
+    let off_q0 = atlas.try_insert(q0, 4)?; // 4 “edge DOFs” for Q0
+    let off_q1 = atlas.try_insert(q1, 4)?;
+    assert_eq!(off_q0, 0);
+    assert_eq!(off_q1, 4);
+    let mut sec: Section<f64> = Section::new(atlas.clone());
+
+    // Initialize base values:
+    sec.try_set(q0, &[1.0, 2.0, 3.0, 4.0])?;
+    sec.try_set(q1, &[10.0, 20.0, 30.0, 40.0])?;
+
+    // ---------------------------------------------
+    // 3) Refine along a sifter with one REVERSE
+    // ---------------------------------------------
+    let mut fine = SievedArray::<PointId, f64>::new(atlas.clone());
+    let mut coarse = SievedArray::<PointId, f64>::new(atlas.clone());
+    for (p, sl) in sec.iter() {
+        coarse.try_set(p, sl)?;
+    }
+    let sifter = vec![
+        (q0, vec![(q0, Orientation::Forward)]),
+        (q1, vec![(q1, Orientation::Reverse)]),
+    ];
+
+    fine.try_refine_with_sifter(&coarse, &sifter)?;
+
+    // Verify reverse happened for q1 against q1’s original:
+    let q1_src = sec.try_restrict(q1)?.to_vec();
+    let q1_fine = fine.try_get(q1)?.to_vec();
+    assert_eq!(q1_fine, q1_src.iter().rev().cloned().collect::<Vec<_>>());
+
+    #[cfg(feature = "rayon")]
+    check_parallel_refine_matches_serial(&atlas, &sec, q0, q1);
+
+    // ---------------------------------------------
+    // 4) Overlap: structural links, closure-of-support, resolution, invariants
+    // ---------------------------------------------
+    let mut ov = Overlap::default();
+    // Simulate rank 0 owning q0, shared with rank 1; rank 1 owning q1 shared back.
+    ov.add_link_structural_one(q0, 1);
+    ov.add_link_structural_one(q1, 0);
+
+    // Structural completion against mesh
+    ensure_closure_of_support(&mut ov, &mesh);
+
+    // Resolve only q0@r=1; leave q1 unresolved to test Option semantics.
+    ov.resolve_remote_point(q0, 1, q0)?; // remote id equals local for demo
+
+    // Invariants must hold (or panic/fail under feature gate):
+    #[cfg(any(debug_assertions, feature = "check-invariants"))]
+    ov.validate_invariants().expect("overlap invariants");
+
+    // Neighbor ranks / links API:
+    let nbrs: Vec<_> = ov.neighbor_ranks().collect();
+    println!("[overlap] neighbor ranks = {:?}", nbrs);
+    assert!(nbrs.contains(&0) || nbrs.contains(&1));
+    let links_to_1: Vec<_> = ov.links_to(1).collect();
+    println!("[overlap] links to rank 1 = {:?}", links_to_1);
+    // At least (q0, Some(remote)) appears:
+    assert!(links_to_1.iter().any(|(p, rp)| *p == q0 && rp.is_some()));
+
+    // ---------------------------------------------
+    // 5) Partitioning pipeline on dual graph (if enabled)
+    // ---------------------------------------------
+    #[cfg(feature = "mpi-support")]
+    {
+        let edges = tiny_mesh::tiny_dual_graph_edges();
+        let g = test_graph::AdjListGraph::from_undirected(2, &edges);
+        let cfg = PartitionerConfig {
+            n_parts: 2,
+            alpha: 0.75,
+            seed_factor: 4.0,
+            rng_seed: 1234,
+            max_iters: 20,
+            epsilon: 0.10,
+            enable_phase1: true,
+            enable_phase2: true,
+            enable_phase3: true,
+        };
+        let pm = partition(&g, &cfg).expect("partition runs");
+        // Sanity metrics
+        let cut = edge_cut(&g, &pm);
+        let rf_approx = replication_factor(&g, &pm);
+        println!("[partition] edge_cut={}  RF≈{:.3}", cut, rf_approx);
+        assert!(cut <= 1);
+        assert!(rf_approx >= 1.0 && rf_approx <= 2.0);
+
+        // Optional: exact RF via vertex_cut outputs if you expose them (feature "exact-metrics")
+        #[cfg(feature = "exact-metrics")]
+        {
+            use mesh_sieve::partitioning::vertex_cut::build_vertex_cuts;
+            use std::collections::HashSet;
+            let (primary, replicas) = build_vertex_cuts(&g, &pm, 999).expect("vcuts");
+            let mut parts = vec![HashSet::new(), HashSet::new()];
+            for v in 0..2 {
+                parts[v].insert(primary[v]);
+                for &(_u, p) in &replicas[v] {
+                    parts[v].insert(p);
+                }
+            }
+            let rf_exact = (parts[0].len() + parts[1].len()) as f64 / 2.0;
+            println!("[partition] RF_exact={:.3}", rf_exact);
+            assert!((rf_exact - rf_approx).abs() <= 1e-6 || rf_exact <= 2.0);
+        }
+    }
+
+    // ---------------------------------------------
+    // 6) Negative-path smoke checks (cheap, targeted)
+    // ---------------------------------------------
+    // a) Atlas rejects zero-length slice
+    let p_bad = PointId::new(999).unwrap();
+    let mut bad = atlas.clone();
+    let err = bad.try_insert(p_bad, 0).unwrap_err();
+    println!("[neg] zero-length insert -> {:?}", err);
+
+    // b) Section set length mismatch
+    let mut sec2: Section<f64> = Section::new(atlas.clone());
+    let err = sec2.try_set(q0, &[1.0, 2.0, 3.0]).unwrap_err();
+    println!("[neg] slice-length mismatch -> {:?}", err);
+
+    // c) Overlap: wrong rank in payload (guarded by validate_invariants)
+    #[cfg(feature = "check-invariants")]
+    {
+        use mesh_sieve::overlap::overlap::{OvlId, Remote};
+        let src = OvlId::Local(q0);
+        let dst = OvlId::Part(7);
+        let mut ov_bad = ov.clone();
+        Sieve::add_arrow(&mut ov_bad, src, dst, Remote { rank: 5, remote_point: None });
+        assert!(ov_bad.validate_invariants().is_err());
+    }
+
+    println!("OK: e2e showcase finished");
+    Ok(())
+}

--- a/examples/support/test_graph_impl.rs
+++ b/examples/support/test_graph_impl.rs
@@ -1,0 +1,44 @@
+use rayon::prelude::*;
+use mesh_sieve::partitioning::graph_traits::PartitionableGraph;
+
+/// Simple adjacency-list graph for examples/tests.
+#[derive(Clone)]
+pub struct AdjListGraph { pub nbrs: Vec<Vec<usize>> }
+
+impl AdjListGraph {
+    pub fn from_undirected(n: usize, edges: &[(usize, usize)]) -> Self {
+        let mut nbrs = vec![Vec::new(); n];
+        for &(u, v) in edges {
+            nbrs[u].push(v);
+            nbrs[v].push(u);
+        }
+        for ns in &mut nbrs {
+            ns.sort_unstable();
+            ns.dedup();
+        }
+        Self { nbrs }
+    }
+}
+
+impl PartitionableGraph for AdjListGraph {
+    type VertexId = usize;
+    type VertexParIter<'a> = rayon::vec::IntoIter<usize>;
+    type NeighParIter<'a> = rayon::vec::IntoIter<usize>;
+    type NeighIter<'a> = std::iter::Copied<std::slice::Iter<'a, usize>>;
+
+    fn vertices(&self) -> Self::VertexParIter<'_> {
+        (0..self.nbrs.len()).collect::<Vec<_>>().into_par_iter()
+    }
+
+    fn neighbors(&self, v: usize) -> Self::NeighParIter<'_> {
+        self.nbrs[v].clone().into_par_iter()
+    }
+
+    fn neighbors_seq(&self, v: usize) -> Self::NeighIter<'_> {
+        self.nbrs[v].iter().copied()
+    }
+
+    fn degree(&self, v: usize) -> usize {
+        self.nbrs[v].len()
+    }
+}

--- a/examples/support/tiny_mesh.rs
+++ b/examples/support/tiny_mesh.rs
@@ -1,0 +1,31 @@
+use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::{InMemorySieve, Sieve};
+
+/// Build a tiny oriented primal mesh: two quads with one shared edge.
+/// One shared edge between `Q0` and `Q1` has reversed orientation to
+/// exercise delta logic.
+pub fn tiny_oriented_mesh() -> InMemorySieve<PointId, Orientation> {
+    let mut s: InMemorySieve<PointId, Orientation> = InMemorySieve::default();
+    let e = |i: u64| PointId::new(100 + i).unwrap();
+    let q = |i: u64| PointId::new(200 + i).unwrap();
+
+    // Q0 edges (Forward, Forward, Reverse, Forward)
+    Sieve::add_arrow(&mut s, q(0), e(0), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(0), e(1), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(0), e(2), Orientation::Reverse); // reversed shared edge
+    Sieve::add_arrow(&mut s, q(0), e(3), Orientation::Forward);
+
+    // Q1 edges (all Forward) sharing edge e(2)
+    Sieve::add_arrow(&mut s, q(1), e(2), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(4), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(5), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(6), Orientation::Forward);
+
+    s
+}
+
+/// Dual graph: two cells `Q0` and `Q1` with one undirected edge between them.
+pub fn tiny_dual_graph_edges() -> Vec<(usize, usize)> {
+    vec![(0, 1)]
+}

--- a/tests/e2e_showcase_smoke.rs
+++ b/tests/e2e_showcase_smoke.rs
@@ -1,0 +1,112 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::refine::sieved_array::SievedArray;
+use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::Sieve;
+
+#[path = "../examples/support/tiny_mesh.rs"]
+mod tiny_mesh;
+
+#[cfg(feature = "mpi-support")]
+#[path = "../examples/support/test_graph_impl.rs"]
+mod test_graph;
+
+#[test]
+fn orientation_and_overlap_smoke() {
+    let mesh = tiny_mesh::tiny_oriented_mesh();
+    let q0 = PointId::new(200).unwrap();
+    let q1 = PointId::new(201).unwrap();
+
+    let mut atlas = Atlas::default();
+    atlas.try_insert(q0, 4).unwrap();
+    atlas.try_insert(q1, 4).unwrap();
+    let mut sec = Section::<f64>::new(atlas.clone());
+    sec.try_set(q0, &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    sec.try_set(q1, &[10.0, 20.0, 30.0, 40.0]).unwrap();
+
+    let mut coarse = SievedArray::<PointId, f64>::new(atlas.clone());
+    for (p, sl) in sec.iter() {
+        coarse.try_set(p, sl).unwrap();
+    }
+    let mut fine = SievedArray::<PointId, f64>::new(atlas.clone());
+    let sifter = vec![
+        (q0, vec![(q0, Orientation::Forward)]),
+        (q1, vec![(q1, Orientation::Reverse)]),
+    ];
+    fine.try_refine_with_sifter(&coarse, &sifter).unwrap();
+    let q1_src = sec.try_restrict(q1).unwrap().to_vec();
+    let q1_fine = fine.try_get(q1).unwrap().to_vec();
+    assert_eq!(q1_fine, q1_src.into_iter().rev().collect::<Vec<_>>());
+
+    use mesh_sieve::overlap::overlap::*;
+    let mut ov = Overlap::default();
+    ov.add_link_structural_one(q0, 1);
+    ov.add_link_structural_one(q1, 0);
+    ensure_closure_of_support(&mut ov, &mesh);
+    ov.resolve_remote_point(q0, 1, q0).unwrap();
+    #[cfg(any(debug_assertions, feature = "check-invariants"))]
+    ov.validate_invariants().unwrap();
+    assert!(ov.neighbor_ranks().any(|r| r == 1 || r == 0));
+    assert!(ov.links_to(1).any(|(p, rp)| p == q0 && rp.is_some()));
+}
+
+#[cfg(feature = "mpi-support")]
+#[test]
+fn partition_metrics_smoke() {
+    use mesh_sieve::partitioning::{
+        partition,
+        PartitionerConfig,
+        metrics::{edge_cut, replication_factor},
+    };
+    let edges = tiny_mesh::tiny_dual_graph_edges();
+    let g = test_graph::AdjListGraph::from_undirected(2, &edges);
+    let cfg = PartitionerConfig {
+        n_parts: 2,
+        alpha: 0.75,
+        seed_factor: 4.0,
+        rng_seed: 1234,
+        max_iters: 20,
+        epsilon: 0.10,
+        enable_phase1: true,
+        enable_phase2: true,
+        enable_phase3: true,
+    };
+    let pm = partition(&g, &cfg).expect("partition");
+    let cut = edge_cut(&g, &pm);
+    let rf = replication_factor(&g, &pm);
+    assert!(cut <= 1);
+    assert!(rf >= 1.0 && rf <= 2.0);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn parallel_refine_parity() {
+    let q0 = PointId::new(200).unwrap();
+    let q1 = PointId::new(201).unwrap();
+
+    let mut atlas = Atlas::default();
+    atlas.try_insert(q0, 4).unwrap();
+    atlas.try_insert(q1, 4).unwrap();
+    let mut sec = Section::<f64>::new(atlas.clone());
+    sec.try_set(q0, &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    sec.try_set(q1, &[10.0, 20.0, 30.0, 40.0]).unwrap();
+
+    let mut src = SievedArray::<PointId, f64>::new(atlas.clone());
+    for (p, sl) in sec.iter() {
+        src.try_set(p, sl).unwrap();
+    }
+    let sifter = vec![
+        (q0, vec![(q0, Orientation::Forward)]),
+        (q1, vec![(q1, Orientation::Reverse)]),
+    ];
+    let mut serial = SievedArray::<PointId, f64>::new(atlas.clone());
+    let mut parallel = SievedArray::<PointId, f64>::new(atlas.clone());
+    serial.try_refine_with_sifter(&src, &sifter).unwrap();
+    parallel
+        .try_refine_with_sifter_parallel(&src, &sifter)
+        .unwrap();
+    for &p in &[q0, q1] {
+        assert_eq!(serial.try_get(p).unwrap(), parallel.try_get(p).unwrap());
+    }
+}


### PR DESCRIPTION
## Summary
- wire up cargo feature flags and `env_logger` dev-dependency
- add `examples/e2e_showcase.rs` demonstrating mesh, data and partitioning APIs
- include reusable tiny mesh graph helpers and smoke tests

## Testing
- `cargo test`
- `cargo run --example e2e_showcase`
- `cargo build --features mpi-support`


------
https://chatgpt.com/codex/tasks/task_e_68bb8ef489188329bbf328a0566d08e5