### PR TITLE
Add metric anisotropic anchors and adaptation transfers

### DIFF
--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -8,9 +8,12 @@ use crate::data::section::Section;
 use crate::data::storage::{Storage, VecStorage};
 use crate::geometry::quality::{CellQuality, cell_quality_from_section};
 use crate::mesh_error::MeshSieveError;
+use crate::topology::anchors::TopologicalAnchors;
 use crate::topology::arrow::Polarity;
 use crate::topology::cell_type::CellType;
 use crate::topology::coarsen::{CoarsenEntity, CoarsenedTopology, coarsen_topology};
+use crate::topology::labels::LabelSet;
+use crate::topology::ownership::PointOwnership;
 use crate::topology::point::PointId;
 use crate::topology::refine::{
     AnisotropicSplitHints, RefineOptions, RefinedMesh, collapse_to_cell_vertices,
@@ -204,6 +207,43 @@ impl Default for MetricThresholds {
             check_geometry: false,
         }
     }
+}
+
+/// Boundary handling policy for adaptation.
+#[derive(Clone, Debug, Default)]
+pub enum BoundaryRemeshingPolicy {
+    /// Preserve all labeled boundary entities and suppress metric split hints on them.
+    #[default]
+    PreserveBoundary,
+    /// Allow split/coarsen decisions on boundary entities.
+    RemeshBoundary,
+    /// Preserve only the named label strata.
+    PreserveLabeled(Vec<(String, i32)>),
+}
+
+impl BoundaryRemeshingPolicy {
+    fn preserves(&self, labels: Option<&LabelSet>, cell: PointId) -> bool {
+        match self {
+            BoundaryRemeshingPolicy::RemeshBoundary => false,
+            BoundaryRemeshingPolicy::PreserveBoundary => labels.is_some_and(|labels| {
+                labels
+                    .iter()
+                    .any(|(name, point, value)| point == cell && name == "boundary" && value != 0)
+            }),
+            BoundaryRemeshingPolicy::PreserveLabeled(strata) => labels.is_some_and(|labels| {
+                strata
+                    .iter()
+                    .any(|(name, value)| labels.get_label(cell, name) == Some(*value))
+            }),
+        }
+    }
+}
+
+/// Metric-adaptation controls beyond numeric thresholds.
+#[derive(Clone, Debug, Default)]
+pub struct MetricAdaptationOptions {
+    /// Boundary remeshing policy.
+    pub boundary_policy: BoundaryRemeshingPolicy,
 }
 
 /// Edge/face split hints for anisotropic refinement.
@@ -737,6 +777,120 @@ where
     Ok(coarse)
 }
 
