### PR TITLE
Add integration test utilities and edge-case suites

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ proptest = "1.0"
 rand_chacha = "0.3"
 criterion = "0.4"
 env_logger = "0.11"
+rayon = "1"
 
 [features]
 default = []            # keep core lean

--- a/tests/communicator_parity.rs
+++ b/tests/communicator_parity.rs
@@ -1,0 +1,62 @@
+mod util;
+use util::*;
+
+use mesh_sieve::algs::communicator::{Communicator, Wait, NoComm};
+use bytemuck::{Pod, Zeroable, cast_slice};
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, Debug, PartialEq, Eq)]
+struct WireU64 { x: u64 }
+
+#[test]
+fn no_comm_is_nop() {
+    let comm = NoComm;
+    assert!(comm.is_no_comm());
+    let mut buf = [0u8; 8];
+    let h = comm.irecv(0, 123, &mut buf);
+    assert!(h.wait().is_none());
+    let s = comm.isend(0, 123, &[]);
+    assert!(s.wait().is_none());
+}
+
+#[test]
+fn rayon_comm_roundtrip_and_tag_isolation() {
+    let (c0, c1) = rayons();
+
+    const TAG_A: u16 = 0xA100;
+    const TAG_B: u16 = 0xB200;
+
+    let mut buf_a = [0u8; core::mem::size_of::<WireU64>()];
+    let mut buf_b = [0u8; core::mem::size_of::<WireU64>()];
+    let rxa = c1.irecv(0, TAG_A, &mut buf_a);
+    let rxb = c1.irecv(0, TAG_B, &mut buf_b);
+
+    let wa = [WireU64 { x: 0xDEAD_BEEF_F00D_F00D }];
+    let wb = [WireU64 { x: 0x0123_4567_89AB_CDEF }];
+    c0.isend(1, TAG_B, cast_slice(&wb));
+    c0.isend(1, TAG_A, cast_slice(&wa));
+
+    let ra = rxa.wait().expect("rxa");
+    let rb = rxb.wait().expect("rxb");
+    assert_eq!(&ra[..], cast_slice(&wa));
+    assert_eq!(&rb[..], cast_slice(&wb));
+}
+
+#[cfg(feature = "mpi-support")]
+#[test]
+fn mpi_comm_smoke_if_available() {
+    use mesh_sieve::algs::communicator::MpiComm;
+    let world = MpiComm::new();
+    let me = world.rank();
+    let n = world.size();
+    const TAG: u16 = 0xCAFE;
+    let to = (me + 1) % n;
+    let from = (me + n - 1) % n;
+    let tx = [42u8, me as u8, 0, 0];
+    let mut rx = [0u8; 4];
+    let r = world.irecv(from, TAG, &mut rx);
+    let s = world.isend(to, TAG, &tx);
+    let got = r.wait().expect("mpi rx");
+    assert_eq!(got, tx);
+    let _ = s.wait();
+}

--- a/tests/dual_graph.rs
+++ b/tests/dual_graph.rs
@@ -1,0 +1,25 @@
+mod util;
+use util::*;
+use mesh_sieve::algs::dual_graph::build_dual_with_order;
+
+#[test]
+fn non_manifold_three_cells_share_one_face_is_clique() {
+    let arrows = &[
+        (1, 10), (1, 11),
+        (2, 10), (2, 12),
+        (3, 10), (3, 13),
+    ];
+    let sieve = sieve_from(arrows);
+    let (dg, order) = build_dual_with_order(&sieve, [pid(1), pid(2), pid(3)]);
+    let mut edges = Vec::new();
+    for i in 0..order.len() {
+        let start = dg.xadj[i];
+        let end = dg.xadj[i + 1];
+        for &j in &dg.adjncy[start..end] {
+            if i < j { edges.push((i, j)); }
+        }
+    }
+    edges.sort_unstable();
+    let want = vec![(0,1),(0,2),(1,2)];
+    assert_eq!(edges, want, "dual graph should be K3 for a face shared by three cells");
+}

--- a/tests/lattice_policy.rs
+++ b/tests/lattice_policy.rs
@@ -1,0 +1,19 @@
+mod util;
+use util::*;
+use mesh_sieve::algs::lattice::{adjacent_with, AdjacencyOpts};
+
+#[test]
+fn face_only_vs_vertex_expansion_differs() {
+    let arrows = &[
+        (1, 10), (1, 11), (10, 100), (11, 101),
+        (2, 12), (2, 13), (12, 100), (13, 102),
+        (2, 100),
+    ];
+    let sieve = sieve_from(arrows);
+
+    let a1 = adjacent_with(&sieve, pid(1), AdjacencyOpts { max_down_depth: Some(1), same_stratum_only: true });
+    assert!(a1.iter().all(|&p| p != pid(2)));
+
+    let a2 = adjacent_with(&sieve, pid(1), AdjacencyOpts { max_down_depth: Some(2), same_stratum_only: true });
+    assert!(a2.contains(&pid(2)));
+}

