### PR TITLE
Make CSR freeze fallible and add checked accessors

### DIFF
--- a/src/mesh_error.rs
+++ b/src/mesh_error.rs
@@ -26,6 +26,9 @@ pub enum MeshSieveError {
     /// A point appeared in a cone but wasn’t in the initial point set.
     #[error("Topology error: point `{0}` found in cone but not in point set")]
     MissingPointInCone(String),
+    /// Attempted to access a point that is not present in the CSR chart.
+    #[error("Topology error: point `{0}` not present in chart")]
+    UnknownPoint(String),
     /// The mesh topology contains a cycle; expected a DAG.
     #[error("Topology error: cycle detected in mesh (expected DAG)")]
     CycleDetected,
@@ -191,6 +194,7 @@ impl PartialEq for MeshSieveError {
             | (PartitionPointOverflow, PartitionPointOverflow) => true,
             (UnsupportedStackOperation(a), UnsupportedStackOperation(b)) => a == b,
             (MissingPointInCone(a), MissingPointInCone(b)) => a == b,
+            (UnknownPoint(a), UnknownPoint(b)) => a == b,
             (DuplicatePoint(a), DuplicatePoint(b)) => a == b,
             (MissingAtlasPoint(a), MissingAtlasPoint(b)) => a == b,
             (PointNotInAtlas(a), PointNotInAtlas(b)) => a == b,

--- a/src/topology/sieve/mod.rs
+++ b/src/topology/sieve/mod.rs
@@ -38,7 +38,7 @@ pub mod traversal_iter;
 
 // Re-export the core trait and in‐memory impl at top level
 pub use build_ext::SieveBuildExt;
-pub use frozen_csr::{FrozenSieveCsr, freeze_csr};
+pub use frozen_csr::{FrozenSieveCsr, freeze_csr, try_freeze_csr};
 pub use in_memory::InMemorySieve;
 pub use in_memory_det::InMemorySieveDeterministic;
 pub use in_memory_oriented::InMemoryOrientedSieve;


### PR DESCRIPTION
## Summary
- add `UnknownPoint` error and fallible CSR freezing via `try_from_sieve` / `try_freeze_csr`
- provide checked cone/support accessors for `FrozenSieveCsr`
- avoid panics on unknown points by returning empty iterators and zero degrees
- test CSR freezing errors and non-panicking accessors

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c10b00e7648329a23dbaac6e940bcf