### PR TITLE
fix: gate partitioning modules behind mpi-support

### DIFF
--- a/src/partitioning/louvain.rs
+++ b/src/partitioning/louvain.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "mpi-support")]
 //! Louvain-style clustering for distributed graph partitioning.
 //!
 //! ## Objective (Newman modularity with balance factor)

--- a/src/partitioning/metrics.rs
+++ b/src/partitioning/metrics.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "mpi-support")]
 //! ## Replication Factor (RF) and Load Balance
 //!
 //! - RF: average number of parts each vertex appears in. If `P(v)` is the set of parts

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -43,9 +43,7 @@ pub mod binpack;
 pub mod error;
 #[cfg(feature = "mpi-support")]
 pub mod graph_traits;
-#[cfg(feature = "mpi-support")]
 pub mod louvain;
-#[cfg(feature = "mpi-support")]
 pub mod metrics;
 #[cfg(feature = "mpi-support")]
 pub mod parallel;
@@ -54,7 +52,6 @@ pub mod seed_select;
 #[cfg(feature = "mpi-support")]
 pub mod vertex_cut;
 
-#[cfg(feature = "mpi-support")]
 pub use self::metrics::*;
 
 #[cfg(feature = "mpi-support")]


### PR DESCRIPTION
## Summary
- gate louvain and metrics modules with `mpi-support`
- drop redundant cfg gating in `mod.rs`

## Testing
- `cargo check`
- `cargo clippy --features "mpi-support,rayon"`
- `cargo test --features "mpi-support,rayon" --tests`


------
https://chatgpt.com/codex/tasks/task_e_68bd14c90cd08329bf1d919500fc065a