### PR TITLE
Bundle length validation and error reporting overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Added `SliceReducer` and `Bundle::assemble_with` to customize how cap slices
   are merged into base slices. `Bundle::assemble` now performs element-wise
   averaging via `AverageReducer`.
+- `Bundle::assemble_with` now validates slice lengths up front and returns
+  `SliceLengthMismatch` with the exact mismatching cap `PointId`. Reducers such
+  as `AverageReducer` assume equal lengths and no longer perform checks.
 - Renamed `data::refine::delta::Delta` to `SliceDelta`; `Delta` remains as a
   deprecated alias.
 - Renamed `overlap::delta::Delta` to `ValueDelta`; `Delta` remains as a

--- a/tests/data/bundle_assemble_length_mismatch.rs
+++ b/tests/data/bundle_assemble_length_mismatch.rs
@@ -1,0 +1,38 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::bundle::{AverageReducer, Bundle};
+use mesh_sieve::data::section::Section;
+use mesh_sieve::mesh_error::MeshSieveError;
+use mesh_sieve::overlap::delta::CopyDelta;
+use mesh_sieve::topology::arrow::Polarity;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::stack::InMemoryStack;
+
+#[test]
+fn assemble_reports_cap_point_on_length_mismatch() {
+    let b = PointId::new(10).unwrap();
+    let c_ok = PointId::new(20).unwrap();
+    let c_bad = PointId::new(30).unwrap();
+
+    let mut atlas = Atlas::default();
+    atlas.try_insert(b, 3).unwrap();
+    atlas.try_insert(c_ok, 3).unwrap();
+    atlas.try_insert(c_bad, 2).unwrap();
+
+    let section: Section<f64> = Section::new(atlas);
+
+    let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
+    stack.add_arrow(b, c_ok, Polarity::Forward).unwrap();
+    stack.add_arrow(b, c_bad, Polarity::Forward).unwrap();
+
+    let mut bundle = Bundle { stack, section, delta: CopyDelta };
+
+    let err = bundle.assemble_with([b], &AverageReducer).unwrap_err();
+    match err {
+        MeshSieveError::SliceLengthMismatch { point, expected, found } => {
+            assert_eq!(point, c_bad);
+            assert_eq!(expected, 3);
+            assert_eq!(found, 2);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/tests/data/bundle_assemble_with_sum.rs
+++ b/tests/data/bundle_assemble_with_sum.rs
@@ -23,13 +23,6 @@ where
         acc: &mut [V],
         src: &[V],
     ) -> Result<(), MeshSieveError> {
-        if acc.len() != src.len() {
-            return Err(MeshSieveError::SliceLengthMismatch {
-                point: unsafe { PointId::new_unchecked(1) },
-                expected: acc.len(),
-                found: src.len(),
-            });
-        }
         for (dst, s) in acc.iter_mut().zip(src.iter()) {
             *dst += s.clone();
         }


### PR DESCRIPTION
## Summary
- validate cap slice lengths in `Bundle::assemble_with` and report offending cap `PointId`
- simplify `AverageReducer::accumulate` to assume equal lengths
- add regression test ensuring length mismatches surface from `assemble_with`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c26956d394832991d850aedbd0159e