### PR TITLE
Add vector DOF support to symmetric data exchange

### DIFF
--- a/src/algs/completion/data_exchange.rs
+++ b/src/algs/completion/data_exchange.rs
@@ -6,10 +6,17 @@ use crate::mesh_error::MeshSieveError;
 /// For each neighbor, pack `Delta::restrict` from your section into a send buffer,
 /// post irecv for the corresponding byte length (from stage 1),
 /// then send and finally wait + `Delta::fuse` into your local section.
+///
+/// This function assumes each point slice has **exactly one degree of freedom**.
+/// For vector DOFs use [`exchange_data_symmetric`], which supports arbitrary
+/// slice lengths via a length-prefixed protocol.
 pub fn exchange_data<V, D, C>(
     links: &std::collections::HashMap<
         usize,
-        Vec<(crate::topology::point::PointId, crate::topology::point::PointId)>,
+        Vec<(
+            crate::topology::point::PointId,
+            crate::topology::point::PointId,
+        )>,
     >,
     recv_counts: &std::collections::HashMap<usize, u32>,
     comm: &C,
@@ -44,12 +51,14 @@ where
         let link_vec = links.get(&nbr).map_or(&[][..], |v| &v[..]);
         let mut scratch = Vec::with_capacity(link_vec.len());
         for &(send_loc, _) in link_vec {
-            let slice = section
-                .try_restrict(send_loc)
-                .map_err(|e| MeshSieveError::SectionAccess {
-                    point: send_loc,
-                    source: Box::new(e),
-                })?;
+            let slice =
+                section
+                    .try_restrict(send_loc)
+                    .map_err(|e| MeshSieveError::SectionAccess {
+                        point: send_loc,
+                        source: Box::new(e),
+                    })?;
+            debug_assert_eq!(slice.len(), 1, "exchange_data assumes scalar DOFs");
             scratch.push(D::restrict(&slice[0]));
         }
         let bytes = cast_slice(&scratch);
@@ -80,12 +89,14 @@ where
             });
         }
         for ((_, recv_loc), part) in link_vec.iter().zip(parts) {
-            let mut_slice = section
-                .try_restrict_mut(*recv_loc)
-                .map_err(|e| MeshSieveError::SectionAccess {
-                    point: *recv_loc,
-                    source: Box::new(e),
-                })?;
+            let mut_slice =
+                section
+                    .try_restrict_mut(*recv_loc)
+                    .map_err(|e| MeshSieveError::SectionAccess {
+                        point: *recv_loc,
+                        source: Box::new(e),
+                    })?;
+            debug_assert_eq!(mut_slice.len(), 1, "exchange_data assumes scalar DOFs");
             D::fuse(&mut mut_slice[0], *part);
         }
     }
@@ -98,12 +109,19 @@ where
     Ok(())
 }
 
