### PR TITLE
Rename arrow Orientation to Polarity

### DIFF
--- a/docs/topology-api.md
+++ b/docs/topology-api.md
@@ -16,7 +16,7 @@ This guide explains the design and usage of `mesh-sieve`’s topology layer: poi
 
 ## Module map
 
-* `arrow` – arrow type (with payload) and a small `Orientation` enum for stacks.
+* `arrow` – arrow type (with payload) and a small `Polarity` enum for stacks.
 * `point` – `PointId` newtype over `NonZeroU64`.
 * `orientation` – compact orientation groups (bit flip, rotations, dihedral, permutations) implementing `sieve::oriented::Orientation` (group structure).
 * `sieve` – core trait and implementations:

--- a/examples/comprehensive_mesh_workflow.rs
+++ b/examples/comprehensive_mesh_workflow.rs
@@ -36,7 +36,7 @@ fn main() {
     // use mesh_sieve::overlap::overlap::{Overlap, Remote};
     use mesh_sieve::algs::dual_graph::build_dual;
     use mesh_sieve::prelude::*;
-    use mesh_sieve::topology::arrow::Orientation;
+    use mesh_sieve::topology::arrow::Polarity;
     use mesh_sieve::topology::point::PointId;
     use mesh_sieve::topology::sieve::{InMemorySieve, Sieve};
     use mesh_sieve::topology::stack::{InMemoryStack, Stack};
@@ -156,7 +156,7 @@ fn build_hierarchical_tetrahedral_mesh() -> (
 ) {
     use mesh_sieve::prelude::Stack;
     use mesh_sieve::prelude::*;
-    use mesh_sieve::topology::arrow::Orientation;
+    use mesh_sieve::topology::arrow::Polarity;
 
     println!("[rank 0] Building hierarchical tetrahedral mesh...");
 
@@ -212,7 +212,7 @@ fn build_hierarchical_tetrahedral_mesh() -> (
 
     // Create refined mesh with DOF hierarchy
     let mut refined_mesh = mesh.clone();
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
 
     // Add refinement: each face gets 3 DOF points
     for (i, &face) in faces.iter().enumerate() {
@@ -221,9 +221,9 @@ fn build_hierarchical_tetrahedral_mesh() -> (
             let dof_id = PointId::new(1000 + i as u64 * 10 + j as u64).unwrap();
             atlas.try_insert(dof_id, 1).unwrap();
             let orientation = if j % 2 == 0 {
-                Orientation::Forward
+                Polarity::Forward
             } else {
-                Orientation::Reverse
+                Polarity::Reverse
             };
             let _ = stack.add_arrow(face, dof_id, orientation);
             mesh_sieve::topology::Sieve::add_point(&mut refined_mesh, dof_id);
@@ -503,7 +503,7 @@ fn test_distributed_completion(
 fn test_bundle_operations(rank: usize) {
     println!("[rank {}] Testing Bundle operations...", rank);
     use mesh_sieve::prelude::*;
-    use mesh_sieve::topology::arrow::Orientation;
+    use mesh_sieve::topology::arrow::Polarity;
 
     // Create test bundle
     let mut atlas = Atlas::default();
@@ -518,9 +518,9 @@ fn test_bundle_operations(rank: usize) {
     let mut section = Section::<f64>::new(atlas);
     section.try_set(base1, &[1.0, 2.0]).unwrap();
 
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
-    let _ = stack.add_arrow(base1, cap1, Orientation::Forward);
-    let _ = stack.add_arrow(base1, cap2, Orientation::Reverse);
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
+    let _ = stack.add_arrow(base1, cap1, Polarity::Forward);
+    let _ = stack.add_arrow(base1, cap2, Polarity::Reverse);
 
     let mut bundle = Bundle {
         stack,

--- a/examples/e2e_showcase.rs
+++ b/examples/e2e_showcase.rs
@@ -1,7 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::refine::sieved_array::SievedArray;
 use mesh_sieve::data::section::Section;
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::Sieve;
 
@@ -28,15 +28,15 @@ fn check_parallel_refine_matches_serial(
     q1: PointId,
 ) {
     use mesh_sieve::data::refine::sieved_array::SievedArray;
-    use mesh_sieve::topology::arrow::Orientation;
+    use mesh_sieve::topology::arrow::Polarity;
 
     let mut src = SievedArray::<PointId, f64>::new(atlas.clone());
     for (p, sl) in sec.iter() {
         src.try_set(p, sl).unwrap();
     }
     let sifter = vec![
-        (q0, vec![(q0, Orientation::Forward)]),
-        (q1, vec![(q1, Orientation::Reverse)]),
+        (q0, vec![(q0, Polarity::Forward)]),
+        (q1, vec![(q1, Polarity::Reverse)]),
     ];
 
     let mut serial = SievedArray::<PointId, f64>::new(atlas.clone());
@@ -90,8 +90,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         coarse.try_set(p, sl)?;
     }
     let sifter = vec![
-        (q0, vec![(q0, Orientation::Forward)]),
-        (q1, vec![(q1, Orientation::Reverse)]),
+        (q0, vec![(q0, Polarity::Forward)]),
+        (q1, vec![(q1, Polarity::Reverse)]),
     ];
 
     fine.try_refine_with_sifter(&coarse, &sifter)?;

--- a/examples/support/tiny_mesh.rs
+++ b/examples/support/tiny_mesh.rs
@@ -1,26 +1,26 @@
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::{InMemorySieve, Sieve};
 
 /// Build a tiny oriented primal mesh: two quads with one shared edge.
 /// One shared edge between `Q0` and `Q1` has reversed orientation to
 /// exercise delta logic.
-pub fn tiny_oriented_mesh() -> InMemorySieve<PointId, Orientation> {
-    let mut s: InMemorySieve<PointId, Orientation> = InMemorySieve::default();
+pub fn tiny_oriented_mesh() -> InMemorySieve<PointId, Polarity> {
+    let mut s: InMemorySieve<PointId, Polarity> = InMemorySieve::default();
     let e = |i: u64| PointId::new(100 + i).unwrap();
     let q = |i: u64| PointId::new(200 + i).unwrap();
 
     // Q0 edges (Forward, Forward, Reverse, Forward)
-    Sieve::add_arrow(&mut s, q(0), e(0), Orientation::Forward);
-    Sieve::add_arrow(&mut s, q(0), e(1), Orientation::Forward);
-    Sieve::add_arrow(&mut s, q(0), e(2), Orientation::Reverse); // reversed shared edge
-    Sieve::add_arrow(&mut s, q(0), e(3), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(0), e(0), Polarity::Forward);
+    Sieve::add_arrow(&mut s, q(0), e(1), Polarity::Forward);
+    Sieve::add_arrow(&mut s, q(0), e(2), Polarity::Reverse); // reversed shared edge
+    Sieve::add_arrow(&mut s, q(0), e(3), Polarity::Forward);
 
     // Q1 edges (all Forward) sharing edge e(2)
-    Sieve::add_arrow(&mut s, q(1), e(2), Orientation::Forward);
-    Sieve::add_arrow(&mut s, q(1), e(4), Orientation::Forward);
-    Sieve::add_arrow(&mut s, q(1), e(5), Orientation::Forward);
-    Sieve::add_arrow(&mut s, q(1), e(6), Orientation::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(2), Polarity::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(4), Polarity::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(5), Polarity::Forward);
+    Sieve::add_arrow(&mut s, q(1), e(6), Polarity::Forward);
 
     s
 }

--- a/src/data/bundle.rs
+++ b/src/data/bundle.rs
@@ -100,12 +100,12 @@ where
 ///
 /// # Fields
 /// - `stack`: vertical arrows from base mesh points → cap (DOF) points,
-///      carrying an `Orientation` payload if needed.
+///      carrying a `Polarity` payload if needed.
 /// - `section`: contiguous storage of data `V` for each point in the atlas.
 /// - `delta`: rules for extracting (`restrict`) and merging (`fuse`) values.
 pub struct Bundle<V, D = CopyDelta> {
     /// Vertical connectivity: base points → cap (DOF) points.
-    pub stack: InMemoryStack<PointId, PointId, crate::topology::arrow::Orientation>,
+    pub stack: InMemoryStack<PointId, PointId, crate::topology::arrow::Polarity>,
     /// Field data storage, indexed by `PointId`.
     pub section: Section<V>,
     /// Delta strategy for refine/assemble operations.
@@ -130,7 +130,7 @@ where
     ///
     /// # Determinism
     /// Deterministic **per cap point slice**, independent of traversal order, provided
-    /// the vertical mapping `base -> {caps}` has no duplicates. Orientation handling
+    /// the vertical mapping `base -> {caps}` has no duplicates. Polarity handling
     /// is local to each write.
     ///
     /// # Errors
@@ -236,7 +236,7 @@ mod tests {
     use super::*;
     use crate::data::atlas::Atlas;
     use crate::overlap::delta::CopyDelta;
-    use crate::topology::arrow::Orientation;
+    use crate::topology::arrow::Polarity;
     #[test]
     fn bundle_basic_refine_and_assemble() {
         let mut atlas = Atlas::default();
@@ -247,16 +247,16 @@ mod tests {
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(1).unwrap(), &[10]).unwrap();
         section.try_set(PointId::new(2).unwrap(), &[20]).unwrap();
-        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let _ = stack.add_arrow(
             PointId::new(2).unwrap(),
             PointId::new(102).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let mut bundle = Bundle {
             stack,
@@ -312,7 +312,7 @@ mod tests {
     fn empty_bundle_noop() {
         let atlas = Atlas::default();
         let section = Section::<i32>::new(atlas.clone());
-        let stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let mut bundle = Bundle {
             stack,
             section,
@@ -332,11 +332,11 @@ mod tests {
         section
             .try_set(PointId::new(1).unwrap(), &[10, 20])
             .unwrap();
-        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let mut bundle = Bundle {
             stack,
@@ -359,11 +359,11 @@ mod tests {
         atlas.try_insert(PointId::new(101).unwrap(), 2).unwrap();
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(1).unwrap(), &[1, 2]).unwrap();
-        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
-            Orientation::Reverse,
+            Polarity::Reverse,
         );
         let mut bundle = Bundle {
             stack,
@@ -391,16 +391,16 @@ mod tests {
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(101).unwrap(), &[5]).unwrap();
         section.try_set(PointId::new(102).unwrap(), &[7]).unwrap();
-        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(102).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let mut bundle = Bundle {
             stack,
@@ -427,16 +427,16 @@ mod tests {
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(101).unwrap(), &[8]).unwrap();
         section.try_set(PointId::new(102).unwrap(), &[9]).unwrap();
-        let mut stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(102).unwrap(),
-            Orientation::Forward,
+            Polarity::Forward,
         );
         let bundle = Bundle {
             stack,
@@ -459,7 +459,7 @@ mod tests {
     fn refine_unknown_base_errors() {
         let atlas = Atlas::default();
         let section = Section::<i32>::new(atlas.clone());
-        let stack = InMemoryStack::<PointId, PointId, Orientation>::new();
+        let stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         let mut bundle = Bundle {
             stack,
             section,

--- a/src/data/refine/mod.rs
+++ b/src/data/refine/mod.rs
@@ -17,8 +17,8 @@ pub use helpers::{
 pub use helpers::{try_restrict_closure_vec_parallel, try_restrict_star_vec_parallel};
 pub use sieved_array::SievedArray;
 
-/// A sifter is a vector of (PointId, Orientation) pairs for refinement.
+/// A sifter is a vector of (PointId, Polarity) pairs for refinement.
 pub type Sifter = Vec<(
     crate::topology::point::PointId,
-    crate::topology::arrow::Orientation,
+    crate::topology::arrow::Polarity,
 )>;

--- a/src/data/refine/sieved_array.rs
+++ b/src/data/refine/sieved_array.rs
@@ -6,7 +6,7 @@
 
 use crate::data::atlas::Atlas;
 use crate::data::refine::delta::SliceDelta;
-use crate::topology::arrow::Orientation;
+use crate::topology::arrow::Polarity;
 use crate::topology::point::PointId;
 
 /// A generic array of values indexed by mesh points, supporting refinement and assembly.
@@ -154,7 +154,7 @@ where
     pub fn try_refine_with_sifter(
         &mut self,
         coarse: &SievedArray<P, V>,
-        refinement: &[(P, Vec<(P, Orientation)>)],
+        refinement: &[(P, Vec<(P, Polarity)>)],
     ) -> Result<(), crate::mesh_error::MeshSieveError> {
         use crate::mesh_error::MeshSieveError;
 
@@ -214,7 +214,7 @@ where
     ) -> Result<(), crate::mesh_error::MeshSieveError> {
         let sifter: Vec<_> = refinement
             .iter()
-            .map(|(c, fs)| (*c, fs.iter().map(|f| (*f, Orientation::Forward)).collect()))
+            .map(|(c, fs)| (*c, fs.iter().map(|f| (*f, Polarity::Forward)).collect()))
             .collect();
         self.try_refine_with_sifter(coarse, &sifter)
     }
@@ -223,7 +223,7 @@ where
     pub fn refine_with_sifter(
         &mut self,
         coarse: &SievedArray<P, V>,
-        refinement: &[(P, Vec<(P, Orientation)>)],
+        refinement: &[(P, Vec<(P, Polarity)>)],
     ) {
         self.try_refine_with_sifter(coarse, refinement).unwrap()
     }
@@ -319,7 +319,7 @@ where
     pub fn try_refine_with_sifter_parallel(
         &mut self,
         coarse: &Self,
-        refinement: &[(P, Vec<(P, Orientation)>)],
+        refinement: &[(P, Vec<(P, Polarity)>)],
     ) -> Result<(), crate::mesh_error::MeshSieveError> {
         use crate::mesh_error::MeshSieveError;
         use std::collections::HashMap;
@@ -389,7 +389,7 @@ mod tests {
     use crate::data::atlas::Atlas;
     use crate::data::refine::sieved_array::SievedArray;
     use crate::mesh_error::MeshSieveError;
-    use crate::topology::arrow::Orientation;
+    use crate::topology::arrow::Polarity;
     use crate::topology::point::PointId;
 
     fn pt(i: u64) -> PointId {
@@ -429,7 +429,7 @@ mod tests {
         coarse.try_set(pt(1), &[10, 20]).unwrap();
         let refinement = vec![(
             pt(1),
-            vec![(pt(2), Orientation::Forward), (pt(3), Orientation::Reverse)],
+            vec![(pt(2), Polarity::Forward), (pt(3), Polarity::Reverse)],
         )];
         fine.try_refine_with_sifter(&coarse, &refinement).unwrap();
         assert_eq!(fine.try_get(pt(2)).unwrap(), &[10, 20]);
@@ -520,7 +520,7 @@ mod tests {
         let mut coarse = make_sieved();
         let mut fine = make_sieved();
         coarse.try_set(pt(1), &[2, 3]).unwrap();
-        let refinement = vec![(pt(1), vec![(pt(2), Orientation::Forward)])];
+        let refinement = vec![(pt(1), vec![(pt(2), Polarity::Forward)])];
         fine.try_refine_with_sifter_parallel(&coarse, &refinement)
             .expect("parallel refinement failed");
         assert_eq!(fine.try_get(pt(2)).unwrap(), &[2, 3]);

--- a/src/topology/arrow_tests.rs
+++ b/src/topology/arrow_tests.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod tests {
+    use crate::topology::arrow::Polarity;
+    use crate::topology::arrow::Polarity::{Forward as F, Reverse as R};
+    use crate::topology::orientation::Sign;
+
+    #[test]
+    fn polarity_ops() {
+        assert_eq!(F.invert(), R);
+        assert_eq!(R.invert(), F);
+
+        assert_eq!(F ^ F, F);
+        assert_eq!(F ^ R, R);
+        assert_eq!(R ^ F, R);
+        assert_eq!(R ^ R, F);
+
+        assert_eq!(F.sign(), 1);
+        assert_eq!(R.sign(), -1);
+
+        assert_eq!(bool::from(F), false);
+        assert_eq!(bool::from(R), true);
+        assert_eq!(Polarity::from(false), F);
+        assert_eq!(Polarity::from(true), R);
+    }
+
+    #[test]
+    fn polarity_sign_roundtrip() {
+        let s_f: Sign = F.into();
+        let s_r: Sign = R.into();
+        assert_eq!(s_f.0, false);
+        assert_eq!(s_r.0, true);
+
+        let pf: Polarity = s_f.into();
+        let pr: Polarity = s_r.into();
+        assert_eq!(pf, F);
+        assert_eq!(pr, R);
+    }
+
+    #[test]
+    fn polarity_serde_roundtrip() {
+        let j = serde_json::to_string(&F).unwrap();
+        assert!(j.contains("Forward"));
+        let k = serde_json::to_string(&R).unwrap();
+        assert!(k.contains("Reverse"));
+        assert_eq!(serde_json::from_str::<Polarity>(&j).unwrap(), F);
+        assert_eq!(serde_json::from_str::<Polarity>(&k).unwrap(), R);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_orientation_alias_compiles() {
+        let _ = crate::topology::arrow::Orientation::Forward;
+    }
+}

--- a/src/topology/stack.rs
+++ b/src/topology/stack.rs
@@ -14,11 +14,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// A `Stack` links a *base* Sieve to a *cap* Sieve via vertical arrows.
-/// Each arrow carries a payload (e.g., orientation or permutation).
+/// Each arrow carries a payload (e.g., polarity or permutation).
 ///
 /// - `Point`:   The point type in the base mesh (commonly `PointId`).
 /// - `CapPt`:   The point type in the cap mesh (commonly `PointId`).
-/// - `Payload`: Data attached to each arrow (e.g., `Orientation`).
+/// - `Payload`: Data attached to each arrow (e.g., `Polarity`).
 ///
 /// Some implementations (such as [`ComposedStack`]) do not expose a concrete
 /// base or cap Sieve. Calling [`Stack::base`] or [`Stack::cap`] on such stacks
@@ -355,6 +355,28 @@ where
 ///
 /// Traversal composes payloads via a `compose_payload` function.
 ///
+/// # Examples
+///
+/// Using [`Polarity`] payloads (XOR composition):
+/// ```
+/// use mesh_sieve::topology::arrow::Polarity;
+/// use mesh_sieve::topology::stack::{ComposedStack, InMemoryStack, Stack};
+/// use mesh_sieve::topology::point::PointId;
+/// let s1 = InMemoryStack::<PointId, PointId, Polarity>::new();
+/// let s2 = InMemoryStack::<PointId, PointId, Polarity>::new();
+/// let _cs = ComposedStack::new(&s1, &s2, |a, b| (*a) ^ (*b));
+/// ```
+///
+/// Using group-valued [`orientation::Sign`] with trait composition:
+/// ```
+/// use mesh_sieve::topology::orientation::Sign;
+/// use mesh_sieve::topology::sieve::oriented::Orientation as _;
+/// use mesh_sieve::topology::stack::{ComposedStack, InMemoryStack, Stack};
+/// use mesh_sieve::topology::point::PointId;
+/// let s1 = InMemoryStack::<PointId, PointId, Sign>::new();
+/// let s2 = InMemoryStack::<PointId, PointId, Sign>::new();
+/// let _cs = ComposedStack::new(&s1, &s2, |a, b| Sign::compose(*a, *b));
+/// ```
 pub struct ComposedStack<'a, S1, S2, F>
 where
     S1: Stack,

--- a/tests/bundle_refine.rs
+++ b/tests/bundle_refine.rs
@@ -2,7 +2,7 @@ use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::bundle::Bundle;
 use mesh_sieve::data::section::Section;
 use mesh_sieve::overlap::delta::CopyDelta;
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::stack::{InMemoryStack, Stack};
 
@@ -16,8 +16,8 @@ fn refine_disjoint_slices_no_allocations() -> Result<(), Box<dyn std::error::Err
     let mut section = Section::<i32>::new(atlas);
     section.try_set(b, &[10, 20, 30])?;
 
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
-    stack.add_arrow(b, c, Orientation::Forward)?;
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.add_arrow(b, c, Polarity::Forward)?;
 
     let mut bundle = Bundle {
         stack,
@@ -39,8 +39,8 @@ fn refine_overlapping_slices_safe_reverse() -> Result<(), Box<dyn std::error::Er
     let mut section = Section::<i32>::new(atlas);
     section.try_set(p, &[1, 2, 3, 4])?;
 
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
-    stack.add_arrow(p, p, Orientation::Reverse)?;
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.add_arrow(p, p, Polarity::Reverse)?;
 
     let mut bundle = Bundle {
         stack,

--- a/tests/data/bundle_assemble_with_sum.rs
+++ b/tests/data/bundle_assemble_with_sum.rs
@@ -2,7 +2,7 @@ use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::bundle::{Bundle, SliceReducer};
 use mesh_sieve::data::section::Section;
 use mesh_sieve::overlap::delta::CopyDelta;
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::stack::InMemoryStack;
 use mesh_sieve::mesh_error::MeshSieveError;
@@ -48,9 +48,9 @@ fn bundle_assemble_with_sum() -> Result<(), Box<dyn std::error::Error>> {
     atlas.try_insert(c2, 3)?;
     let mut section = Section::<i32>::new(atlas.clone());
 
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
-    stack.add_arrow(b, c1, Orientation::Forward)?;
-    stack.add_arrow(b, c2, Orientation::Forward)?;
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.add_arrow(b, c1, Polarity::Forward)?;
+    stack.add_arrow(b, c2, Polarity::Forward)?;
     let mut bundle = Bundle { stack, section, delta: CopyDelta };
 
     bundle.section.try_set(c1, &[2, 4, 6])?;

--- a/tests/data/bundle_vec_dofs.rs
+++ b/tests/data/bundle_vec_dofs.rs
@@ -1,6 +1,6 @@
 use mesh_sieve::data::{atlas::Atlas, bundle::Bundle, section::Section};
 use mesh_sieve::overlap::delta::CopyDelta;
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::stack::{InMemoryStack, Stack};
 
@@ -17,9 +17,9 @@ fn bundle_refine_with_forward_and_reverse() -> Result<(), Box<dyn std::error::Er
     let mut section = Section::<i32>::new(atlas.clone());
     section.try_set(b, &[1, 2, 3])?;
 
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
-    stack.add_arrow(b, c1, Orientation::Forward)?;
-    stack.add_arrow(b, c2, Orientation::Reverse)?;
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.add_arrow(b, c1, Polarity::Forward)?;
+    stack.add_arrow(b, c2, Polarity::Reverse)?;
 
     let mut bundle = Bundle { stack, section, delta: CopyDelta };
     bundle.refine([b])?;
@@ -40,9 +40,9 @@ fn bundle_assemble_elementwise_average() -> Result<(), Box<dyn std::error::Error
     atlas.try_insert(c2, 3)?;
     let mut section = Section::<f64>::new(atlas.clone());
 
-    let mut stack = InMemoryStack::<PointId, PointId, Orientation>::default();
-    stack.add_arrow(b, c1, Orientation::Forward)?;
-    stack.add_arrow(b, c2, Orientation::Forward)?;
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.add_arrow(b, c1, Polarity::Forward)?;
+    stack.add_arrow(b, c2, Polarity::Forward)?;
     let mut bundle = Bundle { stack, section, delta: CopyDelta };
 
     bundle.section.try_set(c1, &[2.0, 4.0, 6.0])?;

--- a/tests/delta_name_compat.rs
+++ b/tests/delta_name_compat.rs
@@ -1,20 +1,20 @@
 use mesh_sieve::data::refine::delta::{Delta, SliceDelta};
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 
 #[test]
 fn impls_satisfy_both_names() {
     fn needs_slice_delta<T: SliceDelta<u8>>() {}
     fn needs_delta<T: Delta<u8>>() {}
 
-    needs_slice_delta::<Orientation>();
-    needs_delta::<Orientation>();
+    needs_slice_delta::<Polarity>();
+    needs_delta::<Polarity>();
 }
 
 #[test]
 fn call_apply_via_reexport() {
     let src = [1u8, 2, 3];
     let mut dst = [0u8; 3];
-    let o = Orientation::Reverse;
-    <Orientation as Delta<u8>>::apply(&o, &src, &mut dst).unwrap();
+    let o = Polarity::Reverse;
+    <Polarity as Delta<u8>>::apply(&o, &src, &mut dst).unwrap();
     assert_eq!(&dst, &[3, 2, 1]);
 }

--- a/tests/e2e_showcase_smoke.rs
+++ b/tests/e2e_showcase_smoke.rs
@@ -1,7 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::refine::sieved_array::SievedArray;
 use mesh_sieve::data::section::Section;
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::Sieve;
 
@@ -31,8 +31,8 @@ fn orientation_and_overlap_smoke() {
     }
     let mut fine = SievedArray::<PointId, f64>::new(atlas.clone());
     let sifter = vec![
-        (q0, vec![(q0, Orientation::Forward)]),
-        (q1, vec![(q1, Orientation::Reverse)]),
+        (q0, vec![(q0, Polarity::Forward)]),
+        (q1, vec![(q1, Polarity::Reverse)]),
     ];
     fine.try_refine_with_sifter(&coarse, &sifter).unwrap();
     let q1_src = sec.try_restrict(q1).unwrap().to_vec();
@@ -100,8 +100,8 @@ fn parallel_refine_parity() {
         src.try_set(p, sl).unwrap();
     }
     let sifter = vec![
-        (q0, vec![(q0, Orientation::Forward)]),
-        (q1, vec![(q1, Orientation::Reverse)]),
+        (q0, vec![(q0, Polarity::Forward)]),
+        (q1, vec![(q1, Polarity::Reverse)]),
     ];
     let mut serial = SievedArray::<PointId, f64>::new(atlas.clone());
     let mut parallel = SievedArray::<PointId, f64>::new(atlas.clone());

--- a/tests/sieved_array_parallel_refine.rs
+++ b/tests/sieved_array_parallel_refine.rs
@@ -5,7 +5,7 @@ use mesh_sieve::data::refine::sieved_array::SievedArray;
 #[cfg(feature = "rayon")]
 use mesh_sieve::mesh_error::MeshSieveError;
 #[cfg(feature = "rayon")]
-use mesh_sieve::topology::arrow::Orientation;
+use mesh_sieve::topology::arrow::Polarity;
 #[cfg(feature = "rayon")]
 use mesh_sieve::topology::point::PointId;
 
@@ -36,7 +36,7 @@ fn parallel_refine_matches_serial() {
 
     let refinement = vec![(
         c,
-        vec![(f1, Orientation::Forward), (f2, Orientation::Reverse)],
+        vec![(f1, Polarity::Forward), (f2, Polarity::Reverse)],
     )];
     fine_serial
         .try_refine_with_sifter(&coarse, &refinement)
@@ -69,7 +69,7 @@ fn parallel_refine_short_circuits_on_error() {
     fine.try_set(f_bad, &[9]).unwrap();
     let refinement = vec![(
         c,
-        vec![(f_ok, Orientation::Forward), (f_bad, Orientation::Forward)],
+        vec![(f_ok, Polarity::Forward), (f_bad, Polarity::Forward)],
     )];
     let err = fine
         .try_refine_with_sifter_parallel(&coarse, &refinement)
@@ -94,8 +94,8 @@ fn parallel_refine_detects_duplicates() {
     coarse.try_set(c2, &[3, 4]).unwrap();
     let mut fine = make_sieved(&[(f, 2)]);
     let refinement = vec![
-        (c1, vec![(f, Orientation::Forward)]),
-        (c2, vec![(f, Orientation::Forward)]),
+        (c1, vec![(f, Polarity::Forward)]),
+        (c2, vec![(f, Polarity::Forward)]),
     ];
     let err = fine
         .try_refine_with_sifter_parallel(&coarse, &refinement)
@@ -118,8 +118,8 @@ fn parallel_refine_is_deterministic() {
     coarse.try_set(c1, &[5, 6]).unwrap();
     coarse.try_set(c2, &[7, 8]).unwrap();
     let refinement = vec![
-        (c1, vec![(f1, Orientation::Forward)]),
-        (c2, vec![(f2, Orientation::Reverse)]),
+        (c1, vec![(f1, Polarity::Forward)]),
+        (c2, vec![(f2, Polarity::Reverse)]),
     ];
     // serial reference
     let mut reference = make_sieved(&[(f1, 2), (f2, 2)]);


### PR DESCRIPTION
## Summary
- introduce `Polarity` for vertical stack arrows
- add deprecated `Orientation` alias and conversions to `orientation::Sign`
- document polarity usage and update examples/tests

## Testing
- `rustup run nightly cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c110dc3d388329b8d5ff79a95e72e0