### PR TITLE
Decouple vertical payloads from horizontal sieves

### DIFF
--- a/src/algs/completion/stack_completion.rs
+++ b/src/algs/completion/stack_completion.rs
@@ -67,7 +67,7 @@ where
     Q: WirePoint + Default + Eq + std::hash::Hash + Copy + Send + 'static,
     Pay: Copy + Pod + Zeroable + Default + PartialEq + Send + 'static,
     C: crate::algs::communicator::Communicator + Sync,
-    S: crate::topology::stack::Stack<Point = P, CapPt = Q, Payload = Pay>,
+    S: crate::topology::stack::Stack<Point = P, CapPt = Q, VerticalPayload = Pay>,
     O: Sieve<Point = P, Payload = R> + Sync,
     R: HasRank + Copy + Send + 'static,
 {
@@ -211,7 +211,7 @@ where
     Q: WirePoint + Default + Eq + std::hash::Hash + Copy + Send + 'static,
     Pay: Copy + Pod + Zeroable + Default + PartialEq + Send + 'static,
     C: crate::algs::communicator::Communicator + Sync,
-    S: crate::topology::stack::Stack<Point = P, CapPt = Q, Payload = Pay>,
+    S: crate::topology::stack::Stack<Point = P, CapPt = Q, VerticalPayload = Pay>,
     O: Sieve<Point = P, Payload = R> + Sync,
     R: HasRank + Copy + Send + 'static,
 {

--- a/src/data/bundle.rs
+++ b/src/data/bundle.rs
@@ -248,6 +248,18 @@ mod tests {
         section.try_set(PointId::new(1).unwrap(), &[10]).unwrap();
         section.try_set(PointId::new(2).unwrap(), &[20]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
+        stack
+            .base
+            .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
+        stack
+            .base
+            .add_arrow(PointId::new(2).unwrap(), PointId::new(2).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(102).unwrap(), PointId::new(102).unwrap(), ());
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -333,6 +345,12 @@ mod tests {
             .try_set(PointId::new(1).unwrap(), &[10, 20])
             .unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
+        stack
+            .base
+            .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -360,6 +378,12 @@ mod tests {
         let mut section = Section::<i32>::new(atlas.clone());
         section.try_set(PointId::new(1).unwrap(), &[1, 2]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
+        stack
+            .base
+            .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -392,6 +416,15 @@ mod tests {
         section.try_set(PointId::new(101).unwrap(), &[5]).unwrap();
         section.try_set(PointId::new(102).unwrap(), &[7]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
+        stack
+            .base
+            .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(102).unwrap(), PointId::new(102).unwrap(), ());
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -428,6 +461,15 @@ mod tests {
         section.try_set(PointId::new(101).unwrap(), &[8]).unwrap();
         section.try_set(PointId::new(102).unwrap(), &[9]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
+        stack
+            .base
+            .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
+        stack
+            .cap
+            .add_arrow(PointId::new(102).unwrap(), PointId::new(102).unwrap(), ());
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),

--- a/src/topology/tests/debug_invariants.rs
+++ b/src/topology/tests/debug_invariants.rs
@@ -26,8 +26,19 @@ fn orientation_mismatch_panics_in_debug() {
 #[should_panic]
 fn stack_mirror_missing_panics_in_debug() {
     let mut st = InMemoryStack::<u32, u32, ()>::new();
+    st.base.add_arrow(1, 1, ());
+    st.cap.add_arrow(2, 2, ());
     st.add_arrow(1, 2, ()).unwrap();
     st.down.get_mut(&2).unwrap().clear();
+    #[cfg(any(debug_assertions, feature = "strict-invariants"))]
+    st.debug_assert_invariants();
+}
+
+#[test]
+#[should_panic]
+fn stack_membership_panics_in_debug() {
+    let mut st = InMemoryStack::<u32, u32, ()>::new();
+    st.add_arrow(1, 2, ()).unwrap();
     #[cfg(any(debug_assertions, feature = "strict-invariants"))]
     st.debug_assert_invariants();
 }

--- a/tests/bundle_refine.rs
+++ b/tests/bundle_refine.rs
@@ -4,6 +4,7 @@ use mesh_sieve::data::section::Section;
 use mesh_sieve::overlap::delta::CopyDelta;
 use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::Sieve;
 use mesh_sieve::topology::stack::{InMemoryStack, Stack};
 
 #[test]
@@ -17,6 +18,8 @@ fn refine_disjoint_slices_no_allocations() -> Result<(), Box<dyn std::error::Err
     section.try_set(b, &[10, 20, 30])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.base.add_arrow(b, b, ());
+    stack.cap.add_arrow(c, c, ());
     stack.add_arrow(b, c, Polarity::Forward)?;
 
     let mut bundle = Bundle {
@@ -40,6 +43,8 @@ fn refine_overlapping_slices_safe_reverse() -> Result<(), Box<dyn std::error::Er
     section.try_set(p, &[1, 2, 3, 4])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.base.add_arrow(p, p, ());
+    stack.cap.add_arrow(p, p, ());
     stack.add_arrow(p, p, Polarity::Reverse)?;
 
     let mut bundle = Bundle {

--- a/tests/shared_payload.rs
+++ b/tests/shared_payload.rs
@@ -43,6 +43,8 @@ fn oriented_upsert_replaces_payload() {
 #[test]
 fn stack_shares_payload_across_directions() {
     let mut st = InMemoryStackArc::<u32, u32, i32>::default();
+    st.base.add_arrow(1, 1, ());
+    st.cap.add_arrow(100, 100, ());
     st.add_arrow_val(1, 100, 9).unwrap();
     let (cap, a) = st.lift(1).next().unwrap();
     let (base, b) = st.drop(100).next().unwrap();


### PR DESCRIPTION
## Summary
- redesign `Stack` trait with independent vertical payloads
- make `InMemoryStack` generic over base, cap, and vertical payload types
- keep horizontal caches intact on vertical edits and add debug membership checks
- allow `ComposedStack` to merge differing payload domains

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68c118007f0483299f85afc7fd13caff