### PR TITLE
feat: parameterize Section storage

### DIFF
--- a/examples/comprehensive_mesh_workflow.rs
+++ b/examples/comprehensive_mesh_workflow.rs
@@ -32,6 +32,7 @@ fn main() {
     };
     use mesh_sieve::data::refine::sieved_array::SievedArray;
     use mesh_sieve::data::section::Section;
+    use mesh_sieve::data::storage::VecStorage;
     use mesh_sieve::overlap::delta::{AddDelta, CopyDelta, ValueDelta, ZeroDelta};
     // use mesh_sieve::overlap::overlap::{Overlap, Remote};
     use mesh_sieve::algs::dual_graph::build_dual;
@@ -297,7 +298,10 @@ fn test_lattice_operations(mesh: &InMemorySieve<PointId, ()>, cells: &[PointId])
 
 /// Test refinement helpers (restrict_closure, restrict_star)
 #[cfg(feature = "mpi-support")]
-fn test_refinement_helpers(mesh: &InMemorySieve<PointId, ()>, _section: &Section<f64>) {
+fn test_refinement_helpers(
+    mesh: &InMemorySieve<PointId, ()>,
+    _section: &Section<f64, VecStorage<f64>>,
+) {
     use mesh_sieve::data::refine::*;
     use mesh_sieve::prelude::*;
 
@@ -312,7 +316,7 @@ fn test_refinement_helpers(mesh: &InMemorySieve<PointId, ()>, _section: &Section
         test_atlas.try_insert(point, 1).unwrap();
     }
 
-    let mut test_section = Section::<f64>::new(test_atlas);
+    let mut test_section = Section::<f64, VecStorage<f64>>::new(test_atlas);
 
     // Set test data for all points
     for (i, &point) in all_points.iter().enumerate() {

--- a/examples/e2e_showcase.rs
+++ b/examples/e2e_showcase.rs
@@ -1,6 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::refine::sieved_array::SievedArray;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::Sieve;
@@ -23,7 +24,7 @@ mod tiny_mesh;
 #[cfg(feature = "rayon")]
 fn check_parallel_refine_matches_serial(
     atlas: &Atlas,
-    sec: &Section<f64>,
+    sec: &Section<f64, VecStorage<f64>>,
     q0: PointId,
     q1: PointId,
 ) {
@@ -75,7 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let off_q1 = atlas.try_insert(q1, 4)?;
     assert_eq!(off_q0, 0);
     assert_eq!(off_q1, 4);
-    let mut sec: Section<f64> = Section::new(atlas.clone());
+    let mut sec: Section<f64, VecStorage<f64>> = Section::new(atlas.clone());
 
     // Initialize base values:
     sec.try_set(q0, &[1.0, 2.0, 3.0, 4.0])?;
@@ -186,7 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("[neg] zero-length insert -> {:?}", err);
 
     // b) Section set length mismatch
-    let mut sec2: Section<f64> = Section::new(atlas.clone());
+    let mut sec2: Section<f64, VecStorage<f64>> = Section::new(atlas.clone());
     let err = sec2.try_set(q0, &[1.0, 2.0, 3.0]).unwrap_err();
     println!("[neg] slice-length mismatch -> {:?}", err);
 

--- a/examples/mpi_partition_exchange.rs
+++ b/examples/mpi_partition_exchange.rs
@@ -10,6 +10,7 @@ use mesh_sieve::algs::partition;
 use mesh_sieve::data::atlas::Atlas;
 #[cfg(feature = "mpi-support")]
 use mesh_sieve::data::section::{Map, Section};
+use mesh_sieve::data::storage::VecStorage;
 #[cfg(feature = "mpi-support")]
 use mesh_sieve::topology::point::PointId;
 #[cfg(feature = "mpi-support")]
@@ -28,7 +29,7 @@ use mesh_sieve::partitioning::{PartitionerConfig, partition};
 
 /// Build a 2×2 structured grid of points (IDs 0..8).
 #[cfg(feature = "mpi-support")]
-fn build_grid() -> (InMemorySieve<PointId, ()>, Atlas, Section<f64>) {
+fn build_grid() -> (InMemorySieve<PointId, ()>, Atlas, Section<f64, VecStorage<f64>>) {
     // 9 points laid out in a 3×3 mesh (4 cells)
     let mut sieve = InMemorySieve::new();
     let mut atlas = Atlas::default();
@@ -36,7 +37,7 @@ fn build_grid() -> (InMemorySieve<PointId, ()>, Atlas, Section<f64>) {
         sieve.add_point(PointId::new(id + 1).unwrap());
         atlas.insert(PointId::new(id + 1).unwrap(), 1); // 1 DOF per point
     }
-    let mut section = Section::new(atlas.clone());
+    let mut section = Section::<f64, VecStorage<f64>>::new(atlas.clone());
     // initialize each point’s value = its ID as f64
     for id in 1u64..=9 {
         section.restrict_mut(PointId::new(id).unwrap())[0] = id as f64;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -12,3 +12,7 @@ pub mod refine;
 pub(crate) use _debug_invariants::DebugInvariants;
 
 pub use storage::{Storage, VecStorage};
+pub use section::Section;
+
+/// Alias for the common Vec-backed section.
+pub type CpuSection<V> = section::Section<V, VecStorage<V>>;

--- a/tests/atlas_section_scatter.rs
+++ b/tests/atlas_section_scatter.rs
@@ -1,14 +1,15 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::mesh_error::MeshSieveError;
 use mesh_sieve::topology::point::PointId;
 
-fn build_section() -> Section<i32> {
+fn build_section() -> Section<i32, VecStorage<i32>> {
     let mut atlas = Atlas::default();
     atlas.try_insert(PointId::new(1).unwrap(), 2).unwrap();
     atlas.try_insert(PointId::new(2).unwrap(), 1).unwrap();
     atlas.try_insert(PointId::new(3).unwrap(), 2).unwrap();
-    Section::new(atlas)
+    Section::<i32, VecStorage<i32>>::new(atlas)
 }
 
 #[test]
@@ -42,7 +43,7 @@ fn plan_staleness() {
     atlas.try_insert(p1, 1).unwrap();
     atlas.try_insert(p2, 1).unwrap();
     let plan = atlas.build_scatter_plan();
-    let mut sec = Section::<i32>::new(atlas);
+    let mut sec = Section::<i32, VecStorage<i32>>::new(atlas);
     let buf = vec![10, 20];
     let p3 = PointId::new(3).unwrap();
     sec.try_add_point(p3, 1).unwrap();

--- a/tests/bundle_refine.rs
+++ b/tests/bundle_refine.rs
@@ -1,6 +1,8 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::bundle::Bundle;
+use core::marker::PhantomData;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::overlap::delta::CopyDelta;
 use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
@@ -14,7 +16,7 @@ fn refine_disjoint_slices_no_allocations() -> Result<(), Box<dyn std::error::Err
     let mut atlas = Atlas::default();
     atlas.try_insert(b, 3)?;
     atlas.try_insert(c, 3)?;
-    let mut section = Section::<i32>::new(atlas);
+    let mut section = Section::<i32, VecStorage<i32>>::new(atlas);
     section.try_set(b, &[10, 20, 30])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
@@ -26,6 +28,7 @@ fn refine_disjoint_slices_no_allocations() -> Result<(), Box<dyn std::error::Err
         stack,
         section,
         delta: CopyDelta,
+        _marker: PhantomData,
     };
     bundle.refine([b])?;
 
@@ -39,7 +42,7 @@ fn refine_overlapping_slices_safe_reverse() -> Result<(), Box<dyn std::error::Er
     let p = PointId::new(42)?;
     let mut atlas = Atlas::default();
     atlas.try_insert(p, 4)?;
-    let mut section = Section::<i32>::new(atlas);
+    let mut section = Section::<i32, VecStorage<i32>>::new(atlas);
     section.try_set(p, &[1, 2, 3, 4])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
@@ -51,6 +54,7 @@ fn refine_overlapping_slices_safe_reverse() -> Result<(), Box<dyn std::error::Er
         stack,
         section,
         delta: CopyDelta,
+        _marker: PhantomData,
     };
     bundle.refine([p])?;
 

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -1,5 +1,5 @@
 use mesh_sieve::algs::{communicator::RayonComm, completion::complete_section};
-use mesh_sieve::data::{atlas::Atlas, section::Section};
+use mesh_sieve::data::{atlas::Atlas, section::Section, storage::VecStorage};
 use mesh_sieve::overlap::delta::CopyDelta;
 use mesh_sieve::overlap::overlap::Overlap;
 use mesh_sieve::topology::point::PointId;
@@ -21,13 +21,13 @@ fn ghost_update_self() {
     atlas
         .try_insert(p0, 1)
         .expect("Failed to insert point into atlas");
-    let mut sec = Section::<u32>::new(atlas);
+    let mut sec = Section::<u32, VecStorage<u32>>::new(atlas);
     sec.try_set(p0, &[42]).expect("Failed to set section value");
 
     let comm = RayonComm::new(0, 1);
 
     // Should complete without deadlock and leave the value intact.
-    let _ = complete_section::<u32, CopyDelta, _>(&mut sec, &ovlp, &comm, 0);
+    let _ = complete_section::<u32, VecStorage<u32>, CopyDelta, _>(&mut sec, &ovlp, &comm, 0);
 
     assert_eq!(
         sec.try_restrict(p0).expect("Failed to restrict section")[0],

--- a/tests/data/bundle_assemble_length_mismatch.rs
+++ b/tests/data/bundle_assemble_length_mismatch.rs
@@ -1,6 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::bundle::{AverageReducer, Bundle};
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::mesh_error::MeshSieveError;
 use mesh_sieve::overlap::delta::CopyDelta;
 use mesh_sieve::topology::arrow::Polarity;
@@ -18,7 +19,7 @@ fn assemble_reports_cap_point_on_length_mismatch() {
     atlas.try_insert(c_ok, 3).unwrap();
     atlas.try_insert(c_bad, 2).unwrap();
 
-    let section: Section<f64> = Section::new(atlas);
+    let section: Section<f64, VecStorage<f64>> = Section::new(atlas);
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
     stack.add_arrow(b, c_ok, Polarity::Forward).unwrap();

--- a/tests/data/bundle_assemble_with_sum.rs
+++ b/tests/data/bundle_assemble_with_sum.rs
@@ -1,6 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::bundle::{Bundle, SliceReducer};
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::overlap::delta::CopyDelta;
 use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
@@ -39,7 +40,7 @@ fn bundle_assemble_with_sum() -> Result<(), Box<dyn std::error::Error>> {
     atlas.try_insert(b, 3)?;
     atlas.try_insert(c1, 3)?;
     atlas.try_insert(c2, 3)?;
-    let mut section = Section::<i32>::new(atlas.clone());
+    let mut section = Section::<i32, VecStorage<i32>>::new(atlas.clone());
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
     stack.add_arrow(b, c1, Polarity::Forward)?;

--- a/tests/data/bundle_vec_dofs.rs
+++ b/tests/data/bundle_vec_dofs.rs
@@ -1,4 +1,4 @@
-use mesh_sieve::data::{atlas::Atlas, bundle::Bundle, section::Section};
+use mesh_sieve::data::{atlas::Atlas, bundle::Bundle, section::Section, storage::VecStorage};
 use mesh_sieve::overlap::delta::CopyDelta;
 use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
@@ -14,7 +14,7 @@ fn bundle_refine_with_forward_and_reverse() -> Result<(), Box<dyn std::error::Er
     atlas.try_insert(c1, 3)?;
     atlas.try_insert(c2, 3)?;
 
-    let mut section = Section::<i32>::new(atlas.clone());
+    let mut section = Section::<i32, VecStorage<i32>>::new(atlas.clone());
     section.try_set(b, &[1, 2, 3])?;
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
@@ -38,7 +38,7 @@ fn bundle_assemble_elementwise_average() -> Result<(), Box<dyn std::error::Error
     atlas.try_insert(b, 3)?;
     atlas.try_insert(c1, 3)?;
     atlas.try_insert(c2, 3)?;
-    let mut section = Section::<f64>::new(atlas.clone());
+    let mut section = Section::<f64, VecStorage<f64>>::new(atlas.clone());
 
     let mut stack = InMemoryStack::<PointId, PointId, Polarity>::default();
     stack.add_arrow(b, c1, Polarity::Forward)?;

--- a/tests/data/invariants.rs
+++ b/tests/data/invariants.rs
@@ -1,5 +1,6 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::data::DebugInvariants;
 use mesh_sieve::topology::point::PointId;
 
@@ -19,7 +20,7 @@ fn section_size_matches_total_len() -> Result<(), Box<dyn std::error::Error>> {
     let mut a = Atlas::default();
     let p = PointId::new(10)?;
     a.try_insert(p, 4)?;
-    let s = Section::<i32>::new(a);
+    let s = Section::<i32, VecStorage<i32>>::new(a);
     assert!(s.validate_invariants().is_ok());
     Ok(())
 }

--- a/tests/data/section_scatter.rs
+++ b/tests/data/section_scatter.rs
@@ -1,5 +1,6 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::topology::point::PointId;
 
 #[test]
@@ -9,7 +10,7 @@ fn section_scatter_in_order_matches_expected_slices() -> Result<(), Box<dyn std:
     let p2 = PointId::new(2)?; a.try_insert(p2, 3)?;
     let p3 = PointId::new(3)?; a.try_insert(p3, 1)?;
 
-    let mut s = Section::<i32>::new(a.clone());
+    let mut s = Section::<i32, VecStorage<i32>>::new(a.clone());
     let total = a.total_len();
     let flat: Vec<i32> = (0..total as i32).collect();
     s.try_scatter_in_order(&flat)?;
@@ -26,7 +27,7 @@ fn section_scatter_in_order_length_mismatch_errors() -> Result<(), Box<dyn std::
     let mut a = Atlas::default();
     a.try_insert(PointId::new(1)?, 3)?;
     a.try_insert(PointId::new(2)?, 2)?;
-    let mut s = Section::<u32>::new(a);
+    let mut s = Section::<u32, VecStorage<u32>>::new(a);
 
     let bad = vec![0u32; 4];
     let err = s.try_scatter_in_order(&bad).unwrap_err();
@@ -40,7 +41,7 @@ fn section_scatter_with_plan_stale_rejected() -> Result<(), Box<dyn std::error::
     let p = PointId::new(7)?; a.try_insert(p, 2)?;
     let plan = a.build_scatter_plan();
 
-    let mut s = Section::<i32>::new(a);
+    let mut s = Section::<i32, VecStorage<i32>>::new(a);
     s.try_add_point(PointId::new(8)?, 1)?;
 
     let buf = vec![0i32; s.as_flat_slice().len()];

--- a/tests/data/section_with_atlas_mut.rs
+++ b/tests/data/section_with_atlas_mut.rs
@@ -1,4 +1,4 @@
-use mesh_sieve::data::{atlas::Atlas, section::Section};
+use mesh_sieve::data::{atlas::Atlas, section::Section, storage::VecStorage};
 use mesh_sieve::topology::point::PointId;
 
 #[test]
@@ -6,7 +6,7 @@ fn section_with_atlas_mut_rebuilds_data() -> Result<(), Box<dyn std::error::Erro
     let mut a = Atlas::default();
     let p = PointId::new(10)?;
     a.try_insert(p, 2)?;
-    let mut s = Section::<i32>::new(a);
+    let mut s = Section::<i32, VecStorage<i32>>::new(a);
     s.try_set(p, &[7, 8])?;
 
     // Add a new point and ensure it's defaulted

--- a/tests/e2e_showcase_smoke.rs
+++ b/tests/e2e_showcase_smoke.rs
@@ -1,6 +1,7 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::refine::sieved_array::SievedArray;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::topology::arrow::Polarity;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::Sieve;
@@ -21,7 +22,7 @@ fn orientation_and_overlap_smoke() {
     let mut atlas = Atlas::default();
     atlas.try_insert(q0, 4).unwrap();
     atlas.try_insert(q1, 4).unwrap();
-    let mut sec = Section::<f64>::new(atlas.clone());
+    let mut sec = Section::<f64, VecStorage<f64>>::new(atlas.clone());
     sec.try_set(q0, &[1.0, 2.0, 3.0, 4.0]).unwrap();
     sec.try_set(q1, &[10.0, 20.0, 30.0, 40.0]).unwrap();
 
@@ -91,7 +92,7 @@ fn parallel_refine_parity() {
     let mut atlas = Atlas::default();
     atlas.try_insert(q0, 4).unwrap();
     atlas.try_insert(q1, 4).unwrap();
-    let mut sec = Section::<f64>::new(atlas.clone());
+    let mut sec = Section::<f64, VecStorage<f64>>::new(atlas.clone());
     sec.try_set(q0, &[1.0, 2.0, 3.0, 4.0]).unwrap();
     sec.try_set(q1, &[10.0, 20.0, 30.0, 40.0]).unwrap();
 

--- a/tests/helpers_try_restrict_ok_err.rs
+++ b/tests/helpers_try_restrict_ok_err.rs
@@ -3,6 +3,7 @@ use mesh_sieve::data::refine::helpers::try_restrict_closure_vec;
 #[cfg(feature = "map-adapter")]
 use mesh_sieve::data::refine::helpers::restrict_closure_vec;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::mesh_error::MeshSieveError;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::in_memory::InMemorySieve;
@@ -17,7 +18,7 @@ fn v(i: u64) -> PointId {
 fn restrict_closure_panics_on_missing_point() {
     let sieve = InMemorySieve::<PointId, ()>::default();
     let atlas = Atlas::default();
-    let section = Section::<i32>::new(atlas);
+    let section = Section::<i32, VecStorage<i32>>::new(atlas);
     // legacy helper panics when point is missing
     let _ = restrict_closure_vec(&sieve, &section, [v(1)]);
 }
@@ -26,7 +27,7 @@ fn restrict_closure_panics_on_missing_point() {
 fn try_restrict_closure_err_on_missing_point() {
     let sieve = InMemorySieve::<PointId, ()>::default();
     let atlas = Atlas::default();
-    let section = Section::<i32>::new(atlas);
+    let section = Section::<i32, VecStorage<i32>>::new(atlas);
     let err = try_restrict_closure_vec(&sieve, &section, [v(1)]).unwrap_err();
     assert!(matches!(err, MeshSieveError::PointNotInAtlas(pid) if pid == v(1)));
 }

--- a/tests/infallible_helpers_off.rs
+++ b/tests/infallible_helpers_off.rs
@@ -1,9 +1,9 @@
-use mesh_sieve::data::{atlas::Atlas, refine::try_restrict_closure_vec, section::Section};
+use mesh_sieve::data::{atlas::Atlas, refine::try_restrict_closure_vec, section::Section, storage::VecStorage};
 use mesh_sieve::topology::{point::PointId, sieve::in_memory::InMemorySieve};
 
 #[test]
 fn fallible_helpers_exist() {
     let s = InMemorySieve::<PointId, ()>::default();
-    let sec: Section<u8> = Section::new(Atlas::default());
+    let sec: Section<u8, VecStorage<u8>> = Section::new(Atlas::default());
     let _ = try_restrict_closure_vec(&s, &sec, std::iter::empty::<PointId>());
 }

--- a/tests/infallible_helpers_on.rs
+++ b/tests/infallible_helpers_on.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "map-adapter")]
 #[test]
 fn infallible_helpers_exist() {
-    use mesh_sieve::data::{atlas::Atlas, refine::restrict_closure_vec, section::Section};
+    use mesh_sieve::data::{atlas::Atlas, refine::restrict_closure_vec, section::Section, storage::VecStorage};
     use mesh_sieve::topology::{point::PointId, sieve::in_memory::InMemorySieve};
     let s = InMemorySieve::<PointId, ()>::default();
-    let sec: Section<u8> = Section::new(Atlas::default());
+    let sec: Section<u8, VecStorage<u8>> = Section::new(Atlas::default());
     let _ = restrict_closure_vec(&s, &sec, std::iter::empty::<PointId>());
 }

--- a/tests/map_adapter_off.rs
+++ b/tests/map_adapter_off.rs
@@ -1,8 +1,9 @@
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 
 // No Map here; just ensure fallible API is available.
 #[test]
 fn fallible_core_is_present() {
     let atlas = mesh_sieve::data::atlas::Atlas::default();
-    let _sec: Section<u32> = Section::new(atlas);
+    let _sec: Section<u32, VecStorage<u32>> = Section::new(atlas);
 }

--- a/tests/map_adapter_on.rs
+++ b/tests/map_adapter_on.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "map-adapter")]
 #[test]
 fn map_trait_is_exposed() {
-    use mesh_sieve::data::section::{Map, Section};
+    use mesh_sieve::data::{section::{Map, Section}, storage::VecStorage};
     let atlas = mesh_sieve::data::atlas::Atlas::default();
-    let sec: Section<u32> = Section::new(atlas);
+    let sec: Section<u32, VecStorage<u32>> = Section::new(atlas);
     // compile-time check that Map is in scope
     fn takes_map<M: Map<u32>>(_m: &M) {}
     takes_map(&sec);

--- a/tests/section_completion.rs
+++ b/tests/section_completion.rs
@@ -1,7 +1,7 @@
 mod util;
 use mesh_sieve::{
     algs::completion::section_completion::complete_section,
-    data::{atlas::Atlas, section::Section},
+    data::{atlas::Atlas, section::Section, storage::VecStorage},
     overlap::{delta::ValueDelta, overlap::Overlap},
 };
 use util::*;
@@ -33,21 +33,21 @@ fn complete_section_vec3_happy_path() {
     let mut ov1 = Overlap::default();
     ov1.add_link(pid(101), 0, pid(1));
 
-    let mut sec0 = Section::<Vec3>::new(Atlas::default());
+    let mut sec0 = Section::<Vec3, VecStorage<Vec3>>::new(Atlas::default());
     sec0.try_add_point(pid(1), 1).unwrap();
     sec0.try_add_point(pid(101), 1).unwrap();
     sec0.try_restrict_mut(pid(1)).unwrap()[0] = Vec3([1.0, 2.0, 3.0]);
 
-    let mut sec1 = Section::<Vec3>::new(Atlas::default());
+    let mut sec1 = Section::<Vec3, VecStorage<Vec3>>::new(Atlas::default());
     sec1.try_add_point(pid(101), 1).unwrap();
     sec1.try_add_point(pid(1), 1).unwrap();
     sec1.try_restrict_mut(pid(101)).unwrap()[0] = Vec3([1.0, 2.0, 3.0]);
 
     let handle = std::thread::spawn(move || {
         let mut s1 = sec1;
-        complete_section::<Vec3, AvgDelta, _>(&mut s1, &ov1, &c1, 1).unwrap();
+        complete_section::<Vec3, VecStorage<Vec3>, AvgDelta, _>(&mut s1, &ov1, &c1, 1).unwrap();
     });
-    complete_section::<Vec3, AvgDelta, _>(&mut sec0, &ov0, &c0, 0).unwrap();
+    complete_section::<Vec3, VecStorage<Vec3>, AvgDelta, _>(&mut sec0, &ov0, &c0, 0).unwrap();
     handle.join().unwrap();
 
     let got = &sec0.try_restrict(pid(1)).unwrap()[0];
@@ -61,11 +61,11 @@ fn complete_section_missing_overlap_errors() {
     let mut ov = Overlap::default();
     ov.add_link_structural_one(pid(2), 1);
 
-    let mut sec = Section::<Vec3>::new(Atlas::default());
+    let mut sec = Section::<Vec3, VecStorage<Vec3>>::new(Atlas::default());
     sec.try_add_point(pid(2), 1).unwrap();
     sec.try_restrict_mut(pid(2)).unwrap()[0] = Vec3([9.0, 9.0, 9.0]);
 
-    let err = complete_section::<Vec3, AvgDelta, _>(&mut sec, &ov, &c0, 0)
+    let err = complete_section::<Vec3, VecStorage<Vec3>, AvgDelta, _>(&mut sec, &ov, &c0, 0)
         .err()
         .expect("should fail");
     let msg = format!("{:?}", err);

--- a/tests/section_scatter.rs
+++ b/tests/section_scatter.rs
@@ -1,5 +1,6 @@
 use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
 use mesh_sieve::mesh_error::MeshSieveError;
 use mesh_sieve::topology::point::PointId;
 
@@ -12,7 +13,7 @@ fn scatter_fast_path_identical_layout() {
     let mut atlas = Atlas::default();
     atlas.try_insert(pid(1), 3).unwrap();
     atlas.try_insert(pid(2), 2).unwrap();
-    let mut sec = Section::<i32>::new(atlas.clone());
+    let mut sec = Section::<i32, VecStorage<i32>>::new(atlas.clone());
 
     let buf = vec![10, 11, 12, 20, 21];
     let spans = atlas.atlas_map();
@@ -26,7 +27,7 @@ fn scatter_generic_noncontiguous_layout() {
     let mut atlas = Atlas::default();
     atlas.try_insert(pid(1), 2).unwrap();
     atlas.try_insert(pid(2), 2).unwrap();
-    let mut sec = Section::<i32>::new(atlas.clone());
+    let mut sec = Section::<i32, VecStorage<i32>>::new(atlas.clone());
 
     let spans = vec![(2usize, 2usize), (0usize, 2usize)];
     let buf = vec![100, 101, 200, 201];
@@ -40,7 +41,7 @@ fn scatter_generic_noncontiguous_layout() {
 fn scatter_mismatched_total_len_is_error() {
     let mut atlas = Atlas::default();
     atlas.try_insert(pid(1), 3).unwrap();
-    let mut sec = Section::<i32>::new(atlas.clone());
+    let mut sec = Section::<i32, VecStorage<i32>>::new(atlas.clone());
 
     let spans = atlas.atlas_map();
     let buf = vec![1, 2];


### PR DESCRIPTION
## Summary
- make core Section type explicitly generic over storage and add `CpuSection` alias
- propagate storage generics to Bundle, ReadOnlyMap, and completion helpers
- update tests and examples for explicit VecStorage usage

## Testing
- `cargo check`
- `cargo check -F check-invariants`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c34717f87c8329a3052a1131a688ed