### PR TITLE
Refactor sieve completion for minimal, symmetric protocol

### DIFF
--- a/src/algs/completion/mod.rs
+++ b/src/algs/completion/mod.rs
@@ -7,7 +7,9 @@ pub mod size_exchange;
 pub mod stack_completion;
 
 pub use section_completion::{complete_section, complete_section_with_tags};
-pub use sieve_completion::complete_sieve;
+pub use sieve_completion::{
+    complete_sieve, complete_sieve_until_converged, complete_sieve_with_tags,
+};
 pub use stack_completion::complete_stack;
 
 pub fn partition_point(rank: usize) -> crate::topology::point::PointId {

--- a/src/algs/completion/sieve_completion.rs
+++ b/src/algs/completion/sieve_completion.rs
@@ -1,257 +1,240 @@
-//! Complete missing sieve arrows across ranks using fixed wire triples.
+//! Complete missing sieve arrows across ranks using minimal wire arrows.
 //!
-//! This module provides routines for synchronizing and completing sieve arrows
-//! across distributed ranks, using packed wire triples for efficient communication.
-//! It supports iterative completion until convergence and ensures DAG invariants.
+//! The protocol performs a symmetric two-phase exchange:
+//! 1. Each rank sends the number of arrows it will send to every neighbor.
+//! 2. Ranks exchange the actual `(src,dst)` arrow pairs, already translated into
+//!    the receiver's local `PointId` space via the [`Overlap`] mapping.
+//!
+//! The wire payload is reduced to two `u64` integers (`WireArrow`), removing
+//! dependencies on remote ranks or mesh payloads. Inserted edges carry the
+//! `Default` payload of the mesh's `Sieve` implementation.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 
-use bytemuck::Zeroable;
+use bytemuck::{cast_slice, cast_slice_mut, Zeroable};
 
-use crate::algs::communicator::Wait;
-use crate::algs::wire::{WireArrowTriple, WireCount};
+use crate::algs::communicator::{CommTag, Communicator, SieveCommTags, Wait};
+use crate::algs::completion::size_exchange::exchange_sizes_symmetric;
+use crate::algs::wire::WireArrow;
 use crate::mesh_error::MeshSieveError;
-use crate::overlap::overlap::{local, OvlId, Remote};
-use crate::prelude::{Communicator, Overlap};
-use crate::topology::cache::InvalidateCache;
+use crate::overlap::overlap::Overlap;
 use crate::topology::point::PointId;
-use crate::topology::sieve::InMemorySieve;
 use crate::topology::sieve::sieve_trait::Sieve;
 
-/// Complete missing sieve arrows across ranks.
-///
-/// Exchanges arrow‐counts and arrow‐payloads in two symmetric phases,
-/// always waiting on every nonblocking send/recv before returning.
-pub fn complete_sieve<C: Communicator>(
-    sieve: &mut InMemorySieve<PointId, Remote>,
+/// Translate a local `PointId` into the neighbor's ID space using the
+/// [`Overlap`] mapping.
+fn remote_id_for(overlap: &Overlap, nbr: usize, local: PointId) -> Result<PointId, MeshSieveError> {
+    overlap
+        .links_to(nbr)
+        .find(|(p, _)| *p == local)
+        .and_then(|(_, rp)| rp)
+        .ok_or_else(|| MeshSieveError::MissingOverlap {
+            source: format!(
+                "Unresolved mapping for local {} to neighbor {}",
+                local.get(),
+                nbr
+            )
+            .into(),
+        })
+}
+
+/// Build per-neighbor buffers of [`WireArrow`] records, expressed in the
+/// receiver's ID space.
+fn build_wires<S: Sieve<Point = PointId>>(
+    mesh: &S,
+    overlap: &Overlap,
+    neighbors: &[usize],
+) -> Result<HashMap<usize, Vec<WireArrow>>, MeshSieveError> {
+    let mut srcs_per_nbr: HashMap<usize, Vec<PointId>> = HashMap::new();
+    for &nbr in neighbors {
+        let mut srcs: Vec<PointId> = overlap.links_to(nbr).map(|(p, _)| p).collect();
+        srcs.sort_unstable();
+        srcs.dedup();
+        srcs_per_nbr.insert(nbr, srcs);
+    }
+
+    let mut est_cap: HashMap<usize, usize> = HashMap::new();
+    for (&nbr, srcs) in &srcs_per_nbr {
+        let mut sum = 0usize;
+        for &s in srcs {
+            sum += mesh.cone_points(s).count();
+        }
+        est_cap.insert(nbr, sum);
+    }
+
+    let mut wires: HashMap<usize, Vec<WireArrow>> = HashMap::new();
+    for (&nbr, srcs) in &srcs_per_nbr {
+        let mut buf = Vec::with_capacity(*est_cap.get(&nbr).unwrap_or(&0));
+        for &src_local in srcs {
+            let src_remote = remote_id_for(overlap, nbr, src_local)?;
+            let mut dsts: Vec<PointId> = mesh.cone_points(src_local).collect();
+            dsts.sort_unstable();
+            dsts.dedup();
+            for dst_local in dsts {
+                let dst_remote = remote_id_for(overlap, nbr, dst_local)?;
+                buf.push(WireArrow::new(src_remote.get(), dst_remote.get()));
+            }
+        }
+        buf.sort_unstable_by_key(|w| (w.src(), w.dst()));
+        buf.dedup_by_key(|w| (w.src(), w.dst()));
+        wires.insert(nbr, buf);
+    }
+    Ok(wires)
+}
+
+/// Complete missing sieve arrows using explicit communication tags.
+pub fn complete_sieve_with_tags<S, C>(
+    mesh: &mut S,
     overlap: &Overlap,
     comm: &C,
     my_rank: usize,
-) -> Result<(), MeshSieveError> {
-    const BASE_TAG: u16 = 0xC0DE;
+    tags: SieveCommTags,
+) -> Result<(), MeshSieveError>
+where
+    S: Sieve<Point = PointId>,
+    S::Payload: Default + Clone + Send + 'static,
+    C: Communicator + Sync,
+{
+    #[cfg(any(debug_assertions, feature = "check-invariants"))]
+    overlap.validate_invariants()?;
 
-    // 0) nothing to do for serial / single‐rank
-    if comm.is_no_comm() || comm.size() <= 1 {
-        sieve.strata.take();
+    // Determine deterministic neighbor set (exclude self)
+    let mut nb: BTreeSet<usize> = overlap.neighbor_ranks().collect();
+    nb.remove(&my_rank);
+    let neighbors: Vec<usize> = nb.iter().copied().collect();
+
+    // Build wire buffers (checks for unresolved mappings)
+    let wires = build_wires(mesh, overlap, &neighbors)?;
+
+    if comm.is_no_comm() || comm.size() <= 1 || neighbors.is_empty() {
+        mesh.invalidate_cache();
         return Ok(());
     }
 
-    // 1) Who needs which arrows?
-    let mut nb_links: HashMap<usize, Vec<(PointId, PointId)>> = HashMap::new();
-    for (&p, outs) in &sieve.adjacency_out {
-        for (_d, _) in outs {
-            for (_d2, rem) in overlap.cone(local(p)) {
-                if rem.rank != my_rank {
-                    nb_links
-                        .entry(rem.rank)
-                        .or_default()
-                        .push((p, rem.remote_point.expect("overlap unresolved")));
-                }
-            }
-        }
-    }
-    if nb_links.is_empty() {
-        let me_pt = Overlap::partition_node_id(my_rank);
-        for (src, rem) in overlap.support(me_pt) {
-            if rem.rank != my_rank {
-                if let OvlId::Local(src_pt) = src {
-                    nb_links
-                        .entry(rem.rank)
-                        .or_default()
-                        .push((rem.remote_point.expect("overlap unresolved"), src_pt));
-                }
-            }
-        }
+    let all_neighbors: HashSet<usize> = neighbors.iter().copied().collect();
+
+    // Phase 1: exchange counts
+    let counts = exchange_sizes_symmetric(&wires, comm, tags.sizes.as_u16(), &all_neighbors)?;
+
+    // Phase 2: exchange payloads
+    let mut recv_payloads = Vec::new();
+    for &nbr in &neighbors {
+        let n_items = counts.get(&nbr).copied().unwrap_or(0) as usize;
+        let mut buf = vec![WireArrow::zeroed(); n_items];
+        let h = comm.irecv(nbr, tags.data.as_u16(), cast_slice_mut(&mut buf));
+        recv_payloads.push((nbr, h, buf));
     }
 
-    // Peers to talk to
-    let peers: Vec<usize> = (0..comm.size()).filter(|&r| r != my_rank).collect();
+    let mut pending_sends = Vec::new();
+    for &nbr in &neighbors {
+        let out = wires.get(&nbr).map_or(&[][..], |v| &v[..]);
+        pending_sends.push(comm.isend(nbr, tags.data.as_u16(), cast_slice(out)));
+    }
 
-    // We'll accumulate all send‐handles here (phase1 + phase2)
-    let mut pending_sends: Vec<C::SendHandle> = Vec::new();
-    // And collect any error we see, but still drain all handles before returning
     let mut maybe_err: Option<MeshSieveError> = None;
-
-    // --- Phase 1: exchange counts ---------------------------------------
-    // 1a) post all receives for counts
-    let mut size_recvs: Vec<(usize, C::RecvHandle, WireCount)> =
-        Vec::with_capacity(peers.len());
-    for &peer in &peers {
-        let mut cnt = WireCount::new(0);
-        let h = comm.irecv(peer, BASE_TAG, bytemuck::cast_slice_mut(std::slice::from_mut(&mut cnt)));
-        size_recvs.push((peer, h, cnt));
-    }
-    // 1b) post all sends for counts
-    for &peer in &peers {
-        let cnt = WireCount::new(nb_links.get(&peer).map(|v| v.len()).unwrap_or(0));
-        pending_sends.push(comm.isend(peer, BASE_TAG, bytemuck::cast_slice(std::slice::from_ref(&cnt))));
-    }
-    // 1c) wait for all count‐recvs
-    let mut sizes_in: HashMap<usize, usize> = HashMap::new();
-    for (peer, h, mut cnt) in size_recvs {
+    for (nbr, h, mut buf) in recv_payloads {
         match h.wait() {
-            Some(data) if data.len() == std::mem::size_of::<WireCount>() => {
-                let bytes = bytemuck::cast_slice_mut(std::slice::from_mut(&mut cnt));
-                bytes.copy_from_slice(&data);
-                sizes_in.insert(peer, cnt.get());
-            }
-            Some(data) => {
-                maybe_err.get_or_insert_with(|| MeshSieveError::CommError {
-                    neighbor: peer,
-                    source: Box::new(crate::mesh_error::CommError(format!(
-                        "expected {} bytes for size from {}, got {}",
-                        std::mem::size_of::<WireCount>(),
-                        peer,
-                        data.len()
-                    ))),
-                });
-            }
-            None => {
-                maybe_err.get_or_insert_with(|| MeshSieveError::CommError {
-                    neighbor: peer,
-                    source: Box::new(crate::mesh_error::CommError(format!(
-                        "failed to recv size from {}",
-                        peer
-                    ))),
-                });
-            }
-        }
-    }
-
-    // --- Phase 2: exchange actual WireArrowTriple payloads -------------------
-    // 2a) post all receives for triples
-    let mut data_recvs: Vec<(usize, C::RecvHandle, Vec<WireArrowTriple>)> =
-        Vec::with_capacity(peers.len());
-    for &peer in &peers {
-        let n = *sizes_in.get(&peer).unwrap_or(&0);
-        let mut buffer = vec![WireArrowTriple::zeroed(); n];
-        let bytes = bytemuck::cast_slice_mut(buffer.as_mut_slice());
-        let h = comm.irecv(peer, BASE_TAG + 1, bytes);
-        data_recvs.push((peer, h, buffer));
-    }
-    // 2b) post all sends of our triples
-    for &peer in &peers {
-        let mut triples = Vec::new();
-        if let Some(links) = nb_links.get(&peer) {
-            for &(src, _) in links {
-                if let Some(outs) = sieve.adjacency_out.get(&src) {
-                    for (d, payload) in outs {
-                        triples.push(WireArrowTriple::new(
-                            src.get(),
-                            d.get(),
-                            payload.remote_point.expect("overlap unresolved").get(),
-                            payload.rank as u32,
-                        ));
-                    }
+            Some(raw) if raw.len() == buf.len() * core::mem::size_of::<WireArrow>() => {
+                cast_slice_mut(&mut buf).copy_from_slice(&raw);
+                for w in &buf {
+                    let src = PointId::new(w.src())
+                        .map_err(|e| MeshSieveError::MeshError(Box::new(e)))?;
+                    let dst = PointId::new(w.dst())
+                        .map_err(|e| MeshSieveError::MeshError(Box::new(e)))?;
+                    mesh.add_arrow(src, dst, S::Payload::default());
                 }
             }
-        }
-        let bytes = bytemuck::cast_slice(&triples);
-        // always post a send, even if empty
-        pending_sends.push(comm.isend(peer, BASE_TAG + 1, bytes));
-    }
-
-    // 3) wait + integrate all triple‐recvs
-    let mut inserted = std::collections::HashSet::new();
-    for (peer, h, mut buffer) in data_recvs {
-        match h.wait() {
-            Some(raw)
-                if raw.len() == buffer.len() * std::mem::size_of::<WireArrowTriple>() =>
-            {
-                let view = bytemuck::cast_slice_mut(buffer.as_mut_slice());
-                view.copy_from_slice(&raw);
-                for t in &buffer {
-                    let (src, dst, remote_point, rank) = t.decode();
-                    match (
-                        PointId::new(src),
-                        PointId::new(dst),
-                        PointId::new(remote_point),
-                    ) {
-                        (Ok(src_pt), Ok(dst_pt), Ok(rem_pt)) => {
-                            let payload = Remote {
-                                rank: rank as usize,
-                                remote_point: Some(rem_pt),
-                            };
-                            if inserted.insert((src_pt, dst_pt)) {
-                                sieve
-                                    .adjacency_out
-                                    .entry(src_pt)
-                                    .or_default()
-                                    .push((dst_pt, payload));
-                                sieve
-                                    .adjacency_in
-                                    .entry(dst_pt)
-                                    .or_default()
-                                    .push((src_pt, payload));
-                            }
-                        }
-                        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
-                            maybe_err.get_or_insert_with(|| MeshSieveError::MeshError(Box::new(e)));
-                        }
-                    }
-                }
-            }
-            Some(raw) => {
-                maybe_err.get_or_insert_with(|| MeshSieveError::CommError {
-                    neighbor: peer,
-                    source: Box::new(crate::mesh_error::CommError(format!(
-                        "expected {} bytes for triples from {}, got {}",
-                        buffer.len() * std::mem::size_of::<WireArrowTriple>(),
-                        peer,
+            Some(raw) if maybe_err.is_none() => {
+                maybe_err = Some(MeshSieveError::CommError {
+                    neighbor: nbr,
+                    source: format!(
+                        "payload size mismatch: expected {}B, got {}B",
+                        buf.len() * core::mem::size_of::<WireArrow>(),
                         raw.len()
-                    ))),
+                    )
+                    .into(),
                 });
             }
-            None => {
-                maybe_err.get_or_insert_with(|| MeshSieveError::CommError {
-                    neighbor: peer,
-                    source: Box::new(crate::mesh_error::CommError(format!(
-                        "failed to recv triples from {}",
-                        peer
-                    ))),
+            None if maybe_err.is_none() => {
+                maybe_err = Some(MeshSieveError::CommError {
+                    neighbor: nbr,
+                    source: "recv returned None".into(),
                 });
             }
+            _ => {}
         }
     }
 
-    // Invalidate cached strata
-    sieve.strata.take();
-
-    // 4) always drain all sends
-    for send in pending_sends {
-        let _ = send.wait();
+    for s in pending_sends {
+        let _ = s.wait();
     }
 
-    // 5) finally, propagate error or success
-    if let Some(err) = maybe_err {
-        Err(err)
+    mesh.invalidate_cache();
+
+    if let Some(e) = maybe_err {
+        Err(e)
     } else {
         Ok(())
     }
 }
 
-/// Iteratively completes the sieve until no new points/arrows are added.
-pub fn complete_sieve_until_converged(
-    sieve: &mut InMemorySieve<PointId, Remote>,
+/// Convenience wrapper using a legacy default tag (0xC0DE).
+pub fn complete_sieve<S, C>(
+    mesh: &mut S,
     overlap: &Overlap,
-    comm: &impl Communicator,
+    comm: &C,
     my_rank: usize,
-) -> Result<(), MeshSieveError> {
+) -> Result<(), MeshSieveError>
+where
+    S: Sieve<Point = PointId>,
+    S::Payload: Default + Clone + Send + 'static,
+    C: Communicator + Sync,
+{
+    let tags = SieveCommTags::from_base(CommTag::new(0xC0DE));
+    complete_sieve_with_tags(mesh, overlap, comm, my_rank, tags)
+}
+
+/// Iteratively complete the sieve until no new points or arrows are added.
+pub fn complete_sieve_until_converged<S, C>(
+    mesh: &mut S,
+    overlap: &Overlap,
+    comm: &C,
+    my_rank: usize,
+) -> Result<(), MeshSieveError>
+where
+    S: Sieve<Point = PointId>,
+    S::Payload: Default + Clone + Send + 'static,
+    C: Communicator + Sync,
+{
     let mut prev = std::collections::HashSet::new();
     loop {
-        let before: std::collections::HashSet<_> = sieve.points().collect();
-        complete_sieve(sieve, overlap, comm, my_rank)?;
-        let after: std::collections::HashSet<_> = sieve.points().collect();
+        let before: std::collections::HashSet<_> = mesh.points().collect();
+        complete_sieve(mesh, overlap, comm, my_rank)?;
+        let after: std::collections::HashSet<_> = mesh.points().collect();
         if after == before || after == prev {
             break;
         }
         prev = after.clone();
-        InvalidateCache::invalidate_cache(sieve);
+        mesh.invalidate_cache();
     }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    // TODO: add tests for complete_sieve with a mock Communicator
+    use super::*;
+    use crate::algs::communicator::NoComm;
+
+    #[test]
+    fn unresolved_mapping_errors() {
+        let mut mesh = crate::topology::sieve::InMemorySieve::<PointId, ()>::default();
+        mesh.add_arrow(PointId::new(1).unwrap(), PointId::new(2).unwrap(), ());
+        let mut ovlp = Overlap::new();
+        ovlp.add_link_structural_one(PointId::new(1).unwrap(), 1);
+        ovlp.add_link_structural_one(PointId::new(2).unwrap(), 1);
+        let comm = NoComm;
+        let tags = SieveCommTags::from_base(CommTag::new(0x4200));
+        let res = complete_sieve_with_tags(&mut mesh, &ovlp, &comm, 0, tags);
+        assert!(matches!(res, Err(MeshSieveError::MissingOverlap { .. })));
+    }
 }

--- a/src/algs/wire.rs
+++ b/src/algs/wire.rs
@@ -1,7 +1,7 @@
 //! Fixed, versioned, little-endian wire types for completion paths.
 
 use bytemuck::{Pod, Zeroable};
-use std::mem::{align_of, size_of};
+use std::mem::size_of;
 
 /// Bump when the layout or semantics change in incompatible ways.
 pub const WIRE_VERSION: u16 = 1;
@@ -15,16 +15,24 @@ pub const WIRE_VERSION: u16 = 1;
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct WireHdr {
     pub version_le: u16,  // = WIRE_VERSION.to_le()
-    pub kind_le:    u16,  // 1 = Cone, 2 = Support, etc.
+    pub kind_le: u16,     // 1 = Cone, 2 = Support, etc.
     pub reserved_le: u32, // future use; keep zero
 }
 
 impl WireHdr {
     pub fn new(kind: u16) -> Self {
-        Self { version_le: WIRE_VERSION.to_le(), kind_le: kind.to_le(), reserved_le: 0 }
+        Self {
+            version_le: WIRE_VERSION.to_le(),
+            kind_le: kind.to_le(),
+            reserved_le: 0,
+        }
     }
-    pub fn kind(&self) -> u16 { u16::from_le(self.kind_le) }
-    pub fn version(&self) -> u16 { u16::from_le(self.version_le) }
+    pub fn kind(&self) -> u16 {
+        u16::from_le(self.kind_le)
+    }
+    pub fn version(&self) -> u16 {
+        u16::from_le(self.version_le)
+    }
 }
 
 #[repr(C)]
@@ -33,8 +41,14 @@ pub struct WireCount {
     pub n_le: u32, // count of following records
 }
 impl WireCount {
-    pub fn new(n: usize) -> Self { Self { n_le: (n as u32).to_le() } }
-    pub fn get(&self) -> usize { u32::from_le(self.n_le) as usize }
+    pub fn new(n: usize) -> Self {
+        Self {
+            n_le: (n as u32).to_le(),
+        }
+    }
+    pub fn get(&self) -> usize {
+        u32::from_le(self.n_le) as usize
+    }
 }
 
 /// A point id (u64) carried on the wire.
@@ -44,11 +58,15 @@ pub struct WirePoint {
     pub id_le: u64,
 }
 impl WirePoint {
-    pub fn of(id: u64) -> Self { Self { id_le: id.to_le() } }
-    pub fn get(&self) -> u64 { u64::from_le(self.id_le) }
+    pub fn of(id: u64) -> Self {
+        Self { id_le: id.to_le() }
+    }
+    pub fn get(&self) -> u64 {
+        u64::from_le(self.id_le)
+    }
 }
 
-/// An adjacency pair (src, dst) — used in closure/support replies.
+/// An adjacency pair (src, dst) — used in closure/support replies and sieve arrows.
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct WireAdj {
@@ -56,44 +74,22 @@ pub struct WireAdj {
     pub dst_le: u64,
 }
 impl WireAdj {
-    pub fn new(src: u64, dst: u64) -> Self { Self { src_le: src.to_le(), dst_le: dst.to_le() } }
-    pub fn src(&self) -> u64 { u64::from_le(self.src_le) }
-    pub fn dst(&self) -> u64 { u64::from_le(self.dst_le) }
-}
-
-// ===== Sieve completion ====================================================
-
-/// Arrow triple used by sieve completion.
-/// NOTE: `rank_le` is u32 (never usize) on the wire.
-#[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
-pub struct WireArrowTriple {
-    pub src_le:         u64,
-    pub dst_le:         u64,
-    pub remote_point_le:u64,
-    pub rank_le:        u32, // remote rank
-    pub _pad:           u32, // pad to 8-byte alignment (explicit)
-}
-impl WireArrowTriple {
-    pub const SIZE: usize = 32; // 3*8 + 4 + 4
-    pub fn new(src: u64, dst: u64, remote: u64, rank: u32) -> Self {
+    pub fn new(src: u64, dst: u64) -> Self {
         Self {
             src_le: src.to_le(),
             dst_le: dst.to_le(),
-            remote_point_le: remote.to_le(),
-            rank_le: rank.to_le(),
-            _pad: 0,
         }
     }
-    pub fn decode(&self) -> (u64, u64, u64, u32) {
-        (
-            u64::from_le(self.src_le),
-            u64::from_le(self.dst_le),
-            u64::from_le(self.remote_point_le),
-            u32::from_le(self.rank_le),
-        )
+    pub fn src(&self) -> u64 {
+        u64::from_le(self.src_le)
+    }
+    pub fn dst(&self) -> u64 {
+        u64::from_le(self.dst_le)
     }
 }
+
+/// Minimal arrow record used for sieve completion (already in receiver IDs).
+pub type WireArrow = WireAdj;
 
 // ===== Stack completion (base, cap, payload) ==============================
 
@@ -105,31 +101,37 @@ pub const WIRE_PAYLOAD_MAX: usize = 16; // example cap; set to your actual need
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct WireStackTriple {
     pub base_le: u64,
-    pub cap_le:  u64,
+    pub cap_le: u64,
     /// Opaque payload bytes. Producer and consumer must agree on its meaning.
-    pub pay:     [u8; WIRE_PAYLOAD_MAX],
+    pub pay: [u8; WIRE_PAYLOAD_MAX],
 }
 impl WireStackTriple {
     pub fn new(base: u64, cap: u64, pay: &[u8]) -> Self {
         let mut buf = [0u8; WIRE_PAYLOAD_MAX];
         let n = pay.len().min(WIRE_PAYLOAD_MAX);
         buf[..n].copy_from_slice(&pay[..n]);
-        Self { base_le: base.to_le(), cap_le: cap.to_le(), pay: buf }
+        Self {
+            base_le: base.to_le(),
+            cap_le: cap.to_le(),
+            pay: buf,
+        }
     }
-    pub fn base(&self) -> u64 { u64::from_le(self.base_le) }
-    pub fn cap(&self) -> u64 { u64::from_le(self.cap_le) }
+    pub fn base(&self) -> u64 {
+        u64::from_le(self.base_le)
+    }
+    pub fn cap(&self) -> u64 {
+        u64::from_le(self.cap_le)
+    }
 }
 
 // ===== Compile-time sanity checks =========================================
 
 const _: () = {
     // Pod/Zeroable ensures no padding contains uninit when cast to bytes.
-    assert!(size_of::<WireHdr>()        == 8);
-    assert!(size_of::<WireCount>()      == 4);
-    assert!(size_of::<WirePoint>()      == 8);
-    assert!(size_of::<WireAdj>()        == 16);
-    assert!(size_of::<WireArrowTriple>()== WireArrowTriple::SIZE);
-    assert!(align_of::<WireArrowTriple>() == 8);
+    assert!(size_of::<WireHdr>() == 8);
+    assert!(size_of::<WireCount>() == 4);
+    assert!(size_of::<WirePoint>() == 8);
+    assert!(size_of::<WireAdj>() == 16);
 };
 
 #[cfg(test)]
@@ -149,20 +151,20 @@ mod tests {
 
     #[test]
     fn roundtrip_arrow() {
-        let t = WireArrowTriple::new(1, 2, 3, 4);
-        let bytes: Vec<u8> = cast_slice(&[t]).to_vec();
-        let mut out = vec![WireArrowTriple::zeroed(); 1];
+        let v = vec![WireAdj::new(1, 2), WireAdj::new(3, 4)];
+        let bytes: Vec<u8> = cast_slice(&v).to_vec();
+        let mut out = vec![WireAdj::zeroed(); v.len()];
         cast_slice_mut(&mut out).copy_from_slice(&bytes);
-        assert_eq!(out[0].decode(), (1,2,3,4));
-        assert_eq!(WireArrowTriple::SIZE, std::mem::size_of::<WireArrowTriple>());
+        assert_eq!(out[0].src(), 1);
+        assert_eq!(out[1].dst(), 4);
     }
 
     #[test]
     fn roundtrip_stack() {
-        let pay = [1u8,2,3,4];
+        let pay = [1u8, 2, 3, 4];
         let t = WireStackTriple::new(10, 20, &pay);
         let bytes: Vec<u8> = cast_slice(&[t]).to_vec();
-        let mut out = vec![WireStackTriple::zeroed();1];
+        let mut out = vec![WireStackTriple::zeroed(); 1];
         cast_slice_mut(&mut out).copy_from_slice(&bytes);
         assert_eq!(out[0].base(), 10);
         assert_eq!(out[0].cap(), 20);
@@ -175,4 +177,3 @@ mod tests {
         assert_eq!(hdr.version(), WIRE_VERSION);
     }
 }
-

--- a/src/overlap/overlap.rs
+++ b/src/overlap/overlap.rs
@@ -115,6 +115,15 @@ pub struct Remote {
     pub remote_point: Option<PointId>,
 }
 
+impl Default for Remote {
+    fn default() -> Self {
+        Self {
+            rank: 0,
+            remote_point: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct Overlap {
     inner: InMemorySieve<OvlId, Remote>,


### PR DESCRIPTION
## Summary
- Add `SieveCommTags` for typed, phase-safe sieve completion tags
- Replace triple-based wire payload with `WireArrow` pair format
- Rework sieve completion to build per-neighbor `WireArrow` buffers and exchange counts/data symmetrically

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c576f78832994c74fcc172e76cc