-/// Symmetric version: post _both_ send+recv to _every_ neighbor (even if count == 0),
-/// so that no rank ever blocks waiting for a peer that never sends.
+/// Symmetric version that supports vector DOFs per point.
+///
+/// For each neighbor we exchange:
+/// 1. point counts (from `exchange_sizes_symmetric`),
+/// 2. a `u32` length per point, and
+/// 3. a flat payload of `D::Part` values.
 pub fn exchange_data_symmetric<V, D, C>(
     links: &std::collections::HashMap<
         usize,
-        Vec<(crate::topology::point::PointId, crate::topology::point::PointId)>,
+        Vec<(
+            crate::topology::point::PointId,
+            crate::topology::point::PointId,
+        )>,
     >,
     recv_counts: &std::collections::HashMap<usize, u32>,
     comm: &C,
@@ -114,103 +132,161 @@ pub fn exchange_data_symmetric<V, D, C>(
 where
     V: Clone + Default + Send + 'static,
     D: crate::overlap::delta::ValueDelta<V> + Send + Sync + 'static,
-    D::Part: bytemuck::Pod + Default,
+    D::Part: bytemuck::Pod + Default + Copy,
     C: crate::algs::communicator::Communicator + Sync,
 {
     use bytemuck::{cast_slice, cast_slice_mut};
     use std::collections::HashMap;
 
-    // 1) post all recvs (possibly zero‐length)
-    let mut recv_data: HashMap<usize, (C::RecvHandle, Vec<D::Part>)> = HashMap::new();
+    let tag_len = base_tag;
+    let tag_data = base_tag + 1;
+
+    // lengths phase
+    let mut recv_lens: HashMap<usize, (C::RecvHandle, Vec<u32>)> = HashMap::new();
     for &nbr in all_neighbors {
-        let n_items = recv_counts.get(&nbr).copied().unwrap_or(0) as usize;
-        let mut buffer = vec![D::Part::default(); n_items];
-        let h = comm.irecv(nbr, base_tag, cast_slice_mut(&mut buffer));
-        recv_data.insert(nbr, (h, buffer));
+        let n_points = recv_counts.get(&nbr).copied().unwrap_or(0) as usize;
+        let mut buf = vec![0u32; n_points];
+        let h = comm.irecv(nbr, tag_len, cast_slice_mut(&mut buf));
+        recv_lens.insert(nbr, (h, buf));
     }
 
-    // 2) pack & post all sends
-    let mut pending_sends = Vec::with_capacity(all_neighbors.len());
-    let mut _keep_alive = Vec::with_capacity(all_neighbors.len());
+    let mut pending_len_sends = Vec::with_capacity(all_neighbors.len());
+    let mut keep_len_send_bufs = Vec::with_capacity(all_neighbors.len());
     for &nbr in all_neighbors {
         let link_vec = links.get(&nbr).map_or(&[][..], |v| &v[..]);
-        let mut scratch = Vec::with_capacity(link_vec.len());
+        let mut lens_out = Vec::<u32>::with_capacity(link_vec.len());
         for &(send_loc, _) in link_vec {
-            let slice = section
-                .try_restrict(send_loc)
-                .map_err(|e| MeshSieveError::SectionAccess {
-                    point: send_loc,
-                    source: Box::new(e),
-                })?;
-            scratch.push(D::restrict(&slice[0]));
+            let slice =
+                section
+                    .try_restrict(send_loc)
+                    .map_err(|e| MeshSieveError::SectionAccess {
+                        point: send_loc,
+                        source: Box::new(e),
+                    })?;
+            lens_out.push(u32::try_from(slice.len()).unwrap_or(u32::MAX));
         }
-        let bytes = cast_slice(&scratch);
-        pending_sends.push(if bytes.is_empty() {
-            comm.isend(nbr, base_tag, &[])
-        } else {
-            comm.isend(nbr, base_tag, bytes)
-        });
-        _keep_alive.push(scratch); // ensure data outlives the nonblocking send
+        let bytes = cast_slice(&lens_out);
+        pending_len_sends.push(comm.isend(nbr, tag_len, bytes));
+        keep_len_send_bufs.push(lens_out);
     }
 
-    // 3) wait+fuse all recvs, capturing only the first error
-    let mut maybe_err: Option<MeshSieveError> = None;
-    let mut recvs: Vec<_> = recv_data.into_iter().collect();
-    for (nbr, (h, mut buffer)) in recvs.drain(..) {
-        match h.wait() {
-            Some(raw) if maybe_err.is_none() => {
-                let buf_bytes = cast_slice_mut(&mut buffer);
-                if raw.len() != buf_bytes.len() {
-                    maybe_err = Some(MeshSieveError::BufferSizeMismatch {
-                        neighbor: nbr,
-                        expected: buf_bytes.len(),
-                        got: raw.len(),
-                    });
-                } else {
-                    buf_bytes.copy_from_slice(&raw);
-                    let parts: &[D::Part] = &buffer;
-                    let link_vec = links.get(&nbr).map_or(&[][..], |v| &v[..]);
-                    if parts.len() != link_vec.len() {
-                        maybe_err = Some(MeshSieveError::PartCountMismatch {
-                            neighbor: nbr,
-                            expected: link_vec.len(),
-                            got: parts.len(),
-                        });
-                    } else {
-                        for ((_, recv_loc), part) in link_vec.iter().zip(parts) {
-                            match section.try_restrict_mut(*recv_loc) {
-                                Ok(mut_slice) => D::fuse(&mut mut_slice[0], *part),
-                                Err(e) => maybe_err = Some(MeshSieveError::SectionAccess {
-                                    point: *recv_loc,
-                                    source: Box::new(e),
-                                }),
-                            }
-                        }
-                    }
-                }
+    let mut lens_in: HashMap<usize, Vec<u32>> = HashMap::with_capacity(all_neighbors.len());
+    for (nbr, (h, mut buf)) in recv_lens {
+        let raw = h.wait().ok_or_else(|| MeshSieveError::CommError {
+            neighbor: nbr,
+            source: "lengths recv returned None".into(),
+        })?;
+        let expect_bytes = buf.len() * std::mem::size_of::<u32>();
+        if raw.len() != expect_bytes {
+            return Err(MeshSieveError::BufferSizeMismatch {
+                neighbor: nbr,
+                expected: expect_bytes,
+                got: raw.len(),
+            });
+        }
+        cast_slice_mut(&mut buf).copy_from_slice(&raw);
+        if buf.len() != recv_counts.get(&nbr).copied().unwrap_or(0) as usize {
+            return Err(MeshSieveError::LengthsCountMismatch {
+                neighbor: nbr,
+                expected: recv_counts.get(&nbr).copied().unwrap_or(0) as usize,
+                got: buf.len(),
+            });
+        }
+        lens_in.insert(nbr, buf);
+    }
+    for s in pending_len_sends {
+        let _ = s.wait();
+    }
+    drop(keep_len_send_bufs);
+
+    // payload phase
+    let mut recv_parts: HashMap<usize, (C::RecvHandle, Vec<D::Part>)> = HashMap::new();
+    for (&nbr, lens) in &lens_in {
+        let total_in: usize = lens.iter().map(|&x| x as usize).sum();
+        let mut buf = vec![D::Part::default(); total_in];
+        let h = comm.irecv(nbr, tag_data, cast_slice_mut(&mut buf));
+        recv_parts.insert(nbr, (h, buf));
+    }
+
+    let mut pending_data_sends = Vec::with_capacity(all_neighbors.len());
+    let mut keep_data_send_bufs = Vec::with_capacity(all_neighbors.len());
+    for &nbr in all_neighbors {
+        let link_vec = links.get(&nbr).map_or(&[][..], |v| &v[..]);
+        let mut flat = Vec::<D::Part>::new();
+        for &(send_loc, _) in link_vec {
+            let slice =
+                section
+                    .try_restrict(send_loc)
+                    .map_err(|e| MeshSieveError::SectionAccess {
+                        point: send_loc,
+                        source: Box::new(e),
+                    })?;
+            for v in slice {
+                flat.push(D::restrict(v));
             }
-            Some(_) | None if maybe_err.is_none() => {
-                // record first communication error
-                maybe_err = Some(MeshSieveError::CommError {
+        }
+        let bytes = cast_slice(&flat);
+        pending_data_sends.push(comm.isend(nbr, tag_data, bytes));
+        keep_data_send_bufs.push(flat);
+    }
+
+    for (nbr, (h, mut buf)) in recv_parts {
+        let raw = h.wait().ok_or_else(|| MeshSieveError::CommError {
+            neighbor: nbr,
+            source: "payload recv returned None".into(),
+        })?;
+        let expect_bytes = buf.len() * std::mem::size_of::<D::Part>();
+        if raw.len() != expect_bytes {
+            return Err(MeshSieveError::BufferSizeMismatch {
+                neighbor: nbr,
+                expected: expect_bytes,
+                got: raw.len(),
+            });
+        }
+        cast_slice_mut(&mut buf).copy_from_slice(&raw);
+
+        let lens = &lens_in[&nbr];
+        let pairs = links.get(&nbr).map_or(&[][..], |v| &v[..]);
+        if lens.len() != pairs.len() {
+            return Err(MeshSieveError::LengthsCountMismatch {
+                neighbor: nbr,
+                expected: pairs.len(),
+                got: lens.len(),
+            });
+        }
+
+        let mut cursor = 0usize;
+        for ((_, recv_loc), &m_u32) in pairs.iter().zip(lens) {
+            let m = m_u32 as usize;
+            let dst =
+                section
+                    .try_restrict_mut(*recv_loc)
+                    .map_err(|e| MeshSieveError::SectionAccess {
+                        point: *recv_loc,
+                        source: Box::new(e),
+                    })?;
+            if dst.len() != m {
+                return Err(MeshSieveError::PayloadCountMismatch {
                     neighbor: nbr,
-                    source: "No data received (wait returned None)".into(),
+                    expected: m,
+                    got: dst.len(),
                 });
             }
-            _ => {}
+            let chunk = &buf[cursor..cursor + m];
+            for (d, &part) in dst.iter_mut().zip(chunk.iter()) {
+                D::fuse(d, part);
+            }
+            cursor += m;
         }
+        debug_assert_eq!(cursor, buf.len(), "payload cursor mismatch");
     }
 
-    // 4) always wait for every send
-    for send in pending_sends {
-        let _ = send.wait();
+    for s in pending_data_sends {
+        let _ = s.wait();
     }
+    drop(keep_data_send_bufs);
 
-    // 5) return error if any
-    if let Some(err) = maybe_err {
-        Err(err)
-    } else {
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -235,11 +311,11 @@ mod tests {
     #[test]
     #[ignore]
     fn test_exchange_data_rayon_comm() {
-        use crate::topology::point::PointId;
+        use crate::algs::completion::data_exchange::exchange_data;
         use crate::data::atlas::Atlas;
         use crate::data::section::Section;
+        use crate::topology::point::PointId;
         use std::collections::HashMap;
-        use crate::algs::completion::data_exchange::exchange_data;
         // Setup: two ranks (0 and 1), each with one value to send/receive
         let base_tag = 42;
         // Use RayonComm for realistic intra-process comm
@@ -262,11 +338,17 @@ mod tests {
 
         // Links and recv_counts for each rank
         let mut links0 = HashMap::new();
-        links0.insert(1, vec![(PointId::new(10).unwrap(), PointId::new(20).unwrap())]);
+        links0.insert(
+            1,
+            vec![(PointId::new(10).unwrap(), PointId::new(20).unwrap())],
+        );
         let mut recv_counts0 = HashMap::new();
         recv_counts0.insert(1, 1);
         let mut links1 = HashMap::new();
-        links1.insert(0, vec![(PointId::new(20).unwrap(), PointId::new(10).unwrap())]);
+        links1.insert(
+            0,
+            vec![(PointId::new(20).unwrap(), PointId::new(10).unwrap())],
+        );
         let mut recv_counts1 = HashMap::new();
         recv_counts1.insert(0, 1);
 
@@ -278,7 +360,8 @@ mod tests {
                 &comm0,
                 base_tag,
                 &mut section0,
-            ).unwrap();
+            )
+            .unwrap();
             (
                 section0.try_restrict(PointId::new(10).unwrap()).unwrap()[0],
                 section0.try_restrict(PointId::new(20).unwrap()).unwrap()[0],
@@ -291,7 +374,8 @@ mod tests {
                 &comm1,
                 base_tag,
                 &mut section1,
-            ).unwrap();
+            )
+            .unwrap();
             (
                 section1.try_restrict(PointId::new(10).unwrap()).unwrap()[0],
                 section1.try_restrict(PointId::new(20).unwrap()).unwrap()[0],
@@ -309,7 +393,10 @@ mod tests {
                 assert_eq!(s1_20, DummyValue(7));
             }
             (Err(e0), Err(e1)) => {
-                panic!("test_exchange_data_rayon_comm: both threads panicked: {:?} | {:?}", e0, e1);
+                panic!(
+                    "test_exchange_data_rayon_comm: both threads panicked: {:?} | {:?}",
+                    e0, e1
+                );
             }
             (Err(e0), _) => {
                 panic!("test_exchange_data_rayon_comm: thread 0 panicked: {:?}", e0);
@@ -320,5 +407,103 @@ mod tests {
             _ => panic!("test_exchange_data_rayon_comm: thread join failed or deadlocked"),
             // unreachable: all cases are covered above
         }
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn test_exchange_data_symmetric_vector_dofs() {
+        use crate::algs::completion::data_exchange::exchange_data_symmetric;
+        use crate::data::atlas::Atlas;
+        use crate::data::section::Section;
+        use crate::topology::point::PointId;
+        use std::collections::{HashMap, HashSet};
+
+        let base_tag = 100u16;
+        let comm0 = crate::algs::communicator::RayonComm::new(0, 2);
+        let comm1 = crate::algs::communicator::RayonComm::new(1, 2);
+
+        let mut atlas0 = Atlas::default();
+        atlas0.try_insert(PointId::new(10).unwrap(), 3);
+        atlas0.try_insert(PointId::new(20).unwrap(), 2);
+        let mut section0 = Section::new(atlas0);
+        section0
+            .try_set(
+                PointId::new(10).unwrap(),
+                &[DummyValue(1), DummyValue(2), DummyValue(3)],
+            )
+            .unwrap();
+        section0
+            .try_set(PointId::new(20).unwrap(), &[DummyValue(0), DummyValue(0)])
+            .unwrap();
+
+        let mut atlas1 = Atlas::default();
+        atlas1.try_insert(PointId::new(10).unwrap(), 3);
+        atlas1.try_insert(PointId::new(20).unwrap(), 2);
+        let mut section1 = Section::new(atlas1);
+        section1
+            .try_set(
+                PointId::new(10).unwrap(),
+                &[DummyValue(0), DummyValue(0), DummyValue(0)],
+            )
+            .unwrap();
+        section1
+            .try_set(PointId::new(20).unwrap(), &[DummyValue(4), DummyValue(5)])
+            .unwrap();
+
+        let mut links0 = HashMap::new();
+        links0.insert(
+            1,
+            vec![(PointId::new(10).unwrap(), PointId::new(20).unwrap())],
+        );
+        let mut links1 = HashMap::new();
+        links1.insert(
+            0,
+            vec![(PointId::new(20).unwrap(), PointId::new(10).unwrap())],
+        );
+
+        let mut recv_counts0 = HashMap::new();
+        recv_counts0.insert(1, 1u32);
+        let mut recv_counts1 = HashMap::new();
+        recv_counts1.insert(0, 1u32);
+
+        let all0: HashSet<usize> = [1usize].into_iter().collect();
+        let all1: HashSet<usize> = [0usize].into_iter().collect();
+
+        let t0 = std::thread::spawn(move || {
+            exchange_data_symmetric::<DummyValue, DummyDelta, crate::algs::communicator::RayonComm>(
+                &links0,
+                &recv_counts0,
+                &comm0,
+                base_tag,
+                &mut section0,
+                &all0,
+            )
+            .unwrap();
+            section0
+                .try_restrict(PointId::new(20).unwrap())
+                .unwrap()
+                .to_vec()
+        });
+        let t1 = std::thread::spawn(move || {
+            exchange_data_symmetric::<DummyValue, DummyDelta, crate::algs::communicator::RayonComm>(
+                &links1,
+                &recv_counts1,
+                &comm1,
+                base_tag,
+                &mut section1,
+                &all1,
+            )
+            .unwrap();
+            section1
+                .try_restrict(PointId::new(10).unwrap())
+                .unwrap()
+                .to_vec()
+        });
+
+        let recv0 = t0.join().unwrap();
+        let recv1 = t1.join().unwrap();
+
+        assert_eq!(recv0, vec![DummyValue(4), DummyValue(5)]);
+        assert_eq!(recv1, vec![DummyValue(1), DummyValue(2), DummyValue(3)]);
     }
 }

--- a/src/mesh_error.rs
+++ b/src/mesh_error.rs
@@ -135,6 +135,20 @@ pub enum MeshSieveError {
         expected: usize,
         got: usize,
     },
+    /// Lengths array count mismatch during data exchange.
+    #[error("Lengths count mismatch for neighbor {neighbor}: expected {expected}, got {got}")]
+    LengthsCountMismatch {
+        neighbor: usize,
+        expected: usize,
+        got: usize,
+    },
+    /// Payload element count mismatch during data exchange.
+    #[error("Payload count mismatch for neighbor {neighbor}: expected {expected}, got {got}")]
+    PayloadCountMismatch {
+        neighbor: usize,
+        expected: usize,
+        got: usize,
+    },
 
     #[error("Overlap link not found for (local={0}, rank={1})")]
     OverlapLinkMissing(crate::topology::point::PointId, usize),
@@ -279,6 +293,30 @@ impl PartialEq for MeshSieveError {
                     got: g1,
                 },
                 PartCountMismatch {
+                    neighbor: n2,
+                    expected: e2,
+                    got: g2,
+                },
+            ) => n1 == n2 && e1 == e2 && g1 == g2,
+            (
+                LengthsCountMismatch {
+                    neighbor: n1,
+                    expected: e1,
+                    got: g1,
+                },
+                LengthsCountMismatch {
+                    neighbor: n2,
+                    expected: e2,
+                    got: g2,
+                },
+            ) => n1 == n2 && e1 == e2 && g1 == g2,
+            (
+                PayloadCountMismatch {
+                    neighbor: n1,
+                    expected: e1,
+                    got: g1,
+                },
+                PayloadCountMismatch {
                     neighbor: n2,
                     expected: e2,
                     got: g2,


### PR DESCRIPTION
## Summary
- add length-prefixed symmetric data exchange that transmits entire point slices
- clarify scalar assumption in existing asymmetric path
- expose detailed mismatch errors for lengths and payload counts

## Testing
- `cargo test --features rayon`


------
https://chatgpt.com/codex/tasks/task_e_68bd175651208329929f1e54c0b6adf0