### PR TITLE
Optimize Section and Bundle hot paths

### DIFF
--- a/src/data/bundle.rs
+++ b/src/data/bundle.rs
@@ -152,11 +152,9 @@ where
         &mut self,
         bases: impl IntoIterator<Item = PointId>,
     ) -> Result<(), crate::mesh_error::MeshSieveError> {
-        let bases_vec: Vec<PointId> = bases.into_iter().collect();
-        for &b in &bases_vec {
+        for b in self.stack.base().closure(bases) {
+            // Validate base slice exists even if no caps are present
             self.section.try_restrict(b)?;
-        }
-        for b in self.stack.base().closure(bases_vec) {
             for (cap, orientation) in self.stack.lift(b) {
                 self.section
                     .try_apply_delta_between_points(b, cap, &orientation)?;


### PR DESCRIPTION
## Summary
- mark hot section helpers inline
- avoid unnecessary allocations when adding or rebuilding points
- stream bundle refinement without temporary vectors

## Testing
- `cargo test`
- `cargo test --features check-invariants`
- `cargo test --features rayon,check-invariants` *(fails: function takes 4 generic arguments but 3 generic arguments were supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68c39ec56a048329a1ee07af045654e5