### PR TITLE
Make lattice adjacency robust and document semantics

### DIFF
--- a/src/algs/dual_graph.rs
+++ b/src/algs/dual_graph.rs
@@ -28,7 +28,7 @@
 //!
 //! // Custom boundary depth and weights
 //! fn w(p: PointId) -> i32 { p.get() as i32 }
-//! let opts = DualGraphOpts { boundary: AdjacencyOpts { max_down_depth: Some(2) }, symmetrize: true };
+//! let opts = DualGraphOpts { boundary: AdjacencyOpts { max_down_depth: Some(2), same_stratum_only: true }, symmetrize: true };
 //! let _dg2 = build_dual_with_opts(&s, vec![c0, c1], opts, Some(w));
 //! ```
 //!

--- a/src/algs/lattice.rs
+++ b/src/algs/lattice.rs
@@ -1,67 +1,151 @@
 //! Set-lattice helpers: meet, join, adjacency and helpers.
-//! All output vectors are **sorted & deduplicated** for deterministic behaviour.
+//!
+//! *Adjacency semantics*
+//! - Two `cells` (points at the same height) are adjacent if they share any
+//!   boundary point found by walking down from a cell by `max_down_depth`
+//!   levels.
+//! - `Some(1)` &rarr; faces only (finite-volume style, and the default).
+//! - `Some(2)` &rarr; faces and vertices (typical 2D finite-element).
+//! - `Some(0)` &rarr; empty boundary (no adjacency).
+//! - `None` &rarr; full transitive down-closure (potentially expensive).
+//!
+//! *Determinism*
+//! - All returned vectors are sorted ascending and deduplicated.
+//!
+//! *Cycle safety*
+//! - A visited set is always used during the down-walk to prevent infinite
+//!   loops on cyclic inputs.
+//!
+//! *Same-stratum adjacency*
+//! - `support(b)` may return parents at different heights. For mesh
+//!   cell-to-cell adjacency we filter neighbors to the same height as the seed
+//!   cell by default. Disable this via [`AdjacencyOpts::same_stratum_only`]
+//!   when cross-stratum relations are desired.
 
 use crate::topology::point::PointId;
 use crate::topology::sieve::Sieve;
+use crate::topology::sieve::strata::compute_strata;
 
 type P = PointId;
 
 /// Controls how to form the "boundary" of `p` that defines adjacency:
-/// - If `max_down_depth = Some(1)`, neighbors are those sharing a **face** (FV style).
-/// - If `max_down_depth = Some(2)`, also through vertices (typical 2D FE).
+/// - If `max_down_depth = Some(1)`, neighbors are those sharing a **face**.
+/// - If `max_down_depth = Some(2)`, also through vertices.
 /// - If `max_down_depth = None`, full transitive closure (all lower strata).
 #[derive(Clone, Copy, Debug)]
 pub struct AdjacencyOpts {
     pub max_down_depth: Option<u32>,
+    /// When `true`, only return neighbors with the same height as `p`.
+    /// This is correct for cell-to-cell adjacency in meshes.
+    pub same_stratum_only: bool,
 }
 
 impl Default for AdjacencyOpts {
-    fn default() -> Self { Self { max_down_depth: Some(1) } }
+    fn default() -> Self {
+        Self { max_down_depth: Some(1), same_stratum_only: true }
+    }
 }
 
+#[inline]
 fn boundary_points<S>(sieve: &S, p: P, max_down_depth: Option<u32>) -> Vec<P>
