### PR TITLE
Add typed communicator tags and explicit section completion tagging

### DIFF
--- a/src/algs/completion/mod.rs
+++ b/src/algs/completion/mod.rs
@@ -6,7 +6,7 @@ pub mod sieve_completion;
 pub mod size_exchange;
 pub mod stack_completion;
 
-pub use section_completion::complete_section;
+pub use section_completion::{complete_section, complete_section_with_tags};
 pub use sieve_completion::complete_sieve;
 pub use stack_completion::complete_stack;
 

--- a/src/algs/completion/section_completion.rs
+++ b/src/algs/completion/section_completion.rs
@@ -1,28 +1,28 @@
-//! High‐level “complete_section” that runs neighbour_links → exchange_sizes → exchange_data.
+//! High-level `complete_section` orchestration: neighbour_links → exchange_sizes → exchange_data.
 //!
-//! This module provides the top-level routine for distributed section completion,
-//! orchestrating neighbor-link discovery, size exchange, and data exchange phases.
+//! The public API now accepts explicit [`CommTag`]s for deterministic, collision-free
+//! communication epochs.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
-use crate::mesh_error::MeshSieveError;
-use crate::algs::communicator::Communicator;
+use crate::algs::communicator::{CommTag, Communicator, SectionCommTags};
 use crate::algs::completion::{
     data_exchange,
     neighbour_links::neighbour_links,
     size_exchange::exchange_sizes_symmetric,
 };
 use crate::data::section::Section;
+use crate::mesh_error::MeshSieveError;
 use crate::overlap::delta::ValueDelta;
 use crate::overlap::overlap::Overlap;
 
