### PR TITLE
Enforce stack arrow membership

### DIFF
--- a/src/data/bundle.rs
+++ b/src/data/bundle.rs
@@ -249,17 +249,23 @@ mod tests {
         section.try_set(PointId::new(2).unwrap(), &[20]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         stack
-            .base
+            .base_mut()
+            .unwrap()
             .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
         stack
-            .base
+            .base_mut()
+            .unwrap()
             .add_arrow(PointId::new(2).unwrap(), PointId::new(2).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(102).unwrap(), PointId::new(102).unwrap(), ());
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(101).unwrap(),
+            PointId::new(101).unwrap(),
+            (),
+        );
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(102).unwrap(),
+            PointId::new(102).unwrap(),
+            (),
+        );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -346,11 +352,14 @@ mod tests {
             .unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         stack
-            .base
+            .base_mut()
+            .unwrap()
             .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(101).unwrap(),
+            PointId::new(101).unwrap(),
+            (),
+        );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -379,11 +388,14 @@ mod tests {
         section.try_set(PointId::new(1).unwrap(), &[1, 2]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         stack
-            .base
+            .base_mut()
+            .unwrap()
             .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(101).unwrap(),
+            PointId::new(101).unwrap(),
+            (),
+        );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -417,14 +429,19 @@ mod tests {
         section.try_set(PointId::new(102).unwrap(), &[7]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         stack
-            .base
+            .base_mut()
+            .unwrap()
             .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(102).unwrap(), PointId::new(102).unwrap(), ());
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(101).unwrap(),
+            PointId::new(101).unwrap(),
+            (),
+        );
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(102).unwrap(),
+            PointId::new(102).unwrap(),
+            (),
+        );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),
@@ -462,14 +479,19 @@ mod tests {
         section.try_set(PointId::new(102).unwrap(), &[9]).unwrap();
         let mut stack = InMemoryStack::<PointId, PointId, Polarity>::new();
         stack
-            .base
+            .base_mut()
+            .unwrap()
             .add_arrow(PointId::new(1).unwrap(), PointId::new(1).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(101).unwrap(), PointId::new(101).unwrap(), ());
-        stack
-            .cap
-            .add_arrow(PointId::new(102).unwrap(), PointId::new(102).unwrap(), ());
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(101).unwrap(),
+            PointId::new(101).unwrap(),
+            (),
+        );
+        stack.cap_mut().unwrap().add_arrow(
+            PointId::new(102).unwrap(),
+            PointId::new(102).unwrap(),
+            (),
+        );
         let _ = stack.add_arrow(
             PointId::new(1).unwrap(),
             PointId::new(101).unwrap(),

--- a/src/mesh_error.rs
+++ b/src/mesh_error.rs
@@ -20,6 +20,9 @@ pub enum MeshSieveError {
     /// Attempted to construct a PointId with a zero value (invalid).
     #[error("PointId must be non-zero (0 is reserved as invalid/sentinel)")]
     InvalidPointId,
+    /// Vertical arrow references a point missing from the base or cap sieve.
+    #[error("stack arrow references missing point in {role}: {point}")]
+    StackMissingPoint { role: &'static str, point: String },
     /// Mutation on a read-only stack (e.g., `ComposedStack`) is not allowed.
     #[error("Unsupported stack operation: {0}")]
     UnsupportedStackOperation(&'static str),

--- a/src/topology/sieve/in_memory.rs
+++ b/src/topology/sieve/in_memory.rs
@@ -104,6 +104,12 @@ impl<P: PointLike, T: PayloadLike> InMemorySieve<P, T> {
         self.strata.take();
     }
 
+    /// Point exists if it has an entry in either role (even with zero degree).
+    #[inline]
+    pub fn contains_point(&self, p: P) -> bool {
+        self.adjacency_out.contains_key(&p) || self.adjacency_in.contains_key(&p)
+    }
+
     #[inline]
     fn scrub_outgoing_only(&mut self, src: P) {
         let old: Vec<(P, T)> = std::mem::take(self.adjacency_out.entry(src).or_default());

--- a/src/topology/sieve/in_memory_det.rs
+++ b/src/topology/sieve/in_memory_det.rs
@@ -56,6 +56,12 @@ impl<P: PointLike, T: PayloadLike> InMemorySieveDeterministic<P, T> {
         }
     }
 
+    /// Point exists if it has an entry in either role (even with zero degree).
+    #[inline]
+    pub fn contains_point(&self, p: P) -> bool {
+        self.adjacency_out.contains_key(&p) || self.adjacency_in.contains_key(&p)
+    }
+
     #[inline]
     fn scrub_outgoing_only(&mut self, src: P) {
         if let Some(outs) = self.adjacency_out.remove(&src) {

--- a/src/topology/sieve/in_memory_oriented.rs
+++ b/src/topology/sieve/in_memory_oriented.rs
@@ -100,6 +100,12 @@ where
         self.strata.take();
     }
 
+    /// Point exists if it has an entry in either role (even with zero degree).
+    #[inline]
+    pub fn contains_point(&self, p: P) -> bool {
+        self.adjacency_out.contains_key(&p) || self.adjacency_in.contains_key(&p)
+    }
+
     #[inline]
     fn scrub_outgoing_only(&mut self, src: P) {
         let old: Vec<(P, T, O)> = std::mem::take(self.adjacency_out.entry(src).or_default());

--- a/src/topology/tests/debug_invariants.rs
+++ b/src/topology/tests/debug_invariants.rs
@@ -26,8 +26,8 @@ fn orientation_mismatch_panics_in_debug() {
 #[should_panic]
 fn stack_mirror_missing_panics_in_debug() {
     let mut st = InMemoryStack::<u32, u32, ()>::new();
-    st.base.add_arrow(1, 1, ());
-    st.cap.add_arrow(2, 2, ());
+    st.base_mut().unwrap().add_arrow(1, 1, ());
+    st.cap_mut().unwrap().add_arrow(2, 2, ());
     st.add_arrow(1, 2, ()).unwrap();
     st.down.get_mut(&2).unwrap().clear();
     st.debug_assert_invariants();

--- a/tests/bundle_refine.rs
+++ b/tests/bundle_refine.rs
@@ -18,8 +18,8 @@ fn refine_disjoint_slices_no_allocations() -> Result<(), Box<dyn std::error::Err
     section.try_set(b, &[10, 20, 30])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
-    stack.base.add_arrow(b, b, ());
-    stack.cap.add_arrow(c, c, ());
+    stack.base_mut().unwrap().add_arrow(b, b, ());
+    stack.cap_mut().unwrap().add_arrow(c, c, ());
     stack.add_arrow(b, c, Polarity::Forward)?;
 
     let mut bundle = Bundle {
@@ -43,8 +43,8 @@ fn refine_overlapping_slices_safe_reverse() -> Result<(), Box<dyn std::error::Er
     section.try_set(p, &[1, 2, 3, 4])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
-    stack.base.add_arrow(p, p, ());
-    stack.cap.add_arrow(p, p, ());
+    stack.base_mut().unwrap().add_arrow(p, p, ());
+    stack.cap_mut().unwrap().add_arrow(p, p, ());
     stack.add_arrow(p, p, Polarity::Reverse)?;
 
     let mut bundle = Bundle {

--- a/tests/shared_payload.rs
+++ b/tests/shared_payload.rs
@@ -43,8 +43,8 @@ fn oriented_upsert_replaces_payload() {
 #[test]
 fn stack_shares_payload_across_directions() {
     let mut st = InMemoryStackArc::<u32, u32, i32>::default();
-    st.base.add_arrow(1, 1, ());
-    st.cap.add_arrow(100, 100, ());
+    st.base_mut().unwrap().add_arrow(1, 1, ());
+    st.cap_mut().unwrap().add_arrow(100, 100, ());
     st.add_arrow_val(1, 100, 9).unwrap();
     let (cap, a) = st.lift(1).next().unwrap();
     let (base, b) = st.drop(100).next().unwrap();


### PR DESCRIPTION
## Summary
- add fast point membership checks to in-memory sieves
- reject stack arrows referencing missing base or cap points with a new `StackMissingPoint` error
- validate stack membership in tests and propagate cache invalidation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c1223527348329bc984591114e7f56