-where S: Sieve<Point = P>
+where
+    S: Sieve<Point = P>,
 {
     use std::collections::{HashSet, VecDeque};
+
     match max_down_depth {
-        None => {
-            let mut v: Vec<_> = sieve.cone_points(p).collect();
-            let mut seen: HashSet<_> = v.iter().copied().collect();
-            let mut q: VecDeque<_> = v.iter().copied().map(|x| (x, 1)).collect();
-            while let Some((r, _d)) = q.pop_front() {
-                for s in sieve.cone_points(r) {
-                    if seen.insert(s) { v.push(s); q.push_back((s, 0)); }
-                }
-            }
-            v.sort_unstable(); v.dedup(); v
+        // No boundary
+        Some(0) => Vec::new(),
+
+        // Faces only (most common)
+        Some(1) => {
+            let mut v: Vec<P> = sieve.cone_points(p).collect();
+            v.sort_unstable();
+            v.dedup();
+            v
         }
-        Some(k) => {
-            if k == 0 { return vec![]; }
+
+        // Faces + vertices (common in 2D FE)
+        Some(2) => {
             let mut out = Vec::new();
-            let mut seen = HashSet::new();
-            let mut q = VecDeque::from_iter(sieve.cone_points(p).map(|x| (x, 1)));
+            let mut seen: HashSet<P> = HashSet::with_capacity(16);
+            let mut q: VecDeque<(P, u32)> = VecDeque::with_capacity(16);
+            q.extend(sieve.cone_points(p).map(|x| (x, 1)));
+
             while let Some((r, d)) = q.pop_front() {
-                if seen.insert(r) { out.push(r); }
-                if d < k {
-                    for s in sieve.cone_points(r) { q.push_back((s, d+1)); }
+                if seen.insert(r) {
+                    out.push(r);
+                    if d < 2 {
+                        for s in sieve.cone_points(r) {
+                            if !seen.contains(&s) {
+                                q.push_back((s, d + 1));
+                            }
+                        }
+                    }
                 }
             }
-            out.sort_unstable(); out.dedup(); out
+            out.sort_unstable();
+            out.dedup();
+            out
+        }
+
+        // Full down-closure (or arbitrary depth > 2)
+        None | Some(_) => {
+            let limit = max_down_depth.unwrap_or(u32::MAX);
+            let mut out = Vec::new();
+            let mut seen: HashSet<P> = HashSet::with_capacity(64);
+            let mut q: VecDeque<(P, u32)> = VecDeque::with_capacity(64);
+            q.extend(sieve.cone_points(p).map(|x| (x, 1)));
+
+            while let Some((r, d)) = q.pop_front() {
+                if seen.insert(r) {
+                    out.push(r);
+                    if d < limit {
+                        for s in sieve.cone_points(r) {
+                            if !seen.contains(&s) {
+                                q.push_back((s, d + 1));
+                            }
+                        }
+                    }
+                }
+            }
+            out.sort_unstable();
+            out.dedup();
+            out
         }
     }
 }
 
 /// Cells adjacent to `p` according to the policy.
 /// Adjacent = share any boundary point in the chosen boundary set.
+/// Respects [`AdjacencyOpts::same_stratum_only`].
+#[inline]
 pub fn adjacent_with<S>(sieve: &S, p: P, opts: AdjacencyOpts) -> Vec<P>
-where S: Sieve<Point = P>
+where
+    S: Sieve<Point = P>,
 {
     use std::collections::HashSet;
+
+    let height_map = if opts.same_stratum_only {
+        compute_strata(sieve).ok().map(|cache| cache.height)
+    } else {
+        None
+    };
+    let seed_height = height_map.as_ref().and_then(|hm| hm.get(&p).copied());
+
     let boundary = boundary_points(sieve, p, opts.max_down_depth);
     let mut neigh = HashSet::new();
     for b in boundary {
         for (cell, _) in sieve.support(b) {
-            if cell != p { neigh.insert(cell); }
+            if cell == p {
+                continue;
+            }
+            if let (Some(hp), Some(ref hm)) = (seed_height, height_map.as_ref()) {
+                if hm.get(&cell).copied() != Some(hp) {
+                    continue;
+                }
+            }
+            neigh.insert(cell);
         }
     }
     let mut out: Vec<P> = neigh.into_iter().collect();

--- a/tests/adjacency_policy.rs
+++ b/tests/adjacency_policy.rs
@@ -11,7 +11,7 @@ fn face_neighbors_only() {
     s.add_arrow(v(1), v(3), ()); s.add_arrow(v(1), v(4), ()); s.add_arrow(v(1), v(5), ());
     s.add_arrow(v(2), v(5), ()); s.add_arrow(v(2), v(6), ()); s.add_arrow(v(2), v(7), ());
     s.add_arrow(v(5), v(8), ()); s.add_arrow(v(5), v(9), ());
-    let neigh = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(1) });
+    let neigh = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(1), same_stratum_only: true });
     assert_eq!(neigh, vec![v(2)]); // share edge 5
 }
 
@@ -22,6 +22,6 @@ fn through_vertices_too() {
     // two cells sharing only a vertex
     s.add_arrow(v(1), v(3), ()); s.add_arrow(v(1), v(4), ());
     s.add_arrow(v(2), v(4), ()); s.add_arrow(v(2), v(5), ());
-    let neigh = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(2) });
+    let neigh = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(2), same_stratum_only: true });
     assert_eq!(neigh, vec![v(2)]);
 }

