### PR TITLE
Add centralized mesh diagnostics and DMPLEX-style checks

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,170 @@
+//! Centralized mesh diagnostics and DMPLEX-style validation options.
+
+use std::fmt::Write as _;
+
+use crate::data::coordinates::Coordinates;
+use crate::data::section::Section;
+use crate::data::storage::Storage;
+use crate::mesh_error::MeshSieveError;
+use crate::overlap::overlap::Overlap;
+use crate::topology::cell_type::CellType;
+use crate::topology::ownership::PointOwnership;
+use crate::topology::point::PointId;
+use crate::topology::sieve::strata::compute_strata;
+use crate::topology::sieve::{MeshSieve, Sieve};
+use crate::topology::validation::{
+    TopologyValidationOptions, validate_oriented_sieve_topology, validate_overlap_ownership_topology,
+};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MeshCheckOptions {
+    pub check_symmetry: bool,
+    pub check_skeleton: bool,
+    pub check_faces: bool,
+    pub check_geometry: bool,
+    pub check_overlap: bool,
+    pub check_ownership: bool,
+    pub check_sections: bool,
+}
+
+impl MeshCheckOptions {
+    pub fn all() -> Self {
+        Self {
+            check_symmetry: true,
+            check_skeleton: true,
+            check_faces: true,
+            check_geometry: true,
+            check_overlap: true,
+            check_ownership: true,
+            check_sections: true,
+        }
+    }
+}
+
+pub fn run_mesh_checks<'a, V, St, CtSt>(
+    sieve: &mut MeshSieve,
+    cell_types: Option<&Section<CellType, CtSt>>,
+    coords: Option<&Coordinates<V, St>>,
+    ownership: Option<&PointOwnership>,
+    overlap: Option<&Overlap>,
+    sections: impl Iterator<Item = &'a Section<V, St>>,
+    options: MeshCheckOptions,
+) -> Result<(), MeshSieveError>
+where
+    V: Clone + Default + 'a,
+    St: Storage<V> + Clone + 'a,
+    CtSt: Storage<CellType>,
+{
+    if options.check_skeleton {
+        compute_strata(sieve)?;
+    }
+
+    if options.check_symmetry {
+        if let Some(cell_types) = cell_types {
+            validate_oriented_sieve_topology(sieve, cell_types, TopologyValidationOptions::all())?;
+        }
+    }
+
+    if options.check_geometry {
+        if let Some(coords) = coords {
+            for (point, (_offset, len)) in coords.section().atlas().iter_entries() {
+                if len != coords.embedding_dimension() {
+                    return Err(MeshSieveError::SliceLengthMismatch {
+                        point,
+                        expected: coords.embedding_dimension(),
+                        found: len,
+                    });
+                }
+            }
+        }
+    }
+
+    if options.check_overlap || options.check_ownership {
+        if let Some(ownership) = ownership {
+            validate_overlap_ownership_topology(sieve, ownership, overlap, 0)?;
+        }
+    }
+
+    if options.check_sections {
+        for section in sections {
+            for (point, (_offset, len)) in section.atlas().iter_entries() {
+                if len == 0 {
+                    return Err(MeshSieveError::SliceLengthMismatch {
+                        point,
+                        expected: 1,
+                        found: 0,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn mesh_text_summary<S: Sieve<Point = PointId>>(sieve: &S) -> Result<String, MeshSieveError> {
+    let strata = compute_strata(sieve)?;
+    Ok(format!(
+        "points={}, topological_dimension={}, strata={:?}",
+        strata.chart_points.len(), strata.diameter, strata.strata
+    ))
+}
+
+pub fn mesh_dot_graph<S: Sieve<Point = PointId>>(sieve: &S) -> String {
+    let mut out = String::from("digraph MeshSieve {\n");
+    for src in sieve.points() {
+        for dst in sieve.cone_points(src) {
+            let _ = writeln!(&mut out, "  \"{:?}\" -> \"{:?}\";", src, dst);
+        }
+    }
+    out.push_str("}\n");
+    out
+}
+
+pub fn mesh_json_debug_dump<S: Sieve<Point = PointId>>(sieve: &S) -> String {
+    let mut edges = Vec::new();
+    for src in sieve.points() {
+        for dst in sieve.cone_points(src) {
+            edges.push(format!("[{},{}]", src.get(), dst.get()));
+        }
+    }
+    format!("{{\"edges\":[{}]}}", edges.join(","))
+}
+
+pub fn mesh_tikz_viewer<S: Sieve<Point = PointId>>(sieve: &S, max_points: usize) -> Option<String> {
+    let points: Vec<_> = sieve.points().collect();
+    if points.len() > max_points {
+        return None;
+    }
+    let mut out = String::from("\\begin{tikzpicture}[scale=1.0]\n");
+    for (i, p) in points.iter().enumerate() {
+        let _ = writeln!(&mut out, "\\node (p{}) at ({},0) {{{}}};", p.get(), i, p.get());
+    }
+    for src in sieve.points() {
+        for dst in sieve.cone_points(src) {
+            let _ = writeln!(&mut out, "\\draw[->] (p{}) -- (p{});", src.get(), dst.get());
+        }
+    }
+    out.push_str("\\end{tikzpicture}\n");
+    Some(out)
+}
+
+pub fn fem_diagnostics_report(
+    element_closure: &[PointId],
+    basis_values: &[f64],
+    quadrature_weights: &[f64],
+    local_matrix: &[f64],
+    local_vector: &[f64],
+) -> String {
+    format!(
+        "FEM diagnostics: closure={:?}, basis={:?}, quadrature={:?}, Ke={:?}, Fe={:?}",
+        element_closure, basis_values, quadrature_weights, local_matrix, local_vector
+    )
+}
+
+pub fn fvm_flux_diagnostics(flux_updates: &[(PointId, f64)]) -> String {
+    let mut out = String::from("FVM flux updates:");
+    for (p, f) in flux_updates {
+        let _ = write!(&mut out, " ({:?}: {f})", p);
+    }
+    out
+}

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -16,6 +16,7 @@ use crate::algs::distribute::{
 use crate::algs::dual_graph::{DualGraph, build_dual};
 use crate::algs::renumber::{StratifiedOrdering, stratified_permutation};
 use crate::data::atlas::Atlas;
+use crate::diagnostics::{MeshCheckOptions, run_mesh_checks};
 use crate::data::coordinates::Coordinates;
 use crate::data::discretization::Discretization;
 use crate::data::global_map::{LocalToGlobalMap, global_vector_for_map};
@@ -31,7 +32,6 @@ use crate::topology::ownership::PointOwnership;
 use crate::topology::point::PointId;
 use crate::topology::sieve::strata::compute_strata;
 use crate::topology::sieve::{MeshSieve, Sieve};
-use crate::topology::validation::{TopologyValidationOptions, validate_oriented_sieve_topology};
 
 /// Options for a DMPLEX-like setup pipeline.
 ///
@@ -59,6 +59,8 @@ pub struct MeshDMOptions {
     pub check_faces: bool,
     /// Validate coordinate geometry metadata when coordinates are present.
     pub check_geometry: bool,
+    /// Enable all mesh checks in a DMPLEX-like single switch.
+    pub check_all: bool,
     /// Reorder section atlas entries by topology strata during setup.
     pub reorder_section: Option<StratifiedOrdering>,
     /// Balance ownership of partition-boundary points during distribution.
@@ -79,6 +81,7 @@ impl Default for MeshDMOptions {
             check_skeleton: false,
             check_faces: false,
             check_geometry: false,
+            check_all: false,
             reorder_section: None,
             balance_boundary_ownership: false,
             synchronize_sections: true,
@@ -352,40 +355,31 @@ where
 
     /// Run topology/geometry checks requested by [`MeshDMOptions`].
     pub fn run_requested_checks(&mut self) -> Result<(), MeshSieveError> {
-        if self.options.check_skeleton {
-            compute_strata(&self.mesh_data.sieve)?;
-        }
+        let check_all = self.options.check_all;
+        let check_options = MeshCheckOptions {
+            check_symmetry: check_all || self.options.check_symmetry,
+            check_skeleton: check_all || self.options.check_skeleton,
+            check_faces: check_all || self.options.check_faces,
+            check_geometry: check_all || self.options.check_geometry,
+            check_overlap: check_all,
+            check_ownership: check_all,
+            check_sections: check_all,
+        };
 
-        if self.options.check_faces {
+        if check_options.check_faces {
             let cells = self.height_stratum(0)?;
             let _ = self.cell_adjacency_graph(cells, Default::default(), AdjacencyWeighting::None);
         }
 
-        if self.options.check_symmetry {
-            if let Some(cell_types) = &self.mesh_data.cell_types {
-                validate_oriented_sieve_topology(
-                    &mut self.mesh_data.sieve,
-                    cell_types,
-                    TopologyValidationOptions::all(),
-                )?;
-            }
-        }
-
-        if self.options.check_geometry {
-            if let Some(coords) = &self.mesh_data.coordinates {
-                for (point, (_offset, len)) in coords.section().atlas().iter_entries() {
-                    if len != coords.embedding_dimension() {
-                        return Err(MeshSieveError::SliceLengthMismatch {
-                            point,
-                            expected: coords.embedding_dimension(),
-                            found: len,
-                        });
-                    }
-                }
-            }
-        }
-
-        Ok(())
+        run_mesh_checks(
+            &mut self.mesh_data.sieve,
+            self.mesh_data.cell_types.as_ref(),
+            self.mesh_data.coordinates.as_ref(),
+            self.ownership.as_ref(),
+            self.overlap.as_ref(),
+            self.mesh_data.sections.values(),
+            check_options,
+        )
     }
 
     /// Return points in a height stratum (height 0 are cells in DMPLEX terms).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod adapt;
 pub mod algs;
 pub mod data;
 pub mod debug_invariants;
+pub mod diagnostics;
 pub mod discretization;
 pub mod dm;
 pub mod forest;
@@ -132,6 +133,10 @@ pub mod prelude {
     pub use crate::data::section::Map;
     pub use crate::data::section::Section;
     pub use crate::debug_invariants::DebugInvariants;
+    pub use crate::diagnostics::{
+        MeshCheckOptions, fem_diagnostics_report, fvm_flux_diagnostics, mesh_dot_graph,
+        mesh_json_debug_dump, mesh_text_summary, mesh_tikz_viewer, run_mesh_checks,
+    };
     pub use crate::discretization::runtime::{
         Basis, BasisFamily, CellGeometry, ClosureDof, CsrPattern, DofMap, ElementRuntime,
         ElementTabulation, FaceGeometry, FiniteVolumeMetadata, FluxStencil, QuadratureRule,

--- a/tests/diagnostics_checks.rs
+++ b/tests/diagnostics_checks.rs
@@ -1,0 +1,50 @@
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::diagnostics::{MeshCheckOptions, mesh_dot_graph, mesh_json_debug_dump, run_mesh_checks};
+use mesh_sieve::mesh_error::MeshSieveError;
+use mesh_sieve::topology::ownership::PointOwnership;
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::{MeshSieve, Sieve};
+
+fn pid(id: u64) -> PointId { PointId::new(id).unwrap() }
+
+fn tiny_mesh() -> MeshSieve {
+    let mut mesh = MeshSieve::default();
+    mesh.add_arrow(pid(3), pid(1), ());
+    mesh.add_arrow(pid(3), pid(2), ());
+    mesh
+}
+
+#[test]
+fn check_all_detects_missing_ownership_precisely() {
+    let mut mesh = tiny_mesh();
+    let mut ownership = PointOwnership::default();
+    ownership.set(pid(1), 0, false).unwrap();
+
+    let err = run_mesh_checks::<f64, VecStorage<f64>, VecStorage<mesh_sieve::topology::cell_type::CellType>>(
+        &mut mesh,
+        None,
+        None,
+        Some(&ownership),
+        None,
+        std::iter::empty(),
+        MeshCheckOptions::all(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, MeshSieveError::TopologyPointMissingOwnership { .. }));
+}
+
+#[test]
+fn viewers_emit_expected_formats() {
+    let mesh = tiny_mesh();
+    let dot = mesh_dot_graph(&mesh);
+    assert!(dot.starts_with("digraph MeshSieve"));
+    let json = mesh_json_debug_dump(&mesh);
+    assert!(json.contains("\"edges\""));
+
+    let mut atlas = Atlas::default();
+    atlas.try_insert(pid(1), 1).unwrap();
+    let _section: Section<f64, VecStorage<f64>> = Section::new(atlas);
+}


### PR DESCRIPTION
### Motivation
- Centralize and standardize mesh validation and diagnostic viewers to mirror PETSc DMPLEX ergonomics and consolidate scattered invariant/validation logic.
- Provide lightweight viewers and FEM/FVM diagnostic helpers so callers can inspect and report mesh and element-level state consistently.

### Description
- Add a new diagnostics module `src/diagnostics.rs` that defines `MeshCheckOptions`, `run_mesh_checks`, lightweight viewers (`mesh_text_summary`, `mesh_dot_graph`, `mesh_json_debug_dump`, `mesh_tikz_viewer`), and FEM/FVM helpers (`fem_diagnostics_report`, `fvm_flux_diagnostics`).
- Wire the centralized checks into the DM facade by adding a `check_all` toggle to `MeshDMOptions` and refactoring `MeshDM::run_requested_checks()` to build `MeshCheckOptions` and call `run_mesh_checks`; preserve face-adjacency checks performed by `MeshDM`.
- Export the diagnostics module and re-export the key APIs in the public `prelude` in `src/lib.rs` for convenient use across the crate.
- Add tests in `tests/diagnostics_checks.rs` that construct small meshes with deliberate issues to assert precise diagnostic errors and to validate DOT/JSON viewer outputs.

### Testing
- Ran the diagnostics test suite with `cargo test -q --test diagnostics_checks`, which executed 2 tests and completed successfully (`2 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c1ce52748329900f7b96f2c80326)