--- a/tests/rcm.rs
+++ b/tests/rcm.rs
@@ -1,0 +1,40 @@
+mod util;
+use util::*;
+use mesh_sieve::algs::rcm::{distributed_rcm, distributed_rcm_with, RcmAdjacency};
+use mesh_sieve::algs::communicator::NoComm;
+use mesh_sieve::topology::sieve::Sieve;
+
+fn path_sieve(n: usize) -> mesh_sieve::topology::sieve::InMemorySieve<mesh_sieve::topology::point::PointId, ()> {
+    let mut s = mesh_sieve::topology::sieve::InMemorySieve::<_, ()>::default();
+    for i in 0..n - 1 {
+        s.add_arrow(pid((i + 1) as u64), pid((i + 2) as u64), ());
+        s.add_arrow(pid((i + 2) as u64), pid((i + 1) as u64), ());
+    }
+    s
+}
+
+#[test]
+fn rcm_path_bandwidth_is_one_and_is_permutation() {
+    let s = path_sieve(6);
+    let comm = NoComm;
+    let order_pts = distributed_rcm_with(&s, &comm, RcmAdjacency::Undirected);
+    let mut pts: Vec<_> = s.base_points().collect();
+    pts.sort_unstable_by_key(|p| p.get());
+    let n = pts.len();
+    let idx_of = |p: mesh_sieve::topology::point::PointId| -> usize { (p.get() - 1) as usize };
+    let perm: Vec<usize> = order_pts.iter().map(|&p| idx_of(p)).collect();
+    assert_eq!(perm.len(), n);
+    let want: Vec<usize> = (0..n).collect();
+    assert_permutation(&perm, &want);
+    let edges: Vec<(usize, usize)> = (0..n - 1).map(|i| (i, i + 1)).collect();
+    assert_eq!(bandwidth(&perm, &edges), 1);
+}
+
+#[test]
+fn rcm_undirected_equals_default() {
+    let s = path_sieve(5);
+    let comm = NoComm;
+    let undirected = distributed_rcm_with(&s, &comm, RcmAdjacency::Undirected);
+    let default = distributed_rcm(&s, &comm);
+    assert_eq!(undirected, default);
+}

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,0 +1,29 @@
+mod util;
+use util::*;
+use mesh_sieve::algs::reduction::{transitive_reduction_dag, transitive_closure_edges};
+use mesh_sieve::topology::sieve::Sieve;
+
+#[test]
+fn transitive_reduction_removes_implied_edge() {
+    let mut s = sieve_from(&[(1,2),(2,3),(1,3)]);
+    let removed = transitive_reduction_dag(&mut s).expect("DAG");
+    assert_eq!(removed, 1);
+    let cone1: Vec<_> = s.cone_points(pid(1)).collect();
+    assert!(!cone1.contains(&pid(3)));
+    assert!(cone1.contains(&pid(2)));
+}
+
+#[test]
+fn transitive_closure_edges_reports_missing_edges() {
+    let mut s = sieve_from(&[(1,2),(2,3)]);
+    let edges = transitive_closure_edges(&mut s).expect("ok");
+    assert!(edges.contains(&(pid(1), pid(3))));
+}
+
+#[test]
+fn cycle_detection_bubbles_error() {
+    let mut s = sieve_from(&[(1,2),(2,1)]);
+    let err = transitive_reduction_dag(&mut s).err().expect("should error");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("Cycle") || msg.contains("chart"), "{msg}");
+}

