### PR TITLE
Add PETSc DMPlex HDF5 v3 I/O (petsc_hdf5 module)

### DIFF
--- a/docs/hdf5-layout.md
+++ b/docs/hdf5-layout.md
@@ -1,33 +1,69 @@
-# HDF5 mesh layout (PETSc/DMPlex conventions)
+# HDF5 mesh layouts
 
-This project stores mesh topology and metadata in an HDF5 file using a
-DMPlex-style layout so it can be consumed by PETSc-compatible tooling and
-XDMF front-ends.
+This repository supports two HDF5 layouts:
 
-## Groups
+1. `src/io/hdf5.rs` keeps the original compact Mesh Sieve layout used by older
+   XDMF/HDF5 round-trips.
+2. `src/io/petsc_hdf5.rs` writes and reads a PETSc DMPlex HDF5 v3-style layout
+   intended for interoperability with PETSc/Firedrake/FEniCSx-like workflows.
+
+## PETSc DMPlex HDF5 v3-compatible layout
+
+The PETSc-compatible writer stores a version marker at the file root and then
+nests mesh topology, labels, sections, and vectors beneath a named topology:
+
+- `/dmplex_storage_version`
+  - `i32[1]`, currently `3`.
+- `/topologies/<mesh>/topology/permutation`
+  - `i64[num_points]` containing the preserved global `PointId` order.
+  - Cone arrays refer to points by zero-based index into this permutation, which
+    allows topology, section, and vector data to be loaded separately and
+    re-associated.
+- `/topologies/<mesh>/topology/strata/<depth>/cone_sizes`
+  - `i32[num_points_at_depth]`; one cone size per point in permutation order for
+    that depth.
+- `/topologies/<mesh>/topology/strata/<depth>/cones`
+  - `i64[sum(cone_sizes)]`; flattened cone point indices into `permutation`.
+- `/topologies/<mesh>/topology/strata/<depth>/orientations`
+  - `i32[sum(cone_sizes)]`; one orientation per cone entry.
+- `/topologies/<mesh>/topology/cell_types`
+  - `i32[num_points]`; DMPlex cell type code for points that carry a cell type,
+    or `-1` for points without one.
+- `/topologies/<mesh>/labels/<label>/<value>/points`
+  - `i64[num_label_points]`; sorted global `PointId`s for each integer label
+    stratum.
+- `/topologies/<mesh>/dms/<dm>/section/<name>/points`
+  - `i64[num_section_points]`; global point IDs in the preserved mesh order.
+- `/topologies/<mesh>/dms/<dm>/section/<name>/dofs`
+  - `i32[num_section_points]`; number of scalar degrees of freedom for each
+    listed point.
+- `/topologies/<mesh>/dms/<dm>/section/<name>/offsets`
+  - `i64[num_section_points]`; offsets into the matching vector dataset.
+- `/topologies/<mesh>/dms/<dm>/vecs/<name>`
+  - `f64[sum(dofs)]`; vector values for the named section.
+
+The public PETSc-compatible API is exposed as `mesh_sieve::io::petsc_hdf5` and
+provides `PetscHdf5Reader`, `PetscHdf5Writer`, `write_mesh_to_petsc_hdf5`, and
+`read_mesh_from_petsc_hdf5`.
+
+## Legacy compact Mesh Sieve layout
+
+The legacy `Hdf5Writer`/`Hdf5Reader` in `src/io/hdf5.rs` store:
 
 - `/topology`
   - `cell_ids` (`i64`, shape = `num_cells`)
-    - Original `PointId` for each cell.
   - `point_ids` (`i64`, shape = `num_points`)
-    - Original `PointId` for each vertex/point.
   - `cell_types` (`i32`, shape = `num_cells`)
-    - DMPlex cell type codes (see mapping below).
   - `cell_offsets` (`i64`, shape = `num_cells + 1`)
-    - Offsets into the flattened `cells` connectivity array.
   - `cells` (`i64`, shape = `num_cell_connectivity`)
-    - Flattened connectivity, storing `PointId` values.
   - `mixed` (`i64`, shape = `num_mixed_entries`)
-    - XDMF Mixed topology encoding (`cell_code, v0, v1, ...`).
 - `/geometry`
   - `coordinates` (`f64`, shape = `num_points x 3`)
-    - XYZ coordinates padded to 3 entries per point.
   - `topological_dimension` (`i32`, shape = `1`)
   - `embedding_dimension` (`i32`, shape = `1`)
   - `point_ids` (`i64`, shape = `num_points`)
 - `/sections/<name>`
   - `ids` (`i64`, shape = `num_entries`)
-    - `PointId` values that own section data.
   - `values` (`f64`, shape = `num_entries x num_components`)
   - `num_components` (`i32`, shape = `1`)
 - `/labels/<name>`
