### PR TITLE
Fix examples for new completion API

### DIFF
--- a/examples/comprehensive_mesh_workflow.rs
+++ b/examples/comprehensive_mesh_workflow.rs
@@ -486,8 +486,9 @@ fn test_distributed_completion(
         );
 
         // Test section completion
-        let delta = CopyDelta;
-        if let Err(e) = complete_section(&mut section, &mut overlap, comm, rank) {
+        if let Err(e) =
+            complete_section::<i32, CopyDelta, MpiComm>(&mut section, &overlap, comm, rank)
+        {
             println!("[rank {}] Section completion failed: {:?}", rank, e);
         } else {
             println!("[rank {}] Section completion succeeded", rank);

--- a/examples/mpi_complete.rs
+++ b/examples/mpi_complete.rs
@@ -65,13 +65,12 @@ fn main() {
     }
 
     // Debug: print neighbour links before exchange
-    let links =
-        mesh_sieve::algs::completion::neighbour_links::neighbour_links(&sec, &mut ovlp, rank);
+    let links = mesh_sieve::algs::completion::neighbour_links::neighbour_links(&sec, &ovlp, rank);
     println!("[rank {}] neighbour_links: {:?}", rank, links);
 
     // 6) Perform the two-phase exchange
-    let delta = CopyDelta;
-    complete_section(&mut sec, &mut ovlp, &comm, &delta, rank, size);
+    complete_section::<u32, CopyDelta, MpiComm>(&mut sec, &ovlp, &comm, rank)
+        .expect("section completion failed");
 
     // 7) Check the result
     if rank == 0 {

--- a/examples/mpi_complete_multiple_neighbors.rs
+++ b/examples/mpi_complete_multiple_neighbors.rs
@@ -91,8 +91,8 @@ pub fn main() {
         sec.try_set(PointId::new(2).unwrap(), &[2])
             .expect("Failed to set value for PointId 2");
     }
-    let delta = CopyDelta;
-    let _ = complete_section(&mut sec, &mut ovlp, &comm, &delta, rank, size);
+    complete_section::<u32, CopyDelta, MpiComm>(&mut sec, &ovlp, &comm, rank)
+        .expect("section completion failed");
     match rank {
         0 => {
             assert_eq!(

--- a/examples/mpi_complete_no_overlap.rs
+++ b/examples/mpi_complete_no_overlap.rs
@@ -37,8 +37,8 @@ fn main() {
             .expect("Failed to set section value");
     }
     let mut ovlp = Overlap::default();
-    let delta = CopyDelta;
-    complete_section(&mut sec, &mut ovlp, &comm, rank);
+    complete_section::<u32, CopyDelta, MpiComm>(&mut sec, &ovlp, &comm, rank)
+        .expect("section completion failed");
     if rank == 2 {
         match sec.try_restrict(PointId::new(2).unwrap()) {
             Ok(values) => assert_eq!(values[0], 42),

--- a/examples/mpi_complete_stack.rs
+++ b/examples/mpi_complete_stack.rs
@@ -39,7 +39,7 @@ fn main() {
             self.rank as u32
         }
     }
-    impl mesh_sieve::algs::completion::stack_completion::WirePoint for PodU64 {
+    impl mesh_sieve::algs::wire::WirePoint for PodU64 {
         fn to_wire(self) -> u64 {
             self.0
         }


### PR DESCRIPTION
## Summary
- update MPI section completion examples for new complete_section signature
- fix stack completion example to use public WirePoint trait

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68be6cb16afc8329a56fea759b426dac