--- a/tests/section_completion.rs
+++ b/tests/section_completion.rs
@@ -1,0 +1,71 @@
+mod util;
+use util::*;
+use mesh_sieve::{
+    algs::completion::section_completion::complete_section,
+    data::{atlas::Atlas, section::Section},
+    overlap::{delta::ValueDelta, overlap::Overlap},
+};
+
+#[derive(Clone, Default, PartialEq, Debug)]
+struct Vec3([f64; 3]);
+
+#[derive(Copy, Clone)]
+struct AvgDelta;
+impl ValueDelta<Vec3> for AvgDelta {
+    type Part = [f64; 3];
+    fn restrict(v: &Vec3) -> Self::Part { v.0 }
+    fn fuse(local: &mut Vec3, incoming: Self::Part) {
+        for i in 0..3 {
+            local.0[i] = 0.5 * (local.0[i] + incoming[i]);
+        }
+    }
+}
+
+#[test]
+fn complete_section_vec3_happy_path() {
+    let (c0, c1) = rayons();
+
+    let mut ov0 = Overlap::default();
+    ov0.add_link(pid(1), 1, pid(101));
+
+    let mut ov1 = Overlap::default();
+    ov1.add_link(pid(101), 0, pid(1));
+
+    let mut sec0 = Section::<Vec3>::new(Atlas::default());
+    sec0.try_add_point(pid(1), 1).unwrap();
+    sec0.try_add_point(pid(101), 1).unwrap();
+    sec0.try_restrict_mut(pid(1)).unwrap()[0] = Vec3([1.0, 2.0, 3.0]);
+
+    let mut sec1 = Section::<Vec3>::new(Atlas::default());
+    sec1.try_add_point(pid(101), 1).unwrap();
+    sec1.try_add_point(pid(1), 1).unwrap();
+    sec1.try_restrict_mut(pid(101)).unwrap()[0] = Vec3([1.0, 2.0, 3.0]);
+
+    let handle = std::thread::spawn(move || {
+        let mut s1 = sec1;
+        complete_section::<Vec3, AvgDelta, _>(&mut s1, &ov1, &c1, 1).unwrap();
+    });
+    complete_section::<Vec3, AvgDelta, _>(&mut sec0, &ov0, &c0, 0).unwrap();
+    handle.join().unwrap();
+
+    let got = &sec0.try_restrict(pid(1)).unwrap()[0];
+    assert_eq!(got, &Vec3([1.0, 2.0, 3.0]));
+}
+
+#[test]
+fn complete_section_missing_overlap_errors() {
+    let (c0, _c1) = rayons();
+
+    let mut ov = Overlap::default();
+    ov.add_link_structural_one(pid(2), 1);
+
+    let mut sec = Section::<Vec3>::new(Atlas::default());
+    sec.try_add_point(pid(2), 1).unwrap();
+    sec.try_restrict_mut(pid(2)).unwrap()[0] = Vec3([9.0, 9.0, 9.0]);
+
+    let err = complete_section::<Vec3, AvgDelta, _>(&mut sec, &ov, &c0, 0)
+        .err()
+        .expect("should fail");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("Overlap link not found"), "{msg}");
+}

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+use mesh_sieve::{
+    algs::communicator::RayonComm,
+    topology::point::PointId,
+    topology::sieve::{InMemorySieve, Sieve},
+};
+
+pub fn pid(u: u64) -> PointId { PointId::new(u).unwrap() }
+
+/// Build a sieve from arrows (u -> v) with unit payload ().
+pub fn sieve_from(arrows: &[(u64, u64)]) -> InMemorySieve<PointId, ()> {
+    let mut s = InMemorySieve::<PointId, ()>::default();
+    for &(u, v) in arrows {
+        s.add_arrow(pid(u), pid(v), ());
+    }
+    s
+}
+
+/// Two-rank Rayon comms (ranks 0 and 1).
+pub fn rayons() -> (RayonComm, RayonComm) {
+    (RayonComm::new(0, 2), RayonComm::new(1, 2))
+}
+
+/// Assert vec is a permutation of another vec (order-agnostic).
+pub fn assert_permutation<T: Ord + Copy + std::fmt::Debug>(got: &[T], want: &[T]) {
+    let mut a = got.to_vec();
+    a.sort_unstable();
+    let mut b = want.to_vec();
+    b.sort_unstable();
+    assert_eq!(a, b, "not a permutation\n got={:?}\nwant={:?}", got, want);
+}
+
+/// Bandwidth of an ordering π over an undirected simple graph E (u,v).
+pub fn bandwidth(order: &[usize], edges: &[(usize, usize)]) -> usize {
+    let mut pos = vec![0usize; order.len()];
+    for (i, &v) in order.iter().enumerate() {
+        pos[v] = i;
+    }
+    edges
+        .iter()
+        .map(|&(u, v)| pos[u].abs_diff(pos[v]))
+        .max()
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## Summary
- add shared test utilities and rayon dev-dependency
- cover communicator parity, dual graph clique, lattice adjacency, section completion, RCM, and reduction

## Testing
- `cargo test --test communicator_parity --test dual_graph --test lattice_policy --test rcm --test reduction --test section_completion`


------
https://chatgpt.com/codex/tasks/task_e_68bd336cbe148329ac6505b598ec1055