### PR TITLE
Add metric-driven adaptivity and anisotropic split hints

### DIFF
--- a/docs/geometry-quality.md
+++ b/docs/geometry-quality.md
@@ -79,7 +79,10 @@ let mesh = reader.read_with_options(std::fs::File::open("mesh.msh")?, opts)?;
 ```rust
 use mesh_sieve::topology::refine::{refine_mesh_with_options, RefineOptions};
 
-let opts = RefineOptions { check_geometry: true };
+let opts = RefineOptions {
+    check_geometry: true,
+    anisotropic_splits: None,
+};
 let refined = refine_mesh_with_options(
     &mut coarse_sieve,
     &cell_types,

--- a/examples/adapt_with_metric.rs
+++ b/examples/adapt_with_metric.rs
@@ -1,0 +1,73 @@
+use mesh_sieve::adapt::{adapt_with_metric, MetricAdaptationAction, MetricThresholds, MetricTensor};
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::coordinates::Coordinates;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::topology::cell_type::CellType;
+use mesh_sieve::topology::coarsen::CoarsenEntity;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::InMemorySieve;
+
+fn pt(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+fn main() {
+    let mut sieve = InMemorySieve::<PointId, ()>::default();
+    let cell = pt(10);
+    let vertices = [pt(1), pt(2), pt(3)];
+    for v in vertices {
+        sieve.add_arrow(cell, v, ());
+    }
+
+    let mut cell_atlas = Atlas::default();
+    cell_atlas.try_insert(cell, 1).unwrap();
+    let mut cell_types = Section::<CellType, VecStorage<CellType>>::new(cell_atlas);
+    cell_types.try_set(cell, &[CellType::Triangle]).unwrap();
+
+    let mut coord_atlas = Atlas::default();
+    for v in vertices {
+        coord_atlas.try_insert(v, 2).unwrap();
+    }
+    let mut coords = Coordinates::<f64, VecStorage<f64>>::try_new(2, 2, coord_atlas).unwrap();
+    coords
+        .try_restrict_mut(vertices[0])
+        .unwrap()
+        .copy_from_slice(&[0.0, 0.0]);
+    coords
+        .try_restrict_mut(vertices[1])
+        .unwrap()
+        .copy_from_slice(&[3.0, 0.0]);
+    coords
+        .try_restrict_mut(vertices[2])
+        .unwrap()
+        .copy_from_slice(&[0.0, 1.0]);
+
+    let mut metric_atlas = Atlas::default();
+    metric_atlas.try_insert(cell, 1).unwrap();
+    let mut metrics = Section::<MetricTensor, VecStorage<MetricTensor>>::new(metric_atlas);
+    metrics
+        .try_set(cell, &[MetricTensor::new_2d(1.0, 1.0, 0.0)])
+        .unwrap();
+
+    let thresholds = MetricThresholds::default();
+    let result = adapt_with_metric(
+        &mut sieve,
+        &cell_types,
+        &coords,
+        &metrics,
+        |_hints| Vec::<CoarsenEntity>::new(),
+        thresholds,
+    )
+    .unwrap();
+
+    match result.action {
+        MetricAdaptationAction::Refined { mesh } => {
+            println!("refined {} cells", mesh.cell_refinement.len());
+        }
+        MetricAdaptationAction::Coarsened { mesh } => {
+            println!("coarsened {} entities", mesh.transfer_map.len());
+        }
+        MetricAdaptationAction::NoChange => println!("no adaptation needed"),
+    }
+}

--- a/src/topology/adapt.rs
+++ b/src/topology/adapt.rs
@@ -125,6 +125,7 @@ where
             coordinates,
             RefineOptions {
                 check_geometry: options.check_geometry,
+                anisotropic_splits: None,
             },
         )?;
         return Ok(AdaptivityResult {

--- a/tests/adapt_metric.rs
+++ b/tests/adapt_metric.rs
@@ -1,0 +1,110 @@
+use mesh_sieve::adapt::{
+    adapt_with_metric_and_transfer, MetricAdaptationAction, MetricThresholds, MetricTensor,
+};
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::coordinates::Coordinates;
+use mesh_sieve::data::refine::sieved_array::SievedArray;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::topology::cell_type::CellType;
+use mesh_sieve::topology::coarsen::CoarsenEntity;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::InMemorySieve;
+
+fn pt(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+fn cell_types_section(cells: &[(PointId, CellType)]) -> Section<CellType, VecStorage<CellType>> {
+    let mut atlas = Atlas::default();
+    for (cell, _) in cells {
+        atlas.try_insert(*cell, 1).unwrap();
+    }
+    let mut section = Section::<CellType, VecStorage<CellType>>::new(atlas);
+    for (cell, cell_type) in cells {
+        section.try_set(*cell, &[*cell_type]).unwrap();
+    }
+    section
+}
+
+#[test]
+fn refine_cells_from_metric_tensor() {
+    let mut sieve = InMemorySieve::<PointId, ()>::default();
+    let cell = pt(10);
+    let vertices = [pt(1), pt(2), pt(3)];
+    for v in vertices {
+        sieve.add_arrow(cell, v, ());
+    }
+
+    let cell_types = cell_types_section(&[(cell, CellType::Triangle)]);
+
+    let mut coord_atlas = Atlas::default();
+    for v in vertices {
+        coord_atlas.try_insert(v, 2).unwrap();
+    }
+    let mut coords = Coordinates::<f64, VecStorage<f64>>::try_new(2, 2, coord_atlas).unwrap();
+    coords
+        .try_restrict_mut(vertices[0])
+        .unwrap()
+        .copy_from_slice(&[0.0, 0.0]);
+    coords
+        .try_restrict_mut(vertices[1])
+        .unwrap()
+        .copy_from_slice(&[3.0, 0.0]);
+    coords
+        .try_restrict_mut(vertices[2])
+        .unwrap()
+        .copy_from_slice(&[0.0, 1.0]);
+
+    let mut metric_atlas = Atlas::default();
+    metric_atlas.try_insert(cell, 1).unwrap();
+    let mut metrics = Section::<MetricTensor, VecStorage<MetricTensor>>::new(metric_atlas);
+    metrics
+        .try_set(cell, &[MetricTensor::new_2d(1.0, 1.0, 0.0)])
+        .unwrap();
+
+    let mut data_atlas = Atlas::default();
+    data_atlas.try_insert(cell, 1).unwrap();
+    let mut cell_data = SievedArray::<PointId, f64>::new(data_atlas);
+    cell_data.try_set(cell, &[2.0]).unwrap();
+
+    let thresholds = MetricThresholds {
+        refine_max_edge_length: 2.0,
+        coarsen_max_edge_length: 0.5,
+        split_edge_length: 2.0,
+        split_face_length: 2.0,
+        check_geometry: false,
+    };
+
+    let result = adapt_with_metric_and_transfer(
+        &mut sieve,
+        &cell_types,
+        &coords,
+        &metrics,
+        &cell_data,
+        |_hints| Vec::<CoarsenEntity>::new(),
+        thresholds,
+    )
+    .unwrap();
+
+    assert_eq!(result.refine_cells, vec![cell]);
+    assert!(result
+        .split_hints
+        .iter()
+        .any(|hint| hint.cell == cell && !hint.split_edges.is_empty()));
+
+    let refined = match result.action {
+        MetricAdaptationAction::Refined { mesh } => mesh,
+        _ => panic!("expected refinement"),
+    };
+
+    let refined_data = result.data.expect("expected refined data");
+    for (fine_cell, _) in refined
+        .cell_refinement
+        .iter()
+        .flat_map(|(_, fine_cells)| fine_cells.iter())
+    {
+        let fine_slice = refined_data.try_get(*fine_cell).unwrap();
+        assert_eq!(fine_slice, &[2.0]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide per-cell metric tensors (anisotropic sizing fields) to drive refine/coarsen decisions and produce DMPlex-style "adapt with metric" workflows. 
- Allow refinement to receive edge/face split hints so the topology refine routines can perform anisotropic splits where appropriate. 
- Expose a high-level API and examples/tests to demonstrate metric-driven adaptation and data transfer.

### Description
- Introduce `MetricTensor`, `MetricCellMetrics`, `MetricThresholds`, and `MetricSplitHint` and helpers to evaluate per-cell metric summaries in `src/adapt/mod.rs`. 
- Add metric evaluation machinery: `evaluate_metric_cells`, `select_cells_for_metric_adaptation`, `metric_split_hints`, and utilities to build anisotropic split hints used during refinement. 
- Add two public adapt APIs: `adapt_with_metric` (no data transfer) and `adapt_with_metric_and_transfer` (with `SievedArray` data transfer), mirroring DMPlex "adapt with metric" semantics. 
- Extend refinement plumbing by adding `AnisotropicSplitHints` to `RefineOptions` and validating these hints in `refine_mesh_with_options` so per-cell edge/face splits can be provided to the refinement code (`src/topology/refine/mod.rs`). 
- Wire anisotropic hints through existing adapt drivers in `src/adapt/mod.rs`, `src/topology/adapt.rs` and keep existing quality-driven adapt APIs intact. 
- Add an example (`examples/adapt_with_metric.rs`) and a unit test (`tests/adapt_metric.rs`) exercising metric-driven refinement and data transfer, and a small docs tweak to demonstrate new `RefineOptions` usage. 
- Remove an unused `SliceDelta` import in `src/adapt/mod.rs`.

### Testing
- Ran the new targeted test with `cargo test --test adapt_metric`, which started compilation and execution but failed during build because the `hdf5-sys` dependency could not locate system HDF5 development headers (build error from `hdf5-sys`), so the test did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983be1fec54832997a35190c15c6809)