### PR TITLE
Refactor mesh distribution for structural overlap

### DIFF
--- a/src/algs/completion/neighbour_links.rs
+++ b/src/algs/completion/neighbour_links.rs
@@ -41,9 +41,12 @@ where
         has_owned = true;
         for (_dst, rem) in ovlp.cone(local(p)) {
             if rem.rank != my_rank {
+                let remote_pt = rem
+                    .remote_point
+                    .ok_or(MeshSieveError::OverlapLinkMissing(p, rem.rank))?;
                 out.entry(rem.rank)
                     .or_default()
-                    .push((p, rem.remote_point.expect("overlap unresolved")));
+                    .push((p, remote_pt));
             }
         }
     }


### PR DESCRIPTION
## Summary
- rewrite `distribute_mesh` to produce bipartite structural `Overlap` without resolved remote IDs
- add optional `resolve_overlap_identity` helper and document phased distribution
- replace outdated test with new `distribute_tests`
- handle unresolved overlap links in `neighbour_links`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd146ed6408329aed426b1fd21a299