--- a/tests/dual_graph_tests.rs
+++ b/tests/dual_graph_tests.rs
@@ -73,6 +73,7 @@ fn widened_boundary_includes_vertices() {
     let opts = DualGraphOpts {
         boundary: AdjacencyOpts {
             max_down_depth: Some(2),
+            same_stratum_only: true,
         },
         symmetrize: true,
     };

--- a/tests/lattice_adjacency_tests.rs
+++ b/tests/lattice_adjacency_tests.rs
@@ -1,0 +1,69 @@
+use mesh_sieve::algs::lattice::{adjacent, adjacent_with, AdjacencyOpts};
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::in_memory::InMemorySieve;
+use mesh_sieve::topology::sieve::Sieve;
+
+fn v(i: u64) -> PointId { PointId::new(i).unwrap() }
+
+#[test]
+fn determinism() {
+    let mut s = InMemorySieve::<PointId, ()>::new();
+    // two triangles sharing an edge: 1->(3,4,5), 2->(5,6,7); edge5->verts
+    s.add_arrow(v(1), v(3), ()); s.add_arrow(v(1), v(4), ()); s.add_arrow(v(1), v(5), ());
+    s.add_arrow(v(2), v(5), ()); s.add_arrow(v(2), v(6), ()); s.add_arrow(v(2), v(7), ());
+    s.add_arrow(v(5), v(8), ()); s.add_arrow(v(5), v(9), ());
+    let first = adjacent(&s, v(1));
+    assert_eq!(first, vec![v(2)]);
+    for _ in 0..100 {
+        let n = adjacent(&s, v(1));
+        assert_eq!(n, first);
+    }
+}
+
+#[test]
+fn depth_semantics() {
+    let mut s = InMemorySieve::<PointId, ()>::new();
+    // cell1 shares edge5 with cell2 and vertex9 with cell3
+    s.add_arrow(v(1), v(3), ());
+    s.add_arrow(v(1), v(4), ());
+    s.add_arrow(v(1), v(5), ());
+    s.add_arrow(v(2), v(5), ());
+    s.add_arrow(v(2), v(6), ());
+    s.add_arrow(v(2), v(7), ());
+    s.add_arrow(v(5), v(8), ());
+    s.add_arrow(v(5), v(9), ());
+    s.add_arrow(v(10), v(9), ());
+
+    let none = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(0), same_stratum_only: true });
+    assert!(none.is_empty());
+    let faces = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(1), same_stratum_only: true });
+    assert_eq!(faces, vec![v(2)]);
+    let verts = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(2), same_stratum_only: true });
+    assert_eq!(verts, vec![v(2), v(10)]);
+    let full = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: None, same_stratum_only: true });
+    for n in &verts { assert!(full.contains(n)); }
+    assert!(full.len() >= verts.len());
+}
+
+#[test]
+fn cycle_safe() {
+    let mut s = InMemorySieve::<PointId, ()>::new();
+    // 1 <-> 2 cycle
+    s.add_arrow(v(1), v(2), ());
+    s.add_arrow(v(2), v(1), ());
+    let neigh = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: None, same_stratum_only: false });
+    assert_eq!(neigh, vec![v(2)]);
+}
+
+#[test]
+fn same_stratum_filter() {
+    let mut s = InMemorySieve::<PointId, ()>::new();
+    // cells 1 and 2 share edge5; vertex9 is boundary of edge5
+    s.add_arrow(v(1), v(5), ());
+    s.add_arrow(v(2), v(5), ());
+    s.add_arrow(v(5), v(9), ());
+    let cells_only = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(2), same_stratum_only: true });
+    assert_eq!(cells_only, vec![v(2)]);
+    let cross = adjacent_with(&s, v(1), AdjacencyOpts { max_down_depth: Some(2), same_stratum_only: false });
+    assert_eq!(cross, vec![v(2), v(5)]);
+}


### PR DESCRIPTION
## Summary
- clarify lattice adjacency semantics and add `same_stratum_only` option
- harden boundary discovery against cycles and optimise shallow depths
- exercise deterministic, depth, cycle and stratum behaviour in new tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bceb2cf190832984e1be97b112f52f