-pub fn complete_section<V, D, C>(
+/// Complete a section using explicit communication tags.
+pub fn complete_section_with_tags<V, D, C>(
     section: &mut Section<V>,
-    overlap: &mut Overlap,
+    overlap: &Overlap,
     comm: &C,
-    _delta: &D,
     my_rank: usize,
-    _n_ranks: usize,
+    tags: SectionCommTags,
 ) -> Result<(), MeshSieveError>
 where
     V: Clone + Default + Send + PartialEq + 'static,
@@ -30,49 +30,103 @@ where
     D::Part: bytemuck::Pod + Default,
     C: Communicator + Sync,
 {
-    const BASE_TAG: u16 = 0xBEEF;
+    #[cfg(any(debug_assertions, feature = "check-invariants"))]
+    overlap.validate_invariants()?;
 
     // 1) discover which points each neighbor needs
-    let links = neighbour_links(section, overlap, my_rank)
-        .map_err(|e| {
-            MeshSieveError::CommError {
-                neighbor: my_rank, // context: error during neighbour_links
-                source: format!("neighbour_links failed: {}", e).into(),
-            }
-        })?;
+    let links = neighbour_links::<V>(section, overlap, my_rank).map_err(|e| MeshSieveError::CommError {
+        neighbor: my_rank,
+        source: format!("neighbour_links failed: {}", e).into(),
+    })?;
 
-    // 2) Build true neighbor set from actual overlap (both outgoing and incoming)
-    let mut all_neighbors = HashSet::new();
-    
-    // outgoing neighbors (who want data from us)
-    all_neighbors.extend(links.keys().copied());
-    
-    // incoming neighbors (from whom we want data)
-    all_neighbors.extend(overlap.neighbor_ranks());
+    // 2) Build true neighbor set (both outgoing and incoming), deterministically ordered
+    let mut all: BTreeSet<usize> = overlap.neighbor_ranks().collect();
+    all.extend(links.keys().copied());
+    all.remove(&my_rank);
+    let all_neighbors: HashSet<usize> = all.into_iter().collect();
 
     // 3) exchange the item counts
-    let counts = exchange_sizes_symmetric(&links, comm, BASE_TAG, &all_neighbors)
-        .map_err(|e| {
-            MeshSieveError::CommError {
-                neighbor: my_rank, // context: error during size exchange
-                source: format!("exchange_sizes_symmetric failed: {}", e).into(),
-            }
-        })?;
+    let counts = exchange_sizes_symmetric(&links, comm, tags.sizes.as_u16(), &all_neighbors).map_err(|e| {
+        MeshSieveError::CommError {
+            neighbor: my_rank,
+            source: format!("exchange_sizes_symmetric failed: {}", e).into(),
+        }
+    })?;
 
-    // 4) exchange the actual data parts & fuse into our section (MPI needs the symmetric handshake)
+    // 4) exchange the actual data parts & fuse into our section
     data_exchange::exchange_data_symmetric::<V, D, C>(
         &links,
         &counts,
         comm,
-        BASE_TAG + 1,
+        tags.data.as_u16(),
         section,
         &all_neighbors,
     )?;
 
+    #[cfg(debug_assertions)]
+    comm.barrier();
+
     Ok(())
+}
+
+/// Convenience wrapper using a legacy default tag (0xBEEF).
+pub fn complete_section<V, D, C>(
+    section: &mut Section<V>,
+    overlap: &Overlap,
+    comm: &C,
+    my_rank: usize,
+) -> Result<(), MeshSieveError>
+where
+    V: Clone + Default + Send + PartialEq + 'static,
+    D: ValueDelta<V> + Send + Sync + 'static,
+    D::Part: bytemuck::Pod + Default,
+    C: Communicator + Sync,
+{
+    let tags = SectionCommTags::from_base(CommTag::new(0xBEEF));
+    complete_section_with_tags::<V, D, C>(section, overlap, comm, my_rank, tags)
 }
 
 #[cfg(test)]
 mod tests {
-    // TODO: add unit tests for complete_section with a mock Communicator
+    use super::*;
+    use crate::algs::communicator::NoComm;
+    use crate::data::atlas::Atlas;
+    use crate::topology::point::PointId;
+
+    use crate::overlap::delta::CopyDelta;
+
+    // Helper to build a section with points set to their ID as value
+    fn make_section(points: &[u64]) -> Section<i32> {
+        let mut atlas = Atlas::default();
+        for &p in points {
+            atlas.try_insert(PointId::new(p).unwrap(), 1).unwrap();
+        }
+        let mut s = Section::new(atlas);
+        for &p in points {
+            s.try_set(PointId::new(p).unwrap(), &[p as i32]).unwrap();
+        }
+        s
+    }
+
+    #[test]
+    fn unresolved_mapping_errors() {
+        let mut section = make_section(&[1]);
+        let mut ovlp = Overlap::new();
+        // structural link without resolving the remote point
+        ovlp.add_link_structural_one(PointId::new(1).unwrap(), 1);
+        let comm = NoComm;
+        let tags = SectionCommTags::from_base(CommTag::new(0x4100));
+        let res = complete_section_with_tags::<i32, CopyDelta, _>(&mut section, &ovlp, &comm, 0, tags);
+        assert!(matches!(res, Err(MeshSieveError::CommError { neighbor: 0, .. })));
+    }
+
+    #[test]
+    fn no_neighbors_errors() {
+        let mut section = make_section(&[]);
+        let ovlp = Overlap::new();
+        let comm = NoComm;
+        let tags = SectionCommTags::from_base(CommTag::new(0x4200));
+        let res = complete_section_with_tags::<i32, CopyDelta, _>(&mut section, &ovlp, &comm, 0, tags);
+        assert!(matches!(res, Err(MeshSieveError::CommError { neighbor: 0, .. })));
+    }
 }

--- a/tests/communicator_tests.rs
+++ b/tests/communicator_tests.rs
@@ -2,32 +2,32 @@ use mesh_sieve::algs::communicator::{CommTag, Communicator, RayonComm, Wait};
 
 #[test]
 fn rayon_round_trip() {
-    let tag = CommTag(0x1000);
+    let tag = CommTag::new(0x1000);
     let c0 = RayonComm::new(0, 2);
     let c1 = RayonComm::new(1, 2);
 
     let msg = b"hello";
-    let _s = c0.isend(1, tag.base(), msg);
+    let _s = c0.isend(1, tag.as_u16(), msg);
 
     let mut buf = [0u8; 5];
-    let h = c1.irecv(0, tag.base(), &mut buf);
+    let h = c1.irecv(0, tag.as_u16(), &mut buf);
     let got = h.wait().unwrap();
     assert_eq!(&got, msg);
 }
 
 #[test]
 fn rayon_fifo_order() {
-    let tag = CommTag(0x1001);
+    let tag = CommTag::new(0x1001);
     let c0 = RayonComm::new(0, 2);
     let c1 = RayonComm::new(1, 2);
 
     for i in 0..10u8 {
-        let _ = c0.isend(1, tag.base(), &[i]);
+        let _ = c0.isend(1, tag.as_u16(), &[i]);
     }
     let mut out = Vec::new();
     for _ in 0..10 {
         let mut b = [0u8; 1];
-        let h = c1.irecv(0, tag.base(), &mut b);
+        let h = c1.irecv(0, tag.as_u16(), &mut b);
         out.push(h.wait().unwrap()[0]);
     }
     assert_eq!(out, (0u8..10u8).collect::<Vec<_>>());
@@ -35,13 +35,13 @@ fn rayon_fifo_order() {
 
 #[test]
 fn truncation_is_ok() {
-    let tag = CommTag(0x1002);
+    let tag = CommTag::new(0x1002);
     let c0 = RayonComm::new(0, 2);
     let c1 = RayonComm::new(1, 2);
 
-    let _ = c0.isend(1, tag.base(), &[1, 2, 3, 4, 5, 6]);
+    let _ = c0.isend(1, tag.as_u16(), &[1, 2, 3, 4, 5, 6]);
     let mut b = [0u8; 4];
-    let h = c1.irecv(0, tag.base(), &mut b);
+    let h = c1.irecv(0, tag.as_u16(), &mut b);
     let got = h.wait().unwrap();
     assert_eq!(got, vec![1, 2, 3, 4]);
 }

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -22,11 +22,10 @@ fn ghost_update_self() {
     let mut sec = Section::<u32>::new(atlas);
     sec.try_set(p0, &[42]).expect("Failed to set section value");
 
-    let mut comm = RayonComm::new(0, 1);
-    let delta = CopyDelta;
+    let comm = RayonComm::new(0, 1);
 
     // Should complete without deadlock and leave the value intact.
-    let _ = complete_section(&mut sec, &mut ovlp, &mut comm, &delta, 0, 1);
+    let _ = complete_section::<u32, CopyDelta, _>(&mut sec, &ovlp, &comm, 0);
 
     assert_eq!(sec.try_restrict(p0).expect("Failed to restrict section")[0], 42);
 }


### PR DESCRIPTION
## Summary
- introduce `CommTag` newtype and `SectionCommTags` helper for phase-safe tag allocation
- allow `complete_section` to accept explicit tags via `complete_section_with_tags`
- add regression tests for unresolved mappings and missing overlap

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bd1a1ff96c8329b841c415e3e0213f