### PR TITLE
Implement safer OvlId accessors

### DIFF
--- a/src/mesh_error.rs
+++ b/src/mesh_error.rs
@@ -192,6 +192,14 @@ pub enum MeshSieveError {
         src: crate::overlap::overlap::OvlId,
         dst: crate::overlap::overlap::OvlId,
     },
+    #[error("expected Local(_), found {found:?}")]
+    OverlapExpectedLocal {
+        found: crate::overlap::overlap::OvlId,
+    },
+    #[error("expected Part(_), found {found:?}")]
+    OverlapExpectedPart {
+        found: crate::overlap::overlap::OvlId,
+    },
     #[error("Overlap: payload.rank {found} != Part({expected})")]
     OverlapRankMismatch { expected: usize, found: usize },
     #[error("Overlap: Part node found in base_points()")]
@@ -430,6 +438,8 @@ impl PartialEq for MeshSieveError {
                 OverlapNonBipartite { src: s1, dst: d1 },
                 OverlapNonBipartite { src: s2, dst: d2 },
             ) => s1 == s2 && d1 == d2,
+            (OverlapExpectedLocal { found: f1 }, OverlapExpectedLocal { found: f2 }) => f1 == f2,
+            (OverlapExpectedPart { found: f1 }, OverlapExpectedPart { found: f2 }) => f1 == f2,
             (
                 OverlapRankMismatch {
                     expected: e1,

--- a/tests/overlap_determinism.rs
+++ b/tests/overlap_determinism.rs
@@ -30,7 +30,7 @@ fn bulk_insertion_is_deterministic() {
     for r in ov.neighbor_ranks() {
         let locals_in_order: Vec<_> = ov
             .support(part(r))
-            .map(|(src, _rem)| src.expect_local())
+            .map(|(src, _rem)| src.as_local().expect("support yields Local ids"))
             .collect();
 
         let mut expected = locals_in_order.clone();
@@ -60,7 +60,7 @@ fn ensure_closure_of_support_order_is_deterministic() {
 
     let locals_in_order: Vec<_> = ov
         .support(part(7))
-        .map(|(src, _rem)| src.expect_local())
+        .map(|(src, _rem)| src.as_local().expect("support yields Local ids"))
         .collect();
     let mut expected = locals_in_order.clone();
     expected.sort_unstable();


### PR DESCRIPTION
## Summary
- add explicit overlap error variants when an OvlId has the wrong form
- provide as_*/try_* helpers on OvlId, deprecate expect_* and implement TryFrom
- cover the new helpers in unit tests and adjust determinism tests to use them

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c8ea29c86c83299184287104ee10f5