### PR TITLE
Remove panicking APIs and gate legacy Map adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,10 @@
 - `Section::with_atlas_mut` now rejects slice length changes with
   `MeshSieveError::AtlasSliceLengthChanged`; use the new
   `with_atlas_resize(ResizePolicy, ...)` to explicitly allow resizing.
+- **Removed:** deprecated panicking shims `Atlas::insert`, `Section::{restrict, restrict_mut, set}`,
+  `SievedArray::{get, get_mut, set, refine_with_sifter, refine, assemble}`, and
+  `SievedArray::try_iter` alias.
+- **Added:** `map-adapter` feature gating the legacy `Map` trait and
+  infallible `restrict_*` helpers. The feature is off by default.
+- **Migration:** switch call sites to `try_*` methods or temporarily enable
+  `map-adapter` to retain panicking behavior.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-sieve"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ rayon = "1"
 
 [features]
 default = []            # keep core lean
+# Enables legacy "infallible" adapter and helpers that panic on missing points.
+map-adapter = []
 mpi-support = ["dep:mpi", "rayon", "dep:rand", "dep:ahash"]
 mpi-derive = ["mpi/derive"]
 metis-support = ["metis", "metis-sys", "libffi-sys","bindgen","pkg-config"]

--- a/src/data/atlas.rs
+++ b/src/data/atlas.rs
@@ -94,11 +94,6 @@ impl Atlas {
         self.debug_assert_invariants();
         Ok(offset)
     }
-    #[deprecated(note = "Use `try_insert` which returns Result instead of panicking")]
-    pub fn insert(&mut self, p: PointId, len: usize) -> usize {
-        self.try_insert(p, len)
-            .expect("Atlas::insert panicked; use try_insert")
-    }
 
     /// Look up the slice descriptor `(offset, len)` for point `p`.
     ///

--- a/src/data/refine/mod.rs
+++ b/src/data/refine/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! This module provides traits and helpers for restricting and refining data
 //! along sieves, including delta transformations, slice extraction, and sieved arrays.
+//! Infallible helpers and the legacy [`Map`] adapter are available only when
+//! the `map-adapter` feature is enabled.
 
 pub mod delta;
 pub mod helpers;
@@ -10,9 +12,10 @@ pub mod sieved_array;
 // re-export the main pieces at the top level:
 pub use delta::{Delta, SliceDelta};
 pub use helpers::{
-    restrict_closure, restrict_closure_vec, restrict_star, restrict_star_vec, try_restrict_closure,
-    try_restrict_closure_vec, try_restrict_star, try_restrict_star_vec,
+    try_restrict_closure, try_restrict_closure_vec, try_restrict_star, try_restrict_star_vec,
 };
+#[cfg(feature = "map-adapter")]
+pub use helpers::{restrict_closure, restrict_closure_vec, restrict_star, restrict_star_vec};
 #[cfg(feature = "rayon")]
 pub use helpers::{try_restrict_closure_vec_parallel, try_restrict_star_vec_parallel};
 pub use sieved_array::SievedArray;

--- a/src/data/refine/sieved_array.rs
+++ b/src/data/refine/sieved_array.rs
@@ -76,23 +76,6 @@ where
         })
     }
 
-    /// Iterate over all points and their associated slices, returning Results.
-    #[deprecated(note = "Use try_iter_in_order instead")]
-    pub fn try_iter(
-        &self,
-    ) -> impl Iterator<Item = Result<(PointId, &[V]), crate::mesh_error::MeshSieveError>> + '_ {
-        self.try_iter_in_order()
-    }
-
-    /// Backwards-compatible panicking versions (deprecated)
-    #[deprecated(note = "Use try_get instead")]
-    pub fn get(&self, p: PointId) -> &[V] {
-        self.try_get(p).unwrap()
-    }
-    #[deprecated(note = "Use try_get_mut instead")]
-    pub fn get_mut(&mut self, p: PointId) -> &mut [V] {
-        self.try_get_mut(p).unwrap()
-    }
 }
 
 impl<P, V: Clone> SievedArray<P, V>
@@ -117,10 +100,6 @@ where
         }
         tgt.clone_from_slice(val);
         Ok(())
-    }
-    #[deprecated(note = "Use try_set instead")]
-    pub fn set(&mut self, p: PointId, val: &[V]) {
-        self.try_set(p, val).unwrap()
     }
 }
 
@@ -219,18 +198,6 @@ where
         self.try_refine_with_sifter(coarse, &sifter)
     }
 
-    #[deprecated(note = "Use try_refine_with_sifter instead")]
-    pub fn refine_with_sifter(
-        &mut self,
-        coarse: &SievedArray<P, V>,
-        refinement: &[(P, Vec<(P, Polarity)>)],
-    ) {
-        self.try_refine_with_sifter(coarse, refinement).unwrap()
-    }
-    #[deprecated(note = "Use try_refine instead")]
-    pub fn refine(&mut self, coarse: &SievedArray<P, V>, refinement: &[(P, Vec<P>)]) {
-        self.try_refine(coarse, refinement).unwrap()
-    }
 }
 
 impl<P, V> SievedArray<P, V>
@@ -289,10 +256,6 @@ where
         Ok(())
     }
 
-    #[deprecated(note = "Use try_assemble instead")]
-    pub fn assemble(&self, coarse: &mut SievedArray<P, V>, refinement: &[(P, Vec<P>)]) {
-        self.try_assemble(coarse, refinement).unwrap()
-    }
 }
 
 #[cfg(feature = "rayon")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,9 @@ pub mod prelude {
     };
     pub use crate::algs::rcm::distributed_rcm;
     pub use crate::data::atlas::Atlas;
-    pub use crate::data::section::{Map, Section};
+    pub use crate::data::section::Section;
+    #[cfg(feature = "map-adapter")]
+    pub use crate::data::section::Map;
     pub use crate::overlap::delta::{AddDelta, CopyDelta, ValueDelta};
     pub use crate::overlap::overlap::Overlap;
     pub use crate::topology::bounds::{PayloadLike, PointLike};

--- a/tests/helpers_try_restrict_ok_err.rs
+++ b/tests/helpers_try_restrict_ok_err.rs
@@ -1,5 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
-use mesh_sieve::data::refine::helpers::{restrict_closure_vec, try_restrict_closure_vec};
+use mesh_sieve::data::refine::helpers::try_restrict_closure_vec;
+#[cfg(feature = "map-adapter")]
+use mesh_sieve::data::refine::helpers::restrict_closure_vec;
 use mesh_sieve::data::section::Section;
 use mesh_sieve::mesh_error::MeshSieveError;
 use mesh_sieve::topology::point::PointId;
@@ -9,6 +11,7 @@ fn v(i: u64) -> PointId {
     PointId::new(i).unwrap()
 }
 
+#[cfg(feature = "map-adapter")]
 #[test]
 #[should_panic]
 fn restrict_closure_panics_on_missing_point() {


### PR DESCRIPTION
## Summary
- delete deprecated panicking helpers across Atlas, Section, and SievedArray
- add optional `map-adapter` feature gating legacy `Map` trait and infallible restrict helpers
- document and surface only fallible APIs by default

## Testing
- `cargo test`
- `cargo test --features map-adapter`


------
https://chatgpt.com/codex/tasks/task_e_68c26b428e1c8329959c717945c4665d