+/// Transfer a point/cell section through a refinement map by oriented copy.
+pub fn transfer_section_refinement<V>(
+    coarse: &SievedArray<PointId, V>,
+    refinement: &[(PointId, Vec<(PointId, Polarity)>)],
+) -> Result<SievedArray<PointId, V>, MeshSieveError>
+where
+    V: Clone + Default,
+{
+    refine_data_with_transfer(coarse, refinement)
+}
+
+/// Transfer a point/cell section through a coarsening map by averaging fine values.
+pub fn transfer_section_coarsening<V>(
+    fine: &SievedArray<PointId, V>,
+    transfer: &[(PointId, Vec<(PointId, Polarity)>)],
+) -> Result<SievedArray<PointId, V>, MeshSieveError>
+where
+    V: Clone
+        + Default
+        + num_traits::FromPrimitive
+        + core::ops::AddAssign
+        + core::ops::Div<Output = V>,
+{
+    coarsen_data_with_transfer(fine, transfer)
+}
+
+/// Transfer labels from coarse entities to refined entities and preserve unchanged labels.
+pub fn transfer_labels_refinement(
+    labels: &LabelSet,
+    refinement: &[(PointId, Vec<(PointId, Polarity)>)],
+) -> LabelSet {
+    let mut out = labels.clone();
+    for (coarse, fine_points) in refinement {
+        for (name, point, value) in labels.iter() {
+            if point == *coarse {
+                for (fine, _) in fine_points {
+                    out.set_label(*fine, name, value);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Transfer cell-type tags through refinement.
+pub fn transfer_cell_types_refinement<S>(
+    cell_types: &Section<CellType, S>,
+    refinement: &[(PointId, Vec<(PointId, Polarity)>)],
+) -> Result<Section<CellType, VecStorage<CellType>>, MeshSieveError>
+where
+    S: Storage<CellType>,
+{
+    let mut atlas = Atlas::default();
+    let mut entries = Vec::new();
+    for (coarse, fine_points) in refinement {
+        let slice = cell_types.try_restrict(*coarse)?;
+        if slice.len() != 1 {
+            return Err(MeshSieveError::SliceLengthMismatch {
+                point: *coarse,
+                expected: 1,
+                found: slice.len(),
+            });
+        }
+        for (fine, _) in fine_points {
+            atlas.try_insert(*fine, 1)?;
+            entries.push((*fine, slice[0]));
+        }
+    }
+    let mut out = Section::<CellType, VecStorage<CellType>>::new(atlas);
+    for (point, cell_type) in entries {
+        out.try_set(point, &[cell_type])?;
+    }
+    Ok(out)
+}
+
+/// Transfer ownership through refinement by inheriting the coarse owner.
+pub fn transfer_ownership_refinement(
+    ownership: &PointOwnership,
+    refined: &RefinedMesh,
+    my_rank: usize,
+) -> Result<PointOwnership, MeshSieveError> {
+    let mut out = ownership.clone();
+    for (coarse, fine_points) in &refined.cell_refinement {
+        let owner = ownership.owner_or_err(*coarse)?;
+        for (fine, _) in fine_points {
+            out.set_owner_min(*fine, owner, my_rank)?;
+            for point in refined.sieve.cone_points(*fine) {
+                if out.entry(point).is_none() {
+                    out.set_owner_min(point, owner, my_rank)?;
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Transfer anchor-derived hanging constraints for scalar sections.
+pub fn transfer_constraints_from_anchors(
+    anchors: &TopologicalAnchors,
+    dofs_per_point: usize,
+) -> crate::data::hanging_node_constraints::HangingNodeConstraints<f64> {
+    crate::data::hanging_node_constraints::constraints_from_topological_anchors(
+        anchors,
+        dofs_per_point,
+    )
+}
+
+/// Transfer coordinates produced by refinement, if available.
+pub fn transfer_coordinates_refinement(
+    refined: &RefinedMesh,
+) -> Option<Coordinates<f64, VecStorage<f64>>> {
+    refined.coordinates.clone()
+}
+
 /// Apply quality-driven refinement/coarsening with data transfer.
 ///
 /// When both refinement and coarsening are requested, refinement is applied
@@ -766,7 +920,7 @@ where
 
     if !refine_cells.is_empty() {
         let refined_section = subset_cell_types(cell_types, &refine_cells)?;
-        let refined = refine_mesh_with_options(
+        let mut refined = refine_mesh_with_options(
             sieve,
             &refined_section,
             Some(coordinates),
@@ -775,6 +929,7 @@ where
                 anisotropic_splits: None,
             },
         )?;
+        materialize_unmodified_cells(sieve, cell_types, &mut refined, &refine_cells)?;
         let refined_data = refine_data_with_transfer(cell_data, &refined.cell_refinement)?;
         return Ok(AdaptationResult {
             metrics,
@@ -818,6 +973,38 @@ where
     })
 }
 
+fn materialize_unmodified_cells<S>(
+    sieve: &mut impl Sieve<Point = PointId>,
+    cell_types: &Section<CellType, S>,
+    refined: &mut RefinedMesh,
+    refined_cells: &[PointId],
+) -> Result<(), MeshSieveError>
+where
+    S: Storage<CellType>,
+{
+    let refined_set: std::collections::HashSet<_> = refined_cells.iter().copied().collect();
+    let collapsed = collapse_to_cell_vertices(sieve, cell_types)?;
+    for (cell, cell_slice) in cell_types.iter() {
+        if cell_slice.len() != 1 {
+            return Err(MeshSieveError::SliceLengthMismatch {
+                point: cell,
+                expected: 1,
+                found: cell_slice.len(),
+            });
+        }
+        if refined_set.contains(&cell) {
+            continue;
+        }
+        for vertex in collapsed.cone_points(cell) {
+            refined.sieve.add_arrow(cell, vertex, ());
+        }
+        refined
+            .cell_refinement
+            .push((cell, vec![(cell, Polarity::Forward)]));
+    }
+    Ok(())
+}
+
 fn filter_split_hints(hints: &[MetricSplitHint], cells: &[PointId]) -> Vec<MetricSplitHint> {
     let cell_set: std::collections::HashSet<_> = cells.iter().copied().collect();
     hints
@@ -825,6 +1012,108 @@ fn filter_split_hints(hints: &[MetricSplitHint], cells: &[PointId]) -> Vec<Metri
         .filter(|hint| cell_set.contains(&hint.cell))
         .cloned()
         .collect()
+}
+
+fn apply_boundary_policy(
+    selection: &mut AdaptivitySelection,
+    split_hints: &mut Vec<MetricSplitHint>,
+    labels: Option<&LabelSet>,
+    policy: &BoundaryRemeshingPolicy,
+) {
+    selection
+        .refine_cells
+        .retain(|cell| !policy.preserves(labels, *cell));
+    selection
+        .coarsen_cells
+        .retain(|cell| !policy.preserves(labels, *cell));
+    split_hints.retain(|hint| !policy.preserves(labels, hint.cell));
+}
+
+/// Apply metric-driven refinement/coarsening with boundary-remeshing controls.
+pub fn adapt_with_metric_policy<S, Cs, Ms, C>(
+    sieve: &mut impl Sieve<Point = PointId>,
+    cell_types: &Section<CellType, S>,
+    coordinates: &Coordinates<f64, Cs>,
+    metric: &Section<MetricTensor, Ms>,
+    labels: Option<&LabelSet>,
+    coarsen_plan: C,
+    thresholds: MetricThresholds,
+    options: MetricAdaptationOptions,
+) -> Result<MetricAdaptationResult<()>, MeshSieveError>
+where
+    S: Storage<CellType>,
+    Cs: Storage<f64>,
+    Ms: Storage<MetricTensor>,
+    C: Fn(&[MetricSplitHint]) -> Vec<CoarsenEntity>,
+{
+    let evaluations = evaluate_metric_cells(sieve, cell_types, coordinates, metric)?;
+    let metrics: Vec<_> = evaluations
+        .iter()
+        .map(|eval| (eval.cell, eval.metrics))
+        .collect();
+    let mut split_hints = metric_split_hints(&evaluations, thresholds);
+    let mut selection = select_cells_for_metric_adaptation(&metrics, thresholds);
+    apply_boundary_policy(
+        &mut selection,
+        &mut split_hints,
+        labels,
+        &options.boundary_policy,
+    );
+    let refine_cells = selection.refine_cells.clone();
+    let coarsen_cells = selection.coarsen_cells.clone();
+
+    if !refine_cells.is_empty() {
+        let refined_section = subset_cell_types(cell_types, &refine_cells)?;
+        let refine_hints = filter_split_hints(&split_hints, &refine_cells);
+        let anisotropic = build_anisotropic_hints(&refine_hints);
+        let mut refined = refine_mesh_with_options(
+            sieve,
+            &refined_section,
+            Some(coordinates),
+            RefineOptions {
+                check_geometry: thresholds.check_geometry,
+                anisotropic_splits: if anisotropic.is_empty() {
+                    None
+                } else {
+                    Some(anisotropic)
+                },
+            },
+        )?;
+        materialize_unmodified_cells(sieve, cell_types, &mut refined, &refine_cells)?;
+        return Ok(MetricAdaptationResult {
+            metrics,
+            refine_cells,
+            coarsen_cells,
+            split_hints,
+            action: MetricAdaptationAction::Refined { mesh: refined },
+            data: None,
+        });
+    }
+
+    if !coarsen_cells.is_empty() {
+        let coarsen_hints = filter_split_hints(&split_hints, &coarsen_cells);
+        let entities = coarsen_plan(&coarsen_hints);
+        if !entities.is_empty() {
+            let coarsened = coarsen_topology(sieve, &entities)?;
+            return Ok(MetricAdaptationResult {
+                metrics,
+                refine_cells,
+                coarsen_cells,
+                split_hints,
+                action: MetricAdaptationAction::Coarsened { mesh: coarsened },
+                data: None,
+            });
+        }
+    }
+
+    Ok(MetricAdaptationResult {
+        metrics,
+        refine_cells,
+        coarsen_cells,
+        split_hints,
+        action: MetricAdaptationAction::NoChange,
+        data: None,
+    })
 }
 
 /// Apply metric-driven refinement/coarsening without data transfer.
@@ -859,7 +1148,7 @@ where
         let refined_section = subset_cell_types(cell_types, &refine_cells)?;
         let refine_hints = filter_split_hints(&split_hints, &refine_cells);
         let anisotropic = build_anisotropic_hints(&refine_hints);
-        let refined = refine_mesh_with_options(
+        let mut refined = refine_mesh_with_options(
             sieve,
             &refined_section,
             Some(coordinates),
@@ -872,6 +1161,7 @@ where
                 },
             },
         )?;
+        materialize_unmodified_cells(sieve, cell_types, &mut refined, &refine_cells)?;
         return Ok(MetricAdaptationResult {
             metrics,
             refine_cells,
@@ -954,7 +1244,7 @@ where
         let refined_section = subset_cell_types(cell_types, &refine_cells)?;
         let refine_hints = filter_split_hints(&split_hints, &refine_cells);
         let anisotropic = build_anisotropic_hints(&refine_hints);
-        let refined = refine_mesh_with_options(
+        let mut refined = refine_mesh_with_options(
             sieve,
             &refined_section,
             Some(coordinates),
@@ -967,6 +1257,7 @@ where
                 },
             },
         )?;
+        materialize_unmodified_cells(sieve, cell_types, &mut refined, &refine_cells)?;
         let refined_data = refine_data_with_transfer(cell_data, &refined.cell_refinement)?;
         return Ok(MetricAdaptationResult {
             metrics,

--- a/src/data/hanging_node_constraints.rs
+++ b/src/data/hanging_node_constraints.rs
@@ -3,6 +3,7 @@
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::mesh_error::MeshSieveError;
+use crate::topology::anchors::TopologicalAnchors;
 use crate::topology::cache::InvalidateCache;
 use crate::topology::point::PointId;
 use std::collections::BTreeMap;
@@ -94,6 +95,37 @@ impl<V> HangingNodeConstraints<V> {
     pub fn clear_constraints(&mut self) {
         self.constraints.clear();
     }
+}
+
+/// Generate point-wise hanging constraints from topology anchors.
+///
+/// Each constrained anchor point is written as the arithmetic average of its
+/// parent points for every requested DOF.  This is the standard linear
+/// constraint for midpoint anchors and a conservative default for higher-order
+/// face/cell anchors.
+pub fn constraints_from_topological_anchors(
+    anchors: &TopologicalAnchors,
+    dofs_per_point: usize,
+) -> HangingNodeConstraints<f64> {
+    let mut constraints = HangingNodeConstraints::default();
+    if dofs_per_point == 0 {
+        return constraints;
+    }
+    for (point, anchor) in anchors.iter() {
+        if !anchor.is_constrained() || anchor.parents.is_empty() {
+            continue;
+        }
+        let weight = 1.0 / anchor.parents.len() as f64;
+        for dof in 0..dofs_per_point {
+            let terms = anchor
+                .parents
+                .iter()
+                .map(|parent| LinearConstraintTerm::new(*parent, dof, weight))
+                .collect();
+            constraints.insert_constraint(point, dof, terms);
+        }
+    }
+    constraints
 }
 
 /// Apply hanging node constraints to a mutable section.

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -45,7 +45,7 @@ pub use discretization::{Discretization, DiscretizationMetadata, FieldDiscretiza
 pub use global_map::{LocalToGlobalMap, global_vector_for_map};
 pub use hanging_node_constraints::{
     HangingDofConstraint, HangingNodeConstraints, LinearConstraintTerm,
-    apply_hanging_constraints_to_section,
+    apply_hanging_constraints_to_section, constraints_from_topological_anchors,
 };
 pub use mixed_section::{
     MixedScalar, MixedSectionStore, ScalarType, TaggedSection, TaggedSectionBuffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub mod prelude {
     pub use crate::data::global_map::LocalToGlobalMap;
     pub use crate::data::hanging_node_constraints::{
         HangingDofConstraint, HangingNodeConstraints, LinearConstraintTerm,
-        apply_hanging_constraints_to_section,
+        apply_hanging_constraints_to_section, constraints_from_topological_anchors,
     };
     pub use crate::data::multi_section::{FieldSection, MultiSection};
     #[cfg(feature = "map-adapter")]

--- a/src/topology/anchors.rs
+++ b/src/topology/anchors.rs
@@ -1,0 +1,159 @@
+//! Topological anchors for nonconforming/adapted meshes.
+//!
+//! Anchors record the coarse parent point(s) that define an adapted point.  They
+//! are intentionally topology-level metadata (not field data) so adjacency,
+//! closure, ownership, and constraint generation can all refer to the same
+//! parentage after local refinement or coarsening.
+
+use crate::topology::point::PointId;
+use crate::topology::sieve::Sieve;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// Classification for an anchored point.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AnchorKind {
+    /// A regular child produced by a conforming refinement/coarsening template.
+    Refined,
+    /// A constrained point, typically a midpoint on an unsplit neighbour edge.
+    Hanging,
+    /// A point that is constrained but should be retained as an explicit anchor.
+    Constrained,
+}
+
+/// Parentage for one adapted point.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PointAnchor {
+    /// Parents defining this point; two parents denote an edge midpoint, more
+    /// parents denote face/cell interpolation, and one parent denotes identity.
+    pub parents: Vec<PointId>,
+    /// Whether the point is regular, hanging, or otherwise constrained.
+    pub kind: AnchorKind,
+}
+
+impl PointAnchor {
+    /// Construct a new point anchor with sorted, duplicate-free parents.
+    pub fn new<I>(parents: I, kind: AnchorKind) -> Self
+    where
+        I: IntoIterator<Item = PointId>,
+    {
+        let mut parents: Vec<_> = parents.into_iter().collect();
+        parents.sort_unstable();
+        parents.dedup();
+        Self { parents, kind }
+    }
+
+    /// Returns true when this point requires a constraint equation.
+    pub fn is_constrained(&self) -> bool {
+        matches!(self.kind, AnchorKind::Hanging | AnchorKind::Constrained)
+    }
+}
+
+/// DMPlex-style anchor map for adapted/nonconforming topology.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TopologicalAnchors {
+    anchors: BTreeMap<PointId, PointAnchor>,
+}
+
+impl TopologicalAnchors {
+    /// Insert or replace parentage for a point.
+    pub fn insert<I>(&mut self, point: PointId, parents: I, kind: AnchorKind)
+    where
+        I: IntoIterator<Item = PointId>,
+    {
+        self.anchors.insert(point, PointAnchor::new(parents, kind));
+    }
+
+    /// Borrow an anchor entry.
+    pub fn get(&self, point: PointId) -> Option<&PointAnchor> {
+        self.anchors.get(&point)
+    }
+
+    /// Iterate over all anchored points in deterministic order.
+    pub fn iter(&self) -> impl Iterator<Item = (PointId, &PointAnchor)> + '_ {
+        self.anchors.iter().map(|(point, anchor)| (*point, anchor))
+    }
+
+    /// Return true when no anchors are recorded.
+    pub fn is_empty(&self) -> bool {
+        self.anchors.is_empty()
+    }
+
+    /// Mark an existing anchored point as constrained/hanging.
+    pub fn set_kind(&mut self, point: PointId, kind: AnchorKind) {
+        if let Some(anchor) = self.anchors.get_mut(&point) {
+            anchor.kind = kind;
+        }
+    }
+
+    /// Parent points for a point, including the point itself when unanchored.
+    pub fn parent_points(&self, point: PointId) -> Vec<PointId> {
+        self.anchors
+            .get(&point)
+            .map(|anchor| anchor.parents.clone())
+            .unwrap_or_else(|| vec![point])
+    }
+
+    /// Expand a point to itself plus its anchor parents.
+    pub fn anchored_points(&self, point: PointId) -> BTreeSet<PointId> {
+        let mut out = BTreeSet::new();
+        out.insert(point);
+        if let Some(anchor) = self.anchors.get(&point) {
+            out.extend(anchor.parents.iter().copied());
+        }
+        out
+    }
+
+    /// Downward closure augmented with anchor parents for each visited point.
+    pub fn anchor_aware_closure<S>(
+        &self,
+        sieve: &S,
+        seeds: impl IntoIterator<Item = PointId>,
+    ) -> BTreeSet<PointId>
+    where
+        S: Sieve<Point = PointId>,
+    {
+        let mut visited = BTreeSet::new();
+        let mut queue: VecDeque<PointId> = seeds.into_iter().collect();
+        while let Some(point) = queue.pop_front() {
+            if !visited.insert(point) {
+                continue;
+            }
+            for child in sieve.cone_points(point) {
+                queue.push_back(child);
+            }
+            if let Some(anchor) = self.anchors.get(&point) {
+                for parent in &anchor.parents {
+                    queue.push_back(*parent);
+                }
+            }
+        }
+        visited
+    }
+
+    /// Upward star augmented by points anchored to any visited point.
+    pub fn anchor_aware_star<S>(
+        &self,
+        sieve: &S,
+        seeds: impl IntoIterator<Item = PointId>,
+    ) -> BTreeSet<PointId>
+    where
+        S: Sieve<Point = PointId>,
+    {
+        let mut visited = BTreeSet::new();
+        let mut queue: VecDeque<PointId> = seeds.into_iter().collect();
+        while let Some(point) = queue.pop_front() {
+            if !visited.insert(point) {
+                continue;
+            }
+            for parent in sieve.support_points(point) {
+                queue.push_back(parent);
+            }
+            for (child, anchor) in &self.anchors {
+                if anchor.parents.contains(&point) {
+                    queue.push_back(*child);
+                }
+            }
+        }
+        visited
+    }
+}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -16,6 +16,7 @@
 
 mod _debug_invariants;
 pub mod adapt;
+pub mod anchors;
 pub mod arrow;
 pub mod bounds;
 pub mod cache;
@@ -32,6 +33,7 @@ pub mod stack;
 pub mod utils;
 pub mod validation;
 
+pub use anchors::{AnchorKind, PointAnchor, TopologicalAnchors};
 pub use cache::InvalidateCache;
 pub use cell_type::CellType;
 pub use labels::LabelSet;

--- a/src/topology/refine/mod.rs
+++ b/src/topology/refine/mod.rs
@@ -19,10 +19,14 @@
 use crate::algs::interpolate::{InterpolationResult, interpolate_edges_faces};
 use crate::data::atlas::Atlas;
 use crate::data::coordinates::{Coordinates, HighOrderCoordinates};
+use crate::data::hanging_node_constraints::{
+    HangingNodeConstraints, constraints_from_topological_anchors,
+};
 use crate::data::section::Section;
 use crate::data::storage::{Storage, VecStorage};
 use crate::geometry::quality::validate_cell_geometry;
 use crate::mesh_error::MeshSieveError;
+use crate::topology::anchors::{AnchorKind, TopologicalAnchors};
 use crate::topology::arrow::Polarity;
 use crate::topology::cell_type::CellType;
 use crate::topology::ownership::PointOwnership;
@@ -43,6 +47,10 @@ pub struct RefinedMesh {
     pub cell_refinement: RefinementMap,
     /// Optional coordinates for the refined mesh vertices.
     pub coordinates: Option<Coordinates<f64, VecStorage<f64>>>,
+    /// Parent/constrained-point anchors produced by refinement.
+    pub anchors: TopologicalAnchors,
+    /// Automatically generated scalar hanging-node constraints from anchors.
+    pub hanging_constraints: HangingNodeConstraints<f64>,
 }
 
 /// Output of [`refine_mesh_with_ownership`], including ownership metadata updates.
@@ -56,6 +64,10 @@ pub struct RefinedMeshWithOwnership {
     pub ownership: PointOwnership,
     /// Optional coordinates for the refined mesh vertices.
     pub coordinates: Option<Coordinates<f64, VecStorage<f64>>>,
+    /// Parent/constrained-point anchors produced by refinement.
+    pub anchors: TopologicalAnchors,
+    /// Automatically generated scalar hanging-node constraints from anchors.
+    pub hanging_constraints: HangingNodeConstraints<f64>,
 }
 
 /// Output of [`refine_mesh_full_topology`], including a full topology and types.
@@ -69,6 +81,10 @@ pub struct RefinedMeshWithTopology {
     pub cell_types: Section<CellType, VecStorage<CellType>>,
     /// Optional coordinates for the refined mesh vertices.
     pub coordinates: Option<Coordinates<f64, VecStorage<f64>>>,
+    /// Parent/constrained-point anchors produced by refinement.
+    pub anchors: TopologicalAnchors,
+    /// Automatically generated scalar hanging-node constraints from anchors.
+    pub hanging_constraints: HangingNodeConstraints<f64>,
 }
 
 /// Optional anisotropic split hints for refinement.
@@ -427,6 +443,7 @@ where
     let mut edge_midpoints: HashMap<(PointId, PointId), PointId> = HashMap::new();
     let mut face_centers: HashMap<Vec<PointId>, PointId> = HashMap::new();
     let mut point_sources: HashMap<PointId, Vec<PointId>> = HashMap::new();
+    let hinted_edge_keys = collect_hinted_edge_keys(options.anisotropic_splits.as_ref());
 
     for (cell, cell_slice) in cell_types.iter() {
         if cell_slice.len() != 1 {
@@ -474,7 +491,11 @@ where
                         vertices[0],
                     )?,
                 ];
-                for verts in triangle_subdivision(vertices, midpoints) {
+                let split_indices =
+                    triangle_split_indices(cell, vertices, options.anisotropic_splits.as_ref());
+                let templates =
+                    anisotropic_triangle_subdivision(vertices, midpoints, &split_indices);
+                for verts in templates {
                     let fine_cell = alloc_point(&mut next_id)?;
                     for v in verts {
                         refined.add_arrow(fine_cell, v, ());
@@ -516,7 +537,18 @@ where
                 ];
                 let center = alloc_point(&mut next_id)?;
                 point_sources.insert(center, vertices.to_vec());
-                for verts in quadrilateral_subdivision(vertices, midpoints, center) {
+                let split_indices = quadrilateral_split_indices(
+                    cell,
+                    vertices,
+                    options.anisotropic_splits.as_ref(),
+                );
+                let templates = anisotropic_quadrilateral_subdivision(
+                    vertices,
+                    midpoints,
+                    center,
+                    &split_indices,
+                );
+                for verts in templates {
                     let fine_cell = alloc_point(&mut next_id)?;
                     for v in verts {
                         refined.add_arrow(fine_cell, v, ());
@@ -940,10 +972,24 @@ where
         None
     };
 
+    let mut anchors = TopologicalAnchors::default();
+    for (point, sources) in &point_sources {
+        let kind =
+            if sources.len() == 2 && hinted_edge_keys.contains(&edge_key(sources[0], sources[1])) {
+                AnchorKind::Hanging
+            } else {
+                AnchorKind::Refined
+            };
+        anchors.insert(*point, sources.iter().copied(), kind);
+    }
+    let hanging_constraints = constraints_from_topological_anchors(&anchors, 1);
+
     Ok(RefinedMesh {
         sieve: refined,
         cell_refinement: refinement_map,
         coordinates: refined_coordinates,
+        anchors,
+        hanging_constraints,
     })
 }
 
@@ -988,6 +1034,8 @@ where
         cell_refinement: refined.cell_refinement,
         cell_types: refined_cell_types,
         coordinates: refined.coordinates,
+        anchors: refined.anchors,
+        hanging_constraints: refined.hanging_constraints,
     })
 }
 
@@ -1034,6 +1082,8 @@ where
         cell_refinement: refined.cell_refinement,
         ownership: refined_ownership,
         coordinates: refined.coordinates,
+        anchors: refined.anchors,
+        hanging_constraints: refined.hanging_constraints,
     })
 }
 
@@ -1073,7 +1123,112 @@ where
         cell_refinement: refined.cell_refinement,
         ownership: refined_ownership,
         coordinates: refined.coordinates,
+        anchors: refined.anchors,
+        hanging_constraints: refined.hanging_constraints,
     })
+}
+
+fn edge_key(a: PointId, b: PointId) -> (PointId, PointId) {
+    if a < b { (a, b) } else { (b, a) }
+}
+
+fn collect_hinted_edge_keys(hints: Option<&AnisotropicSplitHints>) -> HashSet<(PointId, PointId)> {
+    let mut keys = HashSet::new();
+    if let Some(hints) = hints {
+        for edges in hints.edge_splits.values() {
+            for [a, b] in edges {
+                keys.insert(edge_key(*a, *b));
+            }
+        }
+    }
+    keys
+}
+
+fn triangle_split_indices(
+    cell: PointId,
+    vertices: [PointId; 3],
+    hints: Option<&AnisotropicSplitHints>,
+) -> Vec<usize> {
+    let Some(edges) = hints.and_then(|h| h.edge_splits.get(&cell)) else {
+        return vec![0, 1, 2];
+    };
+    let canonical = [
+        edge_key(vertices[0], vertices[1]),
+        edge_key(vertices[1], vertices[2]),
+        edge_key(vertices[2], vertices[0]),
+    ];
+    let requested: HashSet<_> = edges.iter().map(|[a, b]| edge_key(*a, *b)).collect();
+    let mut out = Vec::new();
+    for (idx, key) in canonical.iter().enumerate() {
+        if requested.contains(key) {
+            out.push(idx);
+        }
+    }
+    if out.is_empty() { vec![0, 1, 2] } else { out }
+}
+
+fn quadrilateral_split_indices(
+    cell: PointId,
+    vertices: [PointId; 4],
+    hints: Option<&AnisotropicSplitHints>,
+) -> Vec<usize> {
+    let Some(edges) = hints.and_then(|h| h.edge_splits.get(&cell)) else {
+        return vec![0, 1, 2, 3];
+    };
+    let canonical = [
+        edge_key(vertices[0], vertices[1]),
+        edge_key(vertices[1], vertices[2]),
+        edge_key(vertices[2], vertices[3]),
+        edge_key(vertices[3], vertices[0]),
+    ];
+    let requested: HashSet<_> = edges.iter().map(|[a, b]| edge_key(*a, *b)).collect();
+    let mut out = Vec::new();
+    for (idx, key) in canonical.iter().enumerate() {
+        if requested.contains(key) {
+            out.push(idx);
+        }
+    }
+    if out.is_empty() {
+        vec![0, 1, 2, 3]
+    } else {
+        out
+    }
+}
+
+fn anisotropic_triangle_subdivision(
+    vertices: [PointId; 3],
+    midpoints: [PointId; 3],
+    split_indices: &[usize],
+) -> Vec<[PointId; 3]> {
+    let [v0, v1, v2] = vertices;
+    let [m01, m12, m20] = midpoints;
+    if split_indices.len() == 1 {
+        match split_indices[0] {
+            0 => return vec![[v0, m01, v2], [m01, v1, v2]],
+            1 => return vec![[v1, m12, v0], [m12, v2, v0]],
+            2 => return vec![[v2, m20, v1], [m20, v0, v1]],
+            _ => {}
+        }
+    }
+    triangle_subdivision(vertices, midpoints).to_vec()
+}
+
+fn anisotropic_quadrilateral_subdivision(
+    vertices: [PointId; 4],
+    midpoints: [PointId; 4],
+    center: PointId,
+    split_indices: &[usize],
+) -> Vec<[PointId; 4]> {
+    let [v0, v1, v2, v3] = vertices;
+    let [m01, m12, m23, m30] = midpoints;
+    let splits: HashSet<_> = split_indices.iter().copied().collect();
+    if splits.len() == 2 && splits.contains(&0) && splits.contains(&2) {
+        return vec![[v0, m01, m23, v3], [m01, v1, v2, m23]];
+    }
+    if splits.len() == 2 && splits.contains(&1) && splits.contains(&3) {
+        return vec![[v0, v1, m12, m30], [m30, m12, v2, v3]];
+    }
+    quadrilateral_subdivision(vertices, midpoints, center).to_vec()
 }
 
 fn alloc_point(next_id: &mut u64) -> Result<PointId, MeshSieveError> {

--- a/tests/adapt_anchors.rs
+++ b/tests/adapt_anchors.rs
@@ -1,0 +1,78 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::coordinates::Coordinates;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::topology::anchors::AnchorKind;
+use mesh_sieve::topology::cell_type::CellType;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::refine::{
+    AnisotropicSplitHints, RefineOptions, refine_mesh_with_options,
+};
+use mesh_sieve::topology::sieve::{InMemorySieve, Sieve};
+use std::collections::HashMap;
+
+fn pt(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+#[test]
+fn anisotropic_triangle_edge_split_creates_hanging_anchor_and_constraints() {
+    let mut sieve = InMemorySieve::<PointId, ()>::default();
+    let cell = pt(10);
+    for vertex in [pt(1), pt(2), pt(3)] {
+        sieve.add_arrow(cell, vertex, ());
+    }
+
+    let mut atlas = Atlas::default();
+    atlas.try_insert(cell, 1).unwrap();
+    let mut cell_types = Section::<CellType, VecStorage<CellType>>::new(atlas);
+    cell_types.try_set(cell, &[CellType::Triangle]).unwrap();
+
+    let mut coord_atlas = Atlas::default();
+    for vertex in [pt(1), pt(2), pt(3)] {
+        coord_atlas.try_insert(vertex, 2).unwrap();
+    }
+    let mut coord_section = Section::<f64, VecStorage<f64>>::new(coord_atlas);
+    coord_section.try_set(pt(1), &[0.0, 0.0]).unwrap();
+    coord_section.try_set(pt(2), &[2.0, 0.0]).unwrap();
+    coord_section.try_set(pt(3), &[0.0, 1.0]).unwrap();
+    let coordinates = Coordinates::from_section(2, 2, coord_section).unwrap();
+
+    let mut edge_splits = HashMap::new();
+    edge_splits.insert(cell, vec![[pt(1), pt(2)]]);
+    let refined = refine_mesh_with_options(
+        &mut sieve,
+        &cell_types,
+        Some(&coordinates),
+        RefineOptions {
+            check_geometry: false,
+            anisotropic_splits: Some(AnisotropicSplitHints {
+                edge_splits,
+                face_splits: HashMap::new(),
+            }),
+        },
+    )
+    .unwrap();
+
+    let fine_cells = &refined.cell_refinement[0].1;
+    assert_eq!(fine_cells.len(), 2);
+
+    let hanging = refined
+        .anchors
+        .iter()
+        .find(|(_, anchor)| anchor.kind == AnchorKind::Hanging)
+        .expect("expected a hanging midpoint anchor");
+    assert_eq!(hanging.1.parents, vec![pt(1), pt(2)]);
+    assert!(
+        refined
+            .hanging_constraints
+            .constraints()
+            .contains_key(&hanging.0)
+    );
+
+    let closure = refined
+        .anchors
+        .anchor_aware_closure(&refined.sieve, [fine_cells[0].0]);
+    assert!(closure.contains(&pt(1)));
+    assert!(closure.contains(&pt(2)));
+}


### PR DESCRIPTION
### Motivation
- Provide topology-level support for nonconforming/adapted meshes so anchor parentage and hanging constraints are available to topology and data layers. 
- Turn metric-derived split hints into concrete anisotropic refinement templates so metric-driven adaptation can produce edge/face-directed splits. 
- Preserve boundary semantics and enable robust data transfer (coordinates, labels, ownership, sections, constraints) across refinement/coarsening operations. 

### Description
- Add a DMPlex-style anchor map `TopologicalAnchors` with `AnchorKind` and anchor-aware `closure`/`star` helpers in `src/topology/anchors.rs` and re-export it via `topology` prelude. 
- Extend refinement outputs (`RefinedMesh`, `RefinedMeshWithTopology`, `RefinedMeshWithOwnership`) to include `anchors` and generated `hanging_constraints`, and wire `refine_mesh_with_options` to mark metric-hinted midpoints as hanging; see `src/topology/refine/mod.rs`. 
- Implement simple anisotropic refinement templates driven by `AnisotropicSplitHints`/`MetricSplitHint` including single-edge triangle splits and opposite-edge quad splits while falling back to isotropic templates; add helpers `triangle_split_indices`, `quadrilateral_split_indices`, `anisotropic_*_subdivision`. 
- Generate scalar hanging DOF constraints from anchors via `constraints_from_topological_anchors` and integrate with `apply_hanging_constraints_to_section` in `src/data/hanging_node_constraints.rs`. 
- Add transfer helpers in `src/adapt/mod.rs` for refinement/coarsening of sections, labels, cell types, ownership, coordinates, and anchor-derived constraints (`transfer_section_refinement`, `transfer_section_coarsening`, `transfer_labels_refinement`, `transfer_cell_types_refinement`, `transfer_ownership_refinement`, `transfer_constraints_from_anchors`, `transfer_coordinates_refinement`). 
- Add a boundary-remeshing policy and `adapt_with_metric_policy` to control whether boundary/labeled strata are preserved during metric adaptation and ensure unmodified cells are materialized into the refined topology (`materialize_unmodified_cells`). 
- Add a regression test `tests/adapt_anchors.rs` that verifies anisotropic edge splitting produces a hanging anchor, generated constraint, and anchor-aware closure. 

### Testing
- Ran `cargo fmt` and `cargo check` successfully. 
- Ran unit tests `cargo test --test adapt_anchors --test adapt_metric --test hanging_node_constraints --test refine_mesh --test refine_topology_consistency` and all specified tests passed. 
- The new regression test `tests/adapt_anchors.rs` passed (verifies hanging anchor creation and constraint generation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08027842848329a0305a943839b040)