### PR TITLE
Refactor completion exchanges for typed tags and draining

### DIFF
--- a/examples/mpi_complete_stack.rs
+++ b/examples/mpi_complete_stack.rs
@@ -35,9 +35,13 @@ fn main() {
         remote_point: PodU64,
     }
     impl mesh_sieve::algs::completion::stack_completion::HasRank for DummyRemote {
-        fn rank(&self) -> usize {
-            self.rank
+        fn rank_u32(&self) -> u32 {
+            self.rank as u32
         }
+    }
+    impl mesh_sieve::algs::completion::stack_completion::WirePoint for PodU64 {
+        fn to_wire(self) -> u64 { self.0 }
+        fn from_wire(w: u64) -> Self { PodU64(w) }
     }
     let comm = MpiComm::default();
     let world = &comm.world;

--- a/src/algs/communicator.rs
+++ b/src/algs/communicator.rs
@@ -72,6 +72,13 @@ impl CommTag {
     }
 }
 
+impl From<u16> for CommTag {
+    #[inline]
+    fn from(x: u16) -> Self {
+        CommTag::new(x)
+    }
+}
+
 /// Convenience bundle of tags for the multi-phase section completion.
 #[derive(Copy, Clone, Debug)]
 pub struct SectionCommTags {
@@ -102,6 +109,26 @@ pub struct SieveCommTags {
 }
 
 impl SieveCommTags {
+    /// Construct tags from a base, assigning deterministic offsets per phase.
+    #[inline]
+    pub const fn from_base(base: CommTag) -> Self {
+        Self {
+            sizes: base,
+            data: base.offset(1),
+        }
+    }
+}
+
+/// Convenience bundle of tags for stack completion.
+#[derive(Copy, Clone, Debug)]
+pub struct StackCommTags {
+    /// Tag used during the size exchange phase.
+    pub sizes: CommTag,
+    /// Tag used during the data exchange phase.
+    pub data: CommTag,
+}
+
+impl StackCommTags {
     /// Construct tags from a base, assigning deterministic offsets per phase.
     #[inline]
     pub const fn from_base(base: CommTag) -> Self {

--- a/src/algs/completion/mod.rs
+++ b/src/algs/completion/mod.rs
@@ -8,7 +8,7 @@ pub mod stack_completion;
 
 pub use section_completion::{complete_section, complete_section_with_tags};
 pub use sieve_completion::{complete_sieve, complete_sieve_with_tags};
-pub use stack_completion::complete_stack;
+pub use stack_completion::{complete_stack, complete_stack_with_tags};
 
 pub fn partition_point(rank: usize) -> crate::topology::point::PointId {
     crate::topology::point::PointId::new((rank as u64) + 1)

--- a/src/algs/completion/section_completion.rs
+++ b/src/algs/completion/section_completion.rs
@@ -45,7 +45,7 @@ where
     let all_neighbors: HashSet<usize> = all.into_iter().collect();
 
     // 3) exchange the item counts
-    let counts = exchange_sizes_symmetric(&links, comm, tags.sizes.as_u16(), &all_neighbors)
+    let counts = exchange_sizes_symmetric(&links, comm, tags.sizes, &all_neighbors)
         .map_err(|e| MeshSieveError::CommError {
             neighbor: my_rank,
             source: format!("exchange_sizes_symmetric failed: {e}").into(),

--- a/src/algs/completion/sieve_completion.rs
+++ b/src/algs/completion/sieve_completion.rs
@@ -115,7 +115,7 @@ where
     let wires = build_wires(mesh, overlap, &neighbors)?;
 
     // Phase 1: symmetric exchange of counts
-    let counts = exchange_sizes_symmetric(&wires, comm, tags.sizes.as_u16(), &all_neighbors)?;
+    let counts = exchange_sizes_symmetric(&wires, comm, tags.sizes, &all_neighbors)?;
 
     // Phase 2: payload exchange
     let mut recvs = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@ pub mod prelude {
     pub use crate::algs::communicator::MpiComm;
     #[cfg(feature = "rayon")]
     pub use crate::algs::communicator::RayonComm;
-    pub use crate::algs::completion::{complete_section, complete_sieve, complete_stack};
+    pub use crate::algs::completion::{
+        complete_section, complete_sieve, complete_stack, complete_stack_with_tags,
+    };
     pub use crate::algs::rcm::distributed_rcm;
     pub use crate::data::atlas::Atlas;
     pub use crate::data::section::{Map, Section};

--- a/tests/size_exchange_tests.rs
+++ b/tests/size_exchange_tests.rs
@@ -1,0 +1,58 @@
+use std::collections::{HashMap, HashSet};
+
+use mesh_sieve::algs::communicator::{CommTag, Communicator, NoComm, RayonComm, Wait};
+use mesh_sieve::algs::completion::size_exchange::{
+    exchange_sizes, exchange_sizes_symmetric,
+};
+
+#[test]
+fn zero_neighbors_asymmetric() {
+    let links: HashMap<usize, Vec<u8>> = HashMap::new();
+    let res = exchange_sizes(&links, &NoComm, CommTag::new(0x10));
+    assert!(res.unwrap().is_empty());
+}
+
+#[test]
+fn zero_neighbors_symmetric() {
+    let links: HashMap<usize, Vec<u8>> = HashMap::new();
+    let neighbors: HashSet<usize> = HashSet::new();
+    let res = exchange_sizes_symmetric(&links, &NoComm, CommTag::new(0x11), &neighbors);
+    assert!(res.unwrap().is_empty());
+}
+
+#[test]
+fn mismatch_drain() {
+    let tag = CommTag::new(0x12);
+    let c0 = RayonComm::new(0, 3);
+    let c1 = RayonComm::new(1, 3);
+    let c2 = RayonComm::new(2, 3);
+
+    // Neighbor 1 sends malformed count (3 bytes)
+    let _ = c1.isend(0, tag.as_u16(), &[1, 2, 3]);
+    let mut r1 = [0u8; 4];
+    let h1 = c1.irecv(0, tag.as_u16(), &mut r1);
+
+    // Neighbor 2 sends correct 4-byte count
+    let _ = c2.isend(0, tag.as_u16(), &[0, 0, 0, 0]);
+    let mut r2 = [0u8; 4];
+    let h2 = c2.irecv(0, tag.as_u16(), &mut r2);
+
+    let mut links: HashMap<usize, Vec<u8>> = HashMap::new();
+    links.insert(1, vec![]);
+    links.insert(2, vec![]);
+
+    let res = exchange_sizes(&links, &c0, tag);
+    assert!(res.is_err());
+
+    // Our sends to both neighbors should complete
+    assert_eq!(h1.wait().unwrap().len(), 4);
+    assert_eq!(h2.wait().unwrap().len(), 4);
+}
+
+#[test]
+fn commtag_round_trip() {
+    let val = 0xABCD;
+    let tag = CommTag::new(val);
+    assert_eq!(tag.as_u16(), val);
+}
+


### PR DESCRIPTION
## Summary
- switch size exchanges to typed `CommTag` and drain all handles even on error
- introduce `StackCommTags` and a symmetric stack completion using fixed-width wire records
- derive stack completion neighbor set from overlap instead of sweeping all ranks
- add regression tests for size exchange edge cases

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd226bc82c8329912588b940636abc