### PR TITLE
Add orientation-aware closure DOF maps

### DIFF
--- a/src/discretization/mod.rs
+++ b/src/discretization/mod.rs
@@ -3,7 +3,7 @@
 pub mod runtime;
 
 pub use runtime::{
-    Basis, BasisTabulation, DofMap, ElementRuntime, ElementTabulation, QuadratureRule,
+    Basis, BasisTabulation, ClosureDof, DofMap, ElementRuntime, ElementTabulation, QuadratureRule,
     assemble_local_matrix, assemble_local_vector, cell_vertices, local_load_vector,
     local_stiffness_matrix, runtime_from_metadata, tabulate_element,
 };

--- a/src/discretization/runtime.rs
+++ b/src/discretization/runtime.rs
@@ -327,33 +327,95 @@ where
     vector
 }
 
-/// Mapping from mesh points to contiguous DOF indices.
+/// One scalar degree of freedom in an element closure.
+///
+/// `point` identifies the mesh point that owns the DOF, while
+/// `local_dof` is the section-local slot after any orientation-dependent
+/// [`SectionSym`](crate::data::closure::SectionSym) permutation has been
+/// applied.  This is the unit consumed by high-order and tensor-product
+/// element kernels.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ClosureDof {
+    /// Mesh point that owns this scalar DOF.
+    pub point: PointId,
+    /// Section-local DOF slot on `point`.
+    pub local_dof: usize,
+}
+
+/// Mapping from closure-local scalar DOFs to contiguous assembly indices.
 #[derive(Clone, Debug)]
 pub struct DofMap {
     dofs: Vec<PointId>,
-    indices: HashMap<PointId, usize>,
+    closure_dofs: Vec<ClosureDof>,
+    indices: HashMap<ClosureDof, usize>,
+    first_point_indices: HashMap<PointId, usize>,
 }
 
 impl DofMap {
-    /// Build a DOF map from an ordered list of points.
+    /// Build a scalar DOF map from an ordered list of points.
+    ///
+    /// This constructor preserves the historical scalar API where each point
+    /// owns one DOF.  Use [`from_closure_dofs`](Self::from_closure_dofs) when
+    /// point-local DOF slots matter.
     pub fn new(dofs: Vec<PointId>) -> Self {
-        let indices = dofs.iter().enumerate().map(|(idx, &p)| (p, idx)).collect();
-        Self { dofs, indices }
+        let closure_dofs: Vec<_> = dofs
+            .iter()
+            .map(|&point| ClosureDof {
+                point,
+                local_dof: 0,
+            })
+            .collect();
+        Self::from_closure_dofs(closure_dofs)
     }
 
-    /// Return the ordered DOF points.
+    /// Build a DOF map from orientation-correct closure DOF slots.
+    pub fn from_closure_dofs(closure_dofs: Vec<ClosureDof>) -> Self {
+        let dofs = closure_dofs.iter().map(|dof| dof.point).collect();
+        let mut indices = HashMap::with_capacity(closure_dofs.len());
+        let mut first_point_indices = HashMap::new();
+        for (idx, &dof) in closure_dofs.iter().enumerate() {
+            indices.insert(dof, idx);
+            first_point_indices.entry(dof.point).or_insert(idx);
+        }
+        Self {
+            dofs,
+            closure_dofs,
+            indices,
+            first_point_indices,
+        }
+    }
+
+    /// Return the ordered DOF owner points.
     pub fn dofs(&self) -> &[PointId] {
         &self.dofs
     }
 
-    /// Total number of DOFs.
-    pub fn len(&self) -> usize {
-        self.dofs.len()
+    /// Return the ordered point/local-slot DOFs consumed by closure kernels.
+    pub fn closure_dofs(&self) -> &[ClosureDof] {
+        &self.closure_dofs
     }
 
-    /// Lookup the index for a point.
+    /// Total number of scalar DOFs.
+    pub fn len(&self) -> usize {
+        self.closure_dofs.len()
+    }
+
+    /// Returns true when this map has no DOFs.
+    pub fn is_empty(&self) -> bool {
+        self.closure_dofs.is_empty()
+    }
+
+    /// Lookup the first index for a point.
+    ///
+    /// This method is kept for scalar assembly compatibility.  For high-order
+    /// sections with multiple DOFs per point, use [`slot_index`](Self::slot_index).
     pub fn index(&self, point: PointId) -> Option<usize> {
-        self.indices.get(&point).copied()
+        self.first_point_indices.get(&point).copied()
+    }
+
+    /// Lookup the assembly index for a point-local DOF slot.
+    pub fn slot_index(&self, point: PointId, local_dof: usize) -> Option<usize> {
+        self.indices.get(&ClosureDof { point, local_dof }).copied()
     }
 }
 
@@ -387,11 +449,14 @@ where
 pub fn dof_map_from_closure_index<O>(index: &ClosureIndex<O>) -> DofMap {
     let mut dofs = Vec::with_capacity(index.len);
     for entry in &index.points {
-        for _ in 0..entry.len {
-            dofs.push(entry.point);
+        for &local_dof in &entry.permutation {
+            dofs.push(ClosureDof {
+                point: entry.point,
+                local_dof,
+            });
         }
     }
-    DofMap::new(dofs)
+    DofMap::from_closure_dofs(dofs)
 }
 
 /// Add a local vector contribution into a global section.

--- a/tests/dmplex_closure.rs
+++ b/tests/dmplex_closure.rs
@@ -1,0 +1,134 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::{
+    ClosureOrder, IdentitySectionSym, Section, TableSectionSym, VecStorage, add_closure,
+    build_closure_index, build_closure_index_unoriented, get_closure, set_closure,
+};
+use mesh_sieve::discretization::runtime::dof_map_from_closure_index;
+use mesh_sieve::topology::orientation::Sign;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::oriented::OrientedSieve;
+use mesh_sieve::topology::sieve::{InMemoryOrientedSieve, InMemorySieve, Sieve};
+
+fn p(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+#[test]
+fn dmplex_closure_get_set_add_follow_breadth_first_indices() {
+    let mut topo = InMemorySieve::<PointId, ()>::default();
+    topo.add_arrow(p(1), p(2), ());
+    topo.add_arrow(p(1), p(3), ());
+    topo.add_arrow(p(2), p(4), ());
+
+    let mut atlas = Atlas::default();
+    for (point, len) in [(p(1), 1), (p(2), 2), (p(3), 1), (p(4), 1)] {
+        atlas.try_insert(point, len).unwrap();
+    }
+    let mut section = Section::<i32, VecStorage<i32>>::new(atlas);
+    section.try_scatter_in_order(&[10, 20, 21, 30, 40]).unwrap();
+
+    let index = build_closure_index_unoriented(
+        &topo,
+        &section,
+        p(1),
+        0,
+        &ClosureOrder::BreadthFirstDmpLex,
+        &IdentitySectionSym,
+    )
+    .unwrap();
+
+    assert_eq!(
+        index.point_order().collect::<Vec<_>>(),
+        vec![p(1), p(2), p(3), p(4)]
+    );
+    assert_eq!(
+        get_closure(&section, &index).unwrap(),
+        vec![10, 20, 21, 30, 40]
+    );
+
+    set_closure(&mut section, &index, &[1, 2, 3, 4, 5]).unwrap();
+    add_closure(&mut section, &index, &[10, 20, 30, 40, 50]).unwrap();
+
+    assert_eq!(
+        get_closure(&section, &index).unwrap(),
+        vec![11, 22, 33, 44, 55]
+    );
+}
+
+#[test]
+fn orientation_symmetry_controls_closure_values_and_dof_map_slots() {
+    let mut topo = InMemoryOrientedSieve::<PointId, (), Sign>::default();
+    topo.add_arrow_o(p(1), p(2), (), Sign(true));
+
+    let mut atlas = Atlas::default();
+    atlas.try_insert(p(2), 3).unwrap();
+    let mut section = Section::<i32, VecStorage<i32>>::new(atlas);
+    section.try_scatter_in_order(&[7, 8, 9]).unwrap();
+
+    let mut sym = TableSectionSym::new();
+    sym.insert_orientation(Sign(true), vec![2, 1, 0]);
+
+    let index = build_closure_index(
+        &topo,
+        &section,
+        p(1),
+        42,
+        &ClosureOrder::BreadthFirstDmpLex,
+        &sym,
+    )
+    .unwrap();
+
+    assert_eq!(get_closure(&section, &index).unwrap(), vec![9, 8, 7]);
+
+    let dof_map = dof_map_from_closure_index(&index);
+    let slots: Vec<_> = dof_map
+        .closure_dofs()
+        .iter()
+        .map(|dof| (dof.point, dof.local_dof))
+        .collect();
+    assert_eq!(slots, vec![(p(2), 2), (p(2), 1), (p(2), 0)]);
+    assert_eq!(dof_map.slot_index(p(2), 2), Some(0));
+    assert_eq!(dof_map.slot_index(p(2), 0), Some(2));
+}
+
+#[test]
+fn lexicographic_and_custom_orders_are_predictable() {
+    let mut topo = InMemorySieve::<PointId, ()>::default();
+    topo.add_arrow(p(10), p(30), ());
+    topo.add_arrow(p(10), p(20), ());
+    topo.add_arrow(p(30), p(40), ());
+
+    let mut atlas = Atlas::default();
+    for point in [p(10), p(20), p(30), p(40)] {
+        atlas.try_insert(point, 1).unwrap();
+    }
+    let section = Section::<i32, VecStorage<i32>>::new(atlas);
+
+    let lex = build_closure_index_unoriented(
+        &topo,
+        &section,
+        p(10),
+        0,
+        &ClosureOrder::LexicographicTensor { dims: vec![2, 2] },
+        &IdentitySectionSym,
+    )
+    .unwrap();
+    assert_eq!(
+        lex.point_order().collect::<Vec<_>>(),
+        vec![p(10), p(20), p(30), p(40)]
+    );
+
+    let custom = build_closure_index_unoriented(
+        &topo,
+        &section,
+        p(10),
+        0,
+        &ClosureOrder::Custom(vec![p(40), p(20)]),
+        &IdentitySectionSym,
+    )
+    .unwrap();
+    assert_eq!(
+        custom.point_order().collect::<Vec<_>>(),
+        vec![p(40), p(20), p(10), p(30)]
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide DMPlex-style, orientation-aware closure access so element assembly can consume closure DOFs in a predictable, orientation-correct order for high-order and tensor-product kernels.
- Preserve the historical scalar assembly API while adding slot-level DOF bookkeeping so per-point DOF permutations from orientation symmetries are represented in assembly maps.

### Description
- Introduce `ClosureDof` to represent a scalar DOF as `(point, local_dof)` after applying orientation-dependent `SectionSym` permutations. (`src/discretization/runtime.rs`)
- Extend `DofMap` to store orientation-correct closure slots, add `from_closure_dofs`, `closure_dofs()`, and `slot_index(point, local_dof)`, and keep `index(point)` as a compatibility hook to the first slot. (`src/discretization/runtime.rs`)
- Change `dof_map_from_closure_index` to emit `ClosureDof` entries using each closure entry's `permutation` order so the flattened closure ordering respects orientation permutations. (`src/discretization/runtime.rs`)
- Re-export `ClosureDof` from `discretization` and wire the API into the runtime module. (`src/discretization/mod.rs`)
- Add `tests/dmplex_closure.rs` with tests exercising breadth-first closure get/set/add, orientation-driven DOF permutation feeding into the DOF map slots, and lexicographic/custom ordering behavior. (`tests/dmplex_closure.rs`)

### Testing
- Ran the focused test file with `cargo test --test dmplex_closure` and all 3 new tests passed. 
- Ran the full test suite with `cargo test` and observed a successful run with all tests passing (existing and new), completing without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04abd6d9d88329b97adeabd22f47ec)