@@ -35,8 +71,6 @@ XDMF front-ends.
   - `values` (`i32`, shape = `num_entries`)
 
 ## Cell type codes (DMPlex)
-
-The `cell_types` array uses PETSc/DMPlex numbering:
 
 | DMPlex code | CellType |
 | --- | --- |
@@ -52,5 +86,6 @@ The `cell_types` array uses PETSc/DMPlex numbering:
 ## XDMF/HDF5 linkage
 
 When the XDMF writer is configured to emit HDF5-backed `DataItem`s, the XDMF
-file references the datasets above using `Format="HDF"` and a dataset URI such
-as `mesh.h5:/geometry/coordinates`.
+file references datasets using `Format="HDF"` and a dataset URI such as
+`mesh.h5:/geometry/coordinates` for the legacy layout. PETSc-compatible files
+should reference the DMPlex hierarchy under `/topologies/<mesh>`.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -9,6 +9,7 @@ pub mod exodus;
 pub mod gmsh;
 pub mod hdf5;
 pub mod partitioned;
+pub mod petsc_hdf5;
 pub mod vtk;
 pub mod xdmf;
 

--- a/src/io/petsc_hdf5.rs
+++ b/src/io/petsc_hdf5.rs
@@ -1,0 +1,624 @@
+//! PETSc DMPlex HDF5 v3-compatible mesh, section, label, and vector I/O.
+//!
+//! This module intentionally lives alongside (rather than replacing)
+//! [`crate::io::hdf5`].  The legacy module stores a compact mesh-sieve layout;
+//! this module mirrors PETSc's modern DMPlex hierarchy closely enough for
+//! mesh/section/vector data to be written, loaded independently, and
+//! re-associated by the preserved point permutation/order.
+
+use crate::data::atlas::Atlas;
+use crate::data::section::Section;
+use crate::data::storage::VecStorage;
+use crate::io::{MeshData, SieveSectionReader, SieveSectionWriter};
+use crate::mesh_error::MeshSieveError;
+use crate::topology::cell_type::CellType;
+use crate::topology::labels::LabelSet;
+use crate::topology::point::PointId;
+use crate::topology::sieve::strata::compute_strata;
+use crate::topology::sieve::{MeshSieve, OrientedSieve, Sieve};
+use hdf5::{File, Group};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// PETSc DMPlex HDF5 storage version written by this module.
+pub const DMPLEX_STORAGE_VERSION: i32 = 3;
+
+const GROUP_TOPOLOGIES: &str = "topologies";
+const GROUP_TOPOLOGY: &str = "topology";
+const GROUP_STRATA: &str = "strata";
+const GROUP_LABELS: &str = "labels";
+const GROUP_DMS: &str = "dms";
+const GROUP_SECTION: &str = "section";
+const GROUP_VECS: &str = "vecs";
+
+const DATASET_VERSION: &str = "dmplex_storage_version";
+const DATASET_PERMUTATION: &str = "permutation";
+const DATASET_CONE_SIZES: &str = "cone_sizes";
+const DATASET_CONES: &str = "cones";
+const DATASET_ORIENTATIONS: &str = "orientations";
+const DATASET_POINTS: &str = "points";
+const DATASET_SECTION_POINTS: &str = "points";
+const DATASET_SECTION_DOFS: &str = "dofs";
+const DATASET_SECTION_OFFSETS: &str = "offsets";
+const DATASET_CELL_TYPES: &str = "cell_types";
+
+/// Options controlling DMPlex HDF5 path names.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PetscHdf5Options {
+    /// Mesh name in `/topologies/<mesh>`.
+    pub mesh_name: String,
+    /// DM name in `/topologies/<mesh>/dms/<dm>`.
+    pub dm_name: String,
+}
+
+impl Default for PetscHdf5Options {
+    fn default() -> Self {
+        Self {
+            mesh_name: "plex".to_string(),
+            dm_name: "dm".to_string(),
+        }
+    }
+}
+
+/// PETSc DMPlex HDF5 v3 reader.
+#[derive(Clone, Debug, Default)]
+pub struct PetscHdf5Reader {
+    options: PetscHdf5Options,
+}
+
+/// PETSc DMPlex HDF5 v3 writer.
+#[derive(Clone, Debug, Default)]
+pub struct PetscHdf5Writer {
+    options: PetscHdf5Options,
+}
+
+impl PetscHdf5Reader {
+    /// Construct a reader using explicit mesh and DM names.
+    pub fn new(mesh_name: impl Into<String>, dm_name: impl Into<String>) -> Self {
+        Self {
+            options: PetscHdf5Options {
+                mesh_name: mesh_name.into(),
+                dm_name: dm_name.into(),
+            },
+        }
+    }
+
+    /// Read only the global point permutation from an HDF5 file.
+    pub fn read_order_from_file(
+        file: &File,
+        mesh_name: &str,
+    ) -> Result<Vec<PointId>, MeshSieveError> {
+        let topology = topology_group(file, mesh_name)?;
+        read_permutation(&topology)
+    }
+
+    /// Read only sections/vectors from an HDF5 file and associate them with a saved order.
+    pub fn read_sections_from_file(
+        file: &File,
+        mesh_name: &str,
+        dm_name: &str,
+    ) -> Result<BTreeMap<String, Section<f64, VecStorage<f64>>>, MeshSieveError> {
+        let topo = file.group(&format!("/{GROUP_TOPOLOGIES}/{mesh_name}"))?;
+        let dm = topo.group(&format!("{GROUP_DMS}/{dm_name}"))?;
+        read_sections(&dm)
+    }
+}
+
+impl PetscHdf5Writer {
+    /// Construct a writer using explicit mesh and DM names.
+    pub fn new(mesh_name: impl Into<String>, dm_name: impl Into<String>) -> Self {
+        Self {
+            options: PetscHdf5Options {
+                mesh_name: mesh_name.into(),
+                dm_name: dm_name.into(),
+            },
+        }
+    }
+}
+
+impl SieveSectionReader for PetscHdf5Reader {
+    type Sieve = MeshSieve;
+    type Value = f64;
+    type Storage = VecStorage<f64>;
+    type CellStorage = VecStorage<CellType>;
+
+    fn read<R: Read>(
+        &self,
+        mut reader: R,
+    ) -> Result<MeshData<Self::Sieve, Self::Value, Self::Storage, Self::CellStorage>, MeshSieveError>
+    {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        let temp_path = write_temp_file(&bytes)?;
+        let file = File::open(&temp_path)
+            .map_err(|err| MeshSieveError::MeshIoParse(format!("HDF5 open error: {err}")))?;
+        let result =
+            read_mesh_from_petsc_hdf5(&file, &self.options.mesh_name, &self.options.dm_name);
+        let _ = fs::remove_file(&temp_path);
+        result
+    }
+}
+
+impl SieveSectionWriter for PetscHdf5Writer {
+    type Sieve = MeshSieve;
+    type Value = f64;
+    type Storage = VecStorage<f64>;
+    type CellStorage = VecStorage<CellType>;
+
+    fn write<W: Write>(
+        &self,
+        mut writer: W,
+        mesh: &MeshData<Self::Sieve, Self::Value, Self::Storage, Self::CellStorage>,
+    ) -> Result<(), MeshSieveError> {
+        let temp_path = temp_hdf5_path();
+        let file = File::create(&temp_path)
+            .map_err(|err| MeshSieveError::MeshIoParse(format!("HDF5 create error: {err}")))?;
+        write_mesh_to_petsc_hdf5(&file, mesh, &self.options.mesh_name, &self.options.dm_name)?;
+        drop(file);
+        let bytes = fs::read(&temp_path)?;
+        writer.write_all(&bytes)?;
+        let _ = fs::remove_file(&temp_path);
+        Ok(())
+    }
+}
+
+/// Write `mesh` to a PETSc DMPlex HDF5 v3-style hierarchy.
+pub fn write_mesh_to_petsc_hdf5(
+    file: &File,
+    mesh: &MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>>,
+    mesh_name: &str,
+    dm_name: &str,
+) -> Result<(), MeshSieveError> {
+    file.new_dataset::<i32>()
+        .shape(1)
+        .create(DATASET_VERSION)?
+        .write(&[DMPLEX_STORAGE_VERSION])?;
+
+    let topologies = create_or_open_group(file, GROUP_TOPOLOGIES)?;
+    let topology_root = create_or_open_group(&topologies, mesh_name)?;
+    let topology = create_or_open_group(&topology_root, GROUP_TOPOLOGY)?;
+
+    let order = point_order(mesh)?;
+    let order_raw: Vec<i64> = order.iter().map(|p| p.get() as i64).collect();
+    topology
+        .new_dataset::<i64>()
+        .shape(order_raw.len())
+        .create(DATASET_PERMUTATION)?
+        .write(&order_raw)?;
+
+    let index_by_point: HashMap<PointId, i64> = order
+        .iter()
+        .enumerate()
+        .map(|(idx, point)| (*point, idx as i64))
+        .collect();
+    let strata = compute_strata(&mesh.sieve)?;
+    let strata_group = create_or_open_group(&topology, GROUP_STRATA)?;
+    let depth_count = strata
+        .depth
+        .values()
+        .copied()
+        .max()
+        .map_or(0usize, |d| d as usize + 1);
+    for depth in 0..depth_count {
+        let points: Vec<PointId> = order
+            .iter()
+            .copied()
+            .filter(|point| strata.depth.get(point).copied() == Some(depth as u32))
+            .collect();
+        write_stratum(&strata_group, depth, &points, &mesh.sieve, &index_by_point)?;
+    }
+
+    write_cell_types(&topology, mesh, &order)?;
+    write_labels(&topology_root, mesh.labels.as_ref())?;
+    write_dm(&topology_root, dm_name, &order, &mesh.sections)?;
+    Ok(())
+}
+
+/// Read mesh, labels, sections, and vectors from a PETSc DMPlex HDF5 v3-style hierarchy.
+pub fn read_mesh_from_petsc_hdf5(
+    file: &File,
+    mesh_name: &str,
+    dm_name: &str,
+) -> Result<MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>>, MeshSieveError> {
+    if let Ok(dataset) = file.dataset(DATASET_VERSION) {
+        let version: Vec<i32> = dataset.read_raw()?;
+        if !version.is_empty() && version[0] != DMPLEX_STORAGE_VERSION {
+            return Err(MeshSieveError::MeshIoParse(format!(
+                "unsupported DMPlex HDF5 storage version {}; expected {DMPLEX_STORAGE_VERSION}",
+                version[0]
+            )));
+        }
+    }
+
+    let topology_root = file.group(&format!("/{GROUP_TOPOLOGIES}/{mesh_name}"))?;
+    let topology = topology_root.group(GROUP_TOPOLOGY)?;
+    let order = read_permutation(&topology)?;
+    let mut sieve = MeshSieve::default();
+    read_strata(&topology, &order, &mut sieve)?;
+    let cell_types = read_cell_types(&topology, &order)?;
+    let labels = read_labels(&topology_root)?;
+    let sections = match topology_root.group(&format!("{GROUP_DMS}/{dm_name}")) {
+        Ok(dm) => read_sections(&dm)?,
+        Err(_) => BTreeMap::new(),
+    };
+
+    Ok(MeshData {
+        sieve,
+        coordinates: None,
+        sections,
+        mixed_sections: Default::default(),
+        labels,
+        cell_types,
+        discretization: None,
+    })
+}
+
+fn point_order(
+    mesh: &MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>>,
+) -> Result<Vec<PointId>, MeshSieveError> {
+    let mut points: Vec<PointId> = mesh
+        .sieve
+        .base_points()
+        .chain(mesh.sieve.cap_points())
+        .collect();
+    if let Some(cell_types) = &mesh.cell_types {
+        points.extend(cell_types.atlas().points());
+    }
+    for section in mesh.sections.values() {
+        points.extend(section.atlas().points());
+    }
+    points.sort_unstable();
+    points.dedup();
+
+    let strata = compute_strata(&mesh.sieve)?;
+    points.sort_unstable_by_key(|point| {
+        (
+            strata.depth.get(point).copied().unwrap_or(u32::MAX),
+            point.get(),
+        )
+    });
+    Ok(points)
+}
+
+fn write_stratum(
+    strata_group: &Group,
+    depth: usize,
+    points: &[PointId],
+    sieve: &MeshSieve,
+    index_by_point: &HashMap<PointId, i64>,
+) -> Result<(), MeshSieveError> {
+    let group = create_or_open_group(strata_group, &depth.to_string())?;
+    let mut cone_sizes = Vec::with_capacity(points.len());
+    let mut cones = Vec::new();
+    let mut orientations = Vec::new();
+    for point in points {
+        let cone: Vec<(PointId, i32)> = sieve.cone_o(*point).collect();
+        cone_sizes.push(cone.len() as i32);
+        for (cone_point, orientation) in cone {
+            let cone_index = index_by_point.get(&cone_point).copied().ok_or_else(|| {
+                MeshSieveError::MeshIoParse(format!(
+                    "point {cone_point:?} missing from permutation"
+                ))
+            })?;
+            cones.push(cone_index);
+            orientations.push(orientation);
+        }
+    }
+    group
+        .new_dataset::<i32>()
+        .shape(cone_sizes.len())
+        .create(DATASET_CONE_SIZES)?
+        .write(&cone_sizes)?;
+    group
+        .new_dataset::<i64>()
+        .shape(cones.len())
+        .create(DATASET_CONES)?
+        .write(&cones)?;
+    group
+        .new_dataset::<i32>()
+        .shape(orientations.len())
+        .create(DATASET_ORIENTATIONS)?
+        .write(&orientations)?;
+    Ok(())
+}
+
+fn read_strata(
+    topology: &Group,
+    order: &[PointId],
+    sieve: &mut MeshSieve,
+) -> Result<(), MeshSieveError> {
+    let strata_group = topology.group(GROUP_STRATA)?;
+    let mut names = strata_group.member_names()?;
+    names.sort_by_key(|name| name.parse::<usize>().unwrap_or(usize::MAX));
+    let mut point_offset = 0usize;
+    for name in names {
+        let group = strata_group.group(&name)?;
+        let cone_sizes: Vec<i32> = group.dataset(DATASET_CONE_SIZES)?.read_raw()?;
+        let cones: Vec<i64> = group.dataset(DATASET_CONES)?.read_raw()?;
+        let orientations: Vec<i32> = group.dataset(DATASET_ORIENTATIONS)?.read_raw()?;
+        let mut cone_offset = 0usize;
+        for cone_size in cone_sizes {
+            let point = *order.get(point_offset).ok_or_else(|| {
+                MeshSieveError::MeshIoParse("strata contain more points than permutation".into())
+            })?;
+            point_offset += 1;
+            for local in 0..(cone_size as usize) {
+                let idx = *cones
+                    .get(cone_offset + local)
+                    .ok_or_else(|| MeshSieveError::MeshIoParse("cone array underflow".into()))?
+                    as usize;
+                let dst = *order.get(idx).ok_or_else(|| {
+                    MeshSieveError::MeshIoParse(format!("cone index {idx} outside permutation"))
+                })?;
+                let orientation = orientations.get(cone_offset + local).copied().unwrap_or(0);
+                sieve.add_arrow_o(point, dst, (), orientation);
+            }
+            cone_offset += cone_size as usize;
+        }
+    }
+    Ok(())
+}
+
+fn write_cell_types(
+    topology: &Group,
+    mesh: &MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>>,
+    order: &[PointId],
+) -> Result<(), MeshSieveError> {
+    let Some(cell_types) = &mesh.cell_types else {
+        return Ok(());
+    };
+    let mut values = Vec::with_capacity(order.len());
+    for point in order {
+        let code = match cell_types.try_restrict(*point) {
+            Ok(slice) if !slice.is_empty() => cell_type_to_dmplex(slice[0])?,
+            _ => -1,
+        };
+        values.push(code);
+    }
+    topology
+        .new_dataset::<i32>()
+        .shape(values.len())
+        .create(DATASET_CELL_TYPES)?
+        .write(&values)?;
+    Ok(())
+}
+
+fn read_cell_types(
+    topology: &Group,
+    order: &[PointId],
+) -> Result<Option<Section<CellType, VecStorage<CellType>>>, MeshSieveError> {
+    let Ok(dataset) = topology.dataset(DATASET_CELL_TYPES) else {
+        return Ok(None);
+    };
+    let values: Vec<i32> = dataset.read_raw()?;
+    let mut atlas = Atlas::default();
+    for (point, code) in order.iter().zip(values.iter()) {
+        if *code >= 0 {
+            atlas.try_insert(*point, 1)?;
+        }
+    }
+    if atlas.is_empty() {
+        return Ok(None);
+    }
+    let mut section = Section::<CellType, VecStorage<CellType>>::new(atlas);
+    for (point, code) in order.iter().zip(values.iter()) {
+        if *code >= 0 {
+            section.try_set(*point, &[dmplex_to_cell_type(*code)?])?;
+        }
+    }
+    Ok(Some(section))
+}
+
+fn write_labels(topology_root: &Group, labels: Option<&LabelSet>) -> Result<(), MeshSieveError> {
+    let labels_group = create_or_open_group(topology_root, GROUP_LABELS)?;
+    let Some(labels) = labels else {
+        return Ok(());
+    };
+
+    let mut grouped: BTreeMap<String, BTreeMap<i32, Vec<i64>>> = BTreeMap::new();
+    for (name, point, value) in labels.iter() {
+        grouped
+            .entry(name.to_string())
+            .or_default()
+            .entry(value)
+            .or_default()
+            .push(point.get() as i64);
+    }
+
+    for (name, by_value) in grouped {
+        let group = create_or_open_group(&labels_group, &name)?;
+        for (value, mut points) in by_value {
+            points.sort_unstable();
+            points.dedup();
+            let value_group = create_or_open_group(&group, &value.to_string())?;
+            value_group
+                .new_dataset::<i64>()
+                .shape(points.len())
+                .create(DATASET_POINTS)?
+                .write(&points)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_labels(topology_root: &Group) -> Result<Option<LabelSet>, MeshSieveError> {
+    let Ok(labels_group) = topology_root.group(GROUP_LABELS) else {
+        return Ok(None);
+    };
+    let mut labels = LabelSet::new();
+    for name in labels_group.member_names()? {
+        let group = labels_group.group(&name)?;
+        for value_name in group.member_names()? {
+            let value = value_name.parse::<i32>().map_err(|err| {
+                MeshSieveError::MeshIoParse(format!("invalid label value {value_name}: {err}"))
+            })?;
+            let points: Vec<i64> = group
+                .group(&value_name)?
+                .dataset(DATASET_POINTS)?
+                .read_raw()?;
+            for raw in points {
+                labels.set_label(PointId::new(raw as u64)?, &name, value);
+            }
+        }
+    }
+    Ok((!labels.is_empty()).then_some(labels))
+}
+
+fn write_dm(
+    topology_root: &Group,
+    dm_name: &str,
+    order: &[PointId],
+    sections: &BTreeMap<String, Section<f64, VecStorage<f64>>>,
+) -> Result<(), MeshSieveError> {
+    let dms = create_or_open_group(topology_root, GROUP_DMS)?;
+    let dm = create_or_open_group(&dms, dm_name)?;
+    let section_root = create_or_open_group(&dm, GROUP_SECTION)?;
+    let vecs = create_or_open_group(&dm, GROUP_VECS)?;
+    for (name, section) in sections {
+        let group = create_or_open_group(&section_root, name)?;
+        let mut section_points = Vec::new();
+        let mut dofs = Vec::new();
+        let mut offsets = Vec::new();
+        let mut offset = 0i64;
+        for point in order {
+            if let Some((_off, len)) = section.atlas().get(*point) {
+                section_points.push(point.get() as i64);
+                dofs.push(len as i32);
+                offsets.push(offset);
+                offset += len as i64;
+            }
+        }
+        group
+            .new_dataset::<i64>()
+            .shape(section_points.len())
+            .create(DATASET_SECTION_POINTS)?
+            .write(&section_points)?;
+        group
+            .new_dataset::<i32>()
+            .shape(dofs.len())
+            .create(DATASET_SECTION_DOFS)?
+            .write(&dofs)?;
+        group
+            .new_dataset::<i64>()
+            .shape(offsets.len())
+            .create(DATASET_SECTION_OFFSETS)?
+            .write(&offsets)?;
+
+        let mut values = Vec::new();
+        for raw in &section_points {
+            values.extend_from_slice(section.try_restrict(PointId::new(*raw as u64)?)?);
+        }
+        vecs.new_dataset::<f64>()
+            .shape(values.len())
+            .create(name.as_str())?
+            .write(&values)?;
+    }
+    Ok(())
+}
+
+fn read_sections(
+    dm: &Group,
+) -> Result<BTreeMap<String, Section<f64, VecStorage<f64>>>, MeshSieveError> {
+    let mut sections = BTreeMap::new();
+    let section_root = dm.group(GROUP_SECTION)?;
+    let vecs = dm.group(GROUP_VECS)?;
+    for name in section_root.member_names()? {
+        let group = section_root.group(&name)?;
+        let points: Vec<i64> = group.dataset(DATASET_SECTION_POINTS)?.read_raw()?;
+        let dofs: Vec<i32> = group.dataset(DATASET_SECTION_DOFS)?.read_raw()?;
+        let values: Vec<f64> = vecs.dataset(&name)?.read_raw()?;
+        let mut atlas = Atlas::default();
+        for (raw, dof) in points.iter().zip(dofs.iter()) {
+            if *dof > 0 {
+                atlas.try_insert(PointId::new(*raw as u64)?, *dof as usize)?;
+            }
+        }
+        let mut section = Section::<f64, VecStorage<f64>>::new(atlas);
+        let mut offset = 0usize;
+        for (raw, dof) in points.iter().zip(dofs.iter()) {
+            if *dof > 0 {
+                let point = PointId::new(*raw as u64)?;
+                let end = offset + *dof as usize;
+                if end > values.len() {
+                    return Err(MeshSieveError::MeshIoParse(format!(
+                        "vector {name} shorter than section layout"
+                    )));
+                }
+                section.try_set(point, &values[offset..end])?;
+                offset = end;
+            }
+        }
+        sections.insert(name, section);
+    }
+    Ok(sections)
+}
+
+fn topology_group(file: &File, mesh_name: &str) -> Result<Group, MeshSieveError> {
+    Ok(file.group(&format!("/{GROUP_TOPOLOGIES}/{mesh_name}/{GROUP_TOPOLOGY}"))?)
+}
+
+fn read_permutation(topology: &Group) -> Result<Vec<PointId>, MeshSieveError> {
+    let raw: Vec<i64> = topology.dataset(DATASET_PERMUTATION)?.read_raw()?;
+    raw.into_iter()
+        .map(|value| PointId::new(value as u64))
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn create_or_open_group(parent: &Group, name: &str) -> Result<Group, MeshSieveError> {
+    match parent.group(name) {
+        Ok(group) => Ok(group),
+        Err(_) => Ok(parent.create_group(name)?),
+    }
+}
+
+fn write_temp_file(bytes: &[u8]) -> Result<PathBuf, MeshSieveError> {
+    let path = temp_hdf5_path();
+    fs::write(&path, bytes)?;
+    Ok(path)
+}
+
+fn temp_hdf5_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|v| v.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    path.push(format!("mesh_sieve_petsc_{pid}_{nanos}.h5"));
+    path
+}
+
+fn cell_type_to_dmplex(cell_type: CellType) -> Result<i32, MeshSieveError> {
+    match cell_type {
+        CellType::Vertex => Ok(0),
+        CellType::Segment => Ok(1),
+        CellType::Triangle => Ok(2),
+        CellType::Quadrilateral => Ok(3),
+        CellType::Tetrahedron => Ok(4),
+        CellType::Hexahedron => Ok(5),
+        CellType::Prism => Ok(6),
+        CellType::Pyramid => Ok(7),
+        _ => Err(MeshSieveError::MeshIoParse(format!(
+            "unsupported DMPlex cell type: {cell_type:?}"
+        ))),
+    }
+}
+
+fn dmplex_to_cell_type(code: i32) -> Result<CellType, MeshSieveError> {
+    match code {
+        0 => Ok(CellType::Vertex),
+        1 => Ok(CellType::Segment),
+        2 => Ok(CellType::Triangle),
+        3 => Ok(CellType::Quadrilateral),
+        4 => Ok(CellType::Tetrahedron),
+        5 => Ok(CellType::Hexahedron),
+        6 => Ok(CellType::Prism),
+        7 => Ok(CellType::Pyramid),
+        _ => Err(MeshSieveError::MeshIoParse(format!(
+            "unknown DMPlex cell type code {code}"
+        ))),
+    }
+}

--- a/tests/petsc_hdf5_roundtrip.rs
+++ b/tests/petsc_hdf5_roundtrip.rs
@@ -1,0 +1,171 @@
+use hdf5::File;
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::io::petsc_hdf5::{
+    DMPLEX_STORAGE_VERSION, PetscHdf5Reader, PetscHdf5Writer, read_mesh_from_petsc_hdf5,
+    write_mesh_to_petsc_hdf5,
+};
+use mesh_sieve::io::{MeshData, SieveSectionReader, SieveSectionWriter};
+use mesh_sieve::topology::cell_type::CellType;
+use mesh_sieve::topology::labels::LabelSet;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::{MeshSieve, OrientedSieve, Sieve};
+use std::collections::BTreeMap;
+
+fn p(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+fn fixture_mesh(
+    partitioned: bool,
+) -> MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>> {
+    let mut sieve = MeshSieve::default();
+    sieve.add_arrow_o(p(4), p(1), (), 0);
+    sieve.add_arrow_o(p(4), p(2), (), 0);
+    sieve.add_arrow_o(p(4), p(3), (), 0);
+    if partitioned {
+        sieve.add_arrow_o(p(5), p(2), (), 0);
+        sieve.add_arrow_o(p(5), p(3), (), 0);
+        sieve.add_arrow_o(p(5), p(6), (), 0);
+    }
+
+    let mut cell_atlas = Atlas::default();
+    cell_atlas.try_insert(p(4), 1).unwrap();
+    if partitioned {
+        cell_atlas.try_insert(p(5), 1).unwrap();
+    }
+    let mut cell_types = Section::<CellType, VecStorage<CellType>>::new(cell_atlas);
+    cell_types.try_set(p(4), &[CellType::Triangle]).unwrap();
+    if partitioned {
+        cell_types.try_set(p(5), &[CellType::Triangle]).unwrap();
+    }
+
+    let mut atlas = Atlas::default();
+    for id in [1, 2, 3, 6] {
+        if partitioned || id != 6 {
+            atlas.try_insert(p(id), 1).unwrap();
+        }
+    }
+    let mut section = Section::<f64, VecStorage<f64>>::new(atlas);
+    for (id, value) in [(1, 10.0), (2, 20.0), (3, 30.0), (6, 40.0)] {
+        if partitioned || id != 6 {
+            section.try_set(p(id), &[value]).unwrap();
+        }
+    }
+
+    let mut labels = LabelSet::new();
+    labels.set_label(p(1), "marker", 1);
+    labels.set_label(p(3), "marker", 1);
+    if partitioned {
+        labels.set_label(p(2), "partition", 0);
+        labels.set_label(p(6), "partition", 1);
+    }
+
+    MeshData {
+        sieve,
+        coordinates: None,
+        sections: BTreeMap::from([("u".to_string(), section)]),
+        mixed_sections: Default::default(),
+        labels: Some(labels),
+        cell_types: Some(cell_types),
+        discretization: None,
+    }
+}
+
+fn assert_roundtrip(mesh: &MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>>) {
+    let mut bytes = Vec::new();
+    PetscHdf5Writer::new("mesh", "dm")
+        .write(&mut bytes, mesh)
+        .unwrap();
+    let reread = PetscHdf5Reader::new("mesh", "dm")
+        .read(bytes.as_slice())
+        .unwrap();
+    let mut expected_base = mesh.sieve.base_points().collect::<Vec<_>>();
+    let mut actual_base = reread.sieve.base_points().collect::<Vec<_>>();
+    expected_base.sort_unstable();
+    actual_base.sort_unstable();
+    assert_eq!(expected_base, actual_base);
+    assert_eq!(
+        reread.sections["u"].gather_in_order(),
+        mesh.sections["u"].gather_in_order()
+    );
+    assert_eq!(
+        reread.labels.as_ref().unwrap().stratum_points("marker", 1),
+        mesh.labels.as_ref().unwrap().stratum_points("marker", 1)
+    );
+}
+
+#[test]
+fn serial_fixture_roundtrips_and_exposes_dmplex_v3_paths() {
+    let mesh = fixture_mesh(false);
+    assert_roundtrip(&mesh);
+
+    let path = std::env::temp_dir().join("mesh_sieve_serial_dmplex_v3_fixture.h5");
+    let _ = std::fs::remove_file(&path);
+    let file = File::create(&path).unwrap();
+    write_mesh_to_petsc_hdf5(&file, &mesh, "mesh", "dm").unwrap();
+
+    assert_eq!(
+        file.dataset("dmplex_storage_version")
+            .unwrap()
+            .read_raw::<i32>()
+            .unwrap(),
+        vec![DMPLEX_STORAGE_VERSION]
+    );
+    assert!(
+        file.dataset("/topologies/mesh/topology/permutation")
+            .is_ok()
+    );
+    assert!(
+        file.dataset("/topologies/mesh/topology/strata/0/cone_sizes")
+            .is_ok()
+    );
+    assert!(
+        file.dataset("/topologies/mesh/topology/strata/1/cones")
+            .is_ok()
+    );
+    assert!(file.group("/topologies/mesh/labels/marker/1").is_ok());
+    assert!(file.group("/topologies/mesh/dms/dm/section/u").is_ok());
+    assert!(file.dataset("/topologies/mesh/dms/dm/vecs/u").is_ok());
+
+    let reread = read_mesh_from_petsc_hdf5(&file, "mesh", "dm").unwrap();
+    assert_eq!(
+        reread.sieve.cone_points(p(4)).collect::<Vec<_>>(),
+        vec![p(1), p(2), p(3)]
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn partitioned_fixture_preserves_point_order_sections_and_labels() {
+    let mesh = fixture_mesh(true);
+    assert_roundtrip(&mesh);
+
+    let path = std::env::temp_dir().join("mesh_sieve_partitioned_dmplex_v3_fixture.h5");
+    let _ = std::fs::remove_file(&path);
+    let file = File::create(&path).unwrap();
+    write_mesh_to_petsc_hdf5(&file, &mesh, "mesh", "dm").unwrap();
+
+    let permutation = file
+        .dataset("/topologies/mesh/topology/permutation")
+        .unwrap()
+        .read_raw::<i64>()
+        .unwrap();
+    assert_eq!(permutation, vec![1, 2, 3, 6, 4, 5]);
+
+    let reread = read_mesh_from_petsc_hdf5(&file, "mesh", "dm").unwrap();
+    assert_eq!(
+        reread.sections["u"].gather_in_order(),
+        vec![10.0, 20.0, 30.0, 40.0]
+    );
+    assert_eq!(
+        reread
+            .labels
+            .as_ref()
+            .unwrap()
+            .stratum_points("partition", 1),
+        vec![p(6)]
+    );
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
### Motivation
- Provide PETSc DMPlex v3-compatible HDF5 read/write so meshes, sections, labels, and vectors can interoperate with PETSc/Firedrake/FEniCSx-style workflows. 
- Keep the legacy compact HDF5 layout intact by adding a dedicated module rather than changing `src/io/hdf5.rs`.

### Description
- Add new module `src/io/petsc_hdf5.rs` implementing PETSc DMPlex v3-style write/read routines and `PetscHdf5Reader` / `PetscHdf5Writer` types.
- Write/read `/dmplex_storage_version`, `/topologies/<mesh>/topology/permutation`, and per-depth strata datasets `/topology/strata/<depth>/{cone_sizes,cones,orientations}` and `cell_types` to preserve topology and orientations.
- Serialize labels under `/topologies/<mesh>/labels/<label>/<value>/points` and store sections/vectors under `/topologies/<mesh>/dms/<dm>/section/<name>` and `/topologies/<mesh>/dms/<dm>/vecs/<name>`, preserving global point ordering so topology/section/vector files can be associated later.
- Export the new module by adding `pub mod petsc_hdf5;` to `src/io/mod.rs` and update documentation `docs/hdf5-layout.md` describing both layouts.
- Add round-trip tests `tests/petsc_hdf5_roundtrip.rs` covering serial and partitioned fixture meshes and verifying datasets, preserved permutation, sections, and labels.

### Testing
- Ran `cargo check` (succeeded).
- Ran `cargo test --test petsc_hdf5_roundtrip` which executed the serial and partitioned round-trip tests (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f5d853c48329b002a376327cc553)