### PR TITLE
Streamline cluster merge in partitioning

### DIFF
--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -178,12 +178,8 @@ where
     let clusters: Vec<u32> = if cfg.enable_phase1 {
         louvain_cluster(graph, cfg)
     } else {
-        // Dense, contiguous cluster IDs when Phase 1 disabled
-        verts
-            .iter()
-            .enumerate()
-            .map(|(i, _)| (i as u32 % cfg.n_parts as u32))
-            .collect()
+        // Each vertex starts in its own cluster when Phase 1 is skipped
+        verts.iter().map(|&v| v as u32).collect()
     };
 
     // Defensive checks


### PR DESCRIPTION
## Summary
- compute inter-cluster adjacency directly from edges() without materializing all_edges
- accumulate cluster loads and adjacency lists with deterministic ordering
- add catch-all `Other` variant to `PartitionerError`
- give each vertex its own cluster when phase 1 is disabled so phase 2 can still bin-pack

## Testing
- `cargo test --features mpi-support --lib --tests`


------
https://chatgpt.com/codex/tasks/task_e_68bd14a2f8d0832998bd3583482bbacd