### PR TITLE
feat: enforce strict atlas mutation and explicit resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,6 @@
   deprecated alias.
 - Renamed `overlap::delta::Delta` to `ValueDelta`; `Delta` remains as a
   deprecated alias.
+- `Section::with_atlas_mut` now rejects slice length changes with
+  `MeshSieveError::AtlasSliceLengthChanged`; use the new
+  `with_atlas_resize(ResizePolicy, ...)` to explicitly allow resizing.

--- a/src/mesh_error.rs
+++ b/src/mesh_error.rs
@@ -58,6 +58,13 @@ pub enum MeshSieveError {
         expected: usize,
         found: usize,
     },
+    /// Slice length changed for a point during atlas mutation.
+    #[error("atlas slice length changed for {point:?}: {old} -> {new}")]
+    AtlasSliceLengthChanged {
+        point: crate::topology::point::PointId,
+        old: usize,
+        new: usize,
+    },
     /// Mismatch between expected and provided slice length for a point (SievedArray).
     #[error(
         "SievedArray error: slice length mismatch at {point:?}: expected {expected}, got {found}"
@@ -214,6 +221,18 @@ impl PartialEq for MeshSieveError {
                     found: f2,
                 },
             ) => p1 == p2 && e1 == e2 && f1 == f2,
+            (
+                AtlasSliceLengthChanged {
+                    point: p1,
+                    old: o1,
+                    new: n1,
+                },
+                AtlasSliceLengthChanged {
+                    point: p2,
+                    old: o2,
+                    new: n2,
+                },
+            ) => p1 == p2 && o1 == o2 && n1 == n2,
             (
                 SievedArraySliceLengthMismatch {
                     point: p1,


### PR DESCRIPTION
## Summary
- reject slice length changes during `with_atlas_mut` and add `AtlasSliceLengthChanged`
- introduce `ResizePolicy` and `with_atlas_resize` for controlled slice resizing
- document new behavior and cover prefix/suffix policies with tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c2646981348329912f89255c84b8e9