### PR TITLE
Implement DMPlex-style DMLabel operations and label-driven constrained-section creation

### DIFF
--- a/src/data/constrained_section.rs
+++ b/src/data/constrained_section.rs
@@ -10,6 +10,28 @@ use crate::topology::cache::InvalidateCache;
 use crate::topology::point::PointId;
 use std::collections::BTreeMap;
 
+/// Label-based boundary constraint specification for section construction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LabelConstraintSpec {
+    /// Label name.
+    pub label: String,
+    /// Label value.
+    pub value: i32,
+    /// Component indices constrained when label matches.
+    pub components: Vec<usize>,
+}
+
+impl LabelConstraintSpec {
+    /// Create a new spec.
+    pub fn new(label: impl Into<String>, value: i32, components: Vec<usize>) -> Self {
+        Self {
+            label: label.into(),
+            value,
+            components,
+        }
+    }
+}
+
 /// A single constrained degree of freedom within a point slice.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DofConstraint<V> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -38,7 +38,8 @@ pub use closure::{
     set_closure,
 };
 pub use constrained_section::{
-    ConstrainedSection, ConstraintSet, DofConstraint, apply_constraints_to_section,
+    ConstrainedSection, ConstraintSet, DofConstraint, LabelConstraintSpec,
+    apply_constraints_to_section,
 };
 pub use coordinate_dm::{CoordinateDM, CoordinateNumbering};
 pub use discretization::{Discretization, DiscretizationMetadata, FieldDiscretization, RegionKey};
@@ -50,7 +51,7 @@ pub use hanging_node_constraints::{
 pub use mixed_section::{
     MixedScalar, MixedSectionStore, ScalarType, TaggedSection, TaggedSectionBuffer,
 };
-pub use multi_section::{FieldSection, MultiSection};
+pub use multi_section::{FieldSection, MultiSection, constrained_section_from_label_specs};
 pub use section::Section;
 pub use section_layout::{
     DofLayout, build_layout_with, constrained_dof_len, layout_for_multi_section_with_periodic,

--- a/src/data/multi_section.rs
+++ b/src/data/multi_section.rs
@@ -1,10 +1,13 @@
 //! MultiSection: group multiple field sections with shared point offsets.
 
 use crate::data::atlas::Atlas;
-use crate::data::constrained_section::{DofConstraint, apply_constraints_to_section};
+use crate::data::constrained_section::{
+    ConstrainedSection, DofConstraint, LabelConstraintSpec, apply_constraints_to_section,
+};
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::mesh_error::MeshSieveError;
+use crate::topology::labels::LabelSet;
 use crate::topology::point::PointId;
 use std::collections::{BTreeMap, HashSet};
 
@@ -14,6 +17,43 @@ pub struct FieldSection<V, S: Storage<V>> {
     name: String,
     section: Section<V, S>,
     constraints: BTreeMap<PointId, Vec<DofConstraint<V>>>,
+}
+
+/// Build a constrained section from explicit per-point dofs and label constraints.
+pub fn constrained_section_from_label_specs<V, S>(
+    point_dofs: &[(PointId, usize)],
+    labels: &LabelSet,
+    specs: &[LabelConstraintSpec],
+) -> Result<ConstrainedSection<V, S>, MeshSieveError>
+where
+    V: Clone + Default,
+    S: Storage<V> + Clone,
+{
+    let mut atlas = Atlas::default();
+    for (p, dof) in point_dofs {
+        atlas.try_insert(*p, *dof)?;
+    }
+    let section = Section::<V, S>::new(atlas);
+    let mut constrained = ConstrainedSection::new(section);
+    for spec in specs {
+        for p in labels.stratum_points(&spec.label, spec.value) {
+            let len = constrained
+                .section()
+                .atlas()
+                .get(p)
+                .map(|(_, l)| l)
+                .unwrap_or(0);
+            if len == 0 {
+                continue;
+            }
+            for &c in &spec.components {
+                if c < len {
+                    constrained.insert_constraint(p, c, V::default())?;
+                }
+            }
+        }
+    }
+    Ok(constrained)
 }
 
 impl<V, S> FieldSection<V, S>
@@ -354,7 +394,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{FieldSection, MultiSection};
+    use super::{FieldSection, MultiSection, constrained_section_from_label_specs};
     use crate::data::atlas::Atlas;
     use crate::data::section::Section;
     use crate::data::storage::VecStorage;
@@ -426,5 +466,27 @@ mod tests {
         assert_eq!(multi.field_dof(p3, 0).unwrap(), 0);
         assert_eq!(multi.field_dof_by_name(p3, "pressure").unwrap(), 1);
         assert_eq!(multi.field_offset_by_name(p3, "pressure").unwrap(), 6);
+    }
+
+    #[test]
+    fn constrained_layout_from_labels() {
+        use crate::data::constrained_section::LabelConstraintSpec;
+        use crate::topology::labels::LabelSet;
+
+        let p1 = PointId::new(1).unwrap();
+        let p2 = PointId::new(2).unwrap();
+        let mut labels = LabelSet::new();
+        labels.set_label(p2, "boundary", 1);
+        let cs = constrained_section_from_label_specs::<f64, VecStorage<f64>>(
+            &[(p1, 3), (p2, 3)],
+            &labels,
+            &[LabelConstraintSpec::new("boundary", 1, vec![0, 2])],
+        )
+        .unwrap();
+        assert_eq!(cs.section().atlas().total_len(), 6);
+        let c = cs.constraints().get(&p2).unwrap();
+        assert_eq!(c.len(), 2);
+        assert_eq!(c[0].index, 0);
+        assert_eq!(c[1].index, 2);
     }
 }

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -16,12 +16,14 @@ use crate::algs::distribute::{
 use crate::algs::dual_graph::{DualGraph, build_dual};
 use crate::algs::renumber::{StratifiedOrdering, stratified_permutation};
 use crate::data::atlas::Atlas;
-use crate::diagnostics::{MeshCheckOptions, run_mesh_checks};
 use crate::data::coordinates::Coordinates;
 use crate::data::discretization::Discretization;
 use crate::data::global_map::{LocalToGlobalMap, global_vector_for_map};
+use crate::data::multi_section::constrained_section_from_label_specs;
 use crate::data::section::Section;
 use crate::data::storage::{Storage, VecStorage};
+use crate::data::{ConstrainedSection, LabelConstraintSpec};
+use crate::diagnostics::{MeshCheckOptions, run_mesh_checks};
 use crate::io::MeshData;
 use crate::mesh_error::MeshSieveError;
 use crate::mesh_graph::{AdjacencyWeighting, MeshGraph, cell_adjacency_graph_with_cells};
@@ -497,6 +499,28 @@ where
             section: Some(section_name.to_string()),
             values: global_vector_for_map(map),
         })
+    }
+
+    /// Create a constrained section for a field using label constraints.
+    pub fn create_constrained_section_from_labels(
+        &self,
+        field_name: &str,
+        point_dofs: &[(PointId, usize)],
+        constraints: &[LabelConstraintSpec],
+    ) -> Result<ConstrainedSection<V, St>, MeshSieveError> {
+        if let Some(discretization) = self.discretization() {
+            if discretization.field(field_name).is_none() {
+                return Err(MeshSieveError::MissingSectionName {
+                    name: field_name.to_string(),
+                });
+            }
+        }
+        let labels = self
+            .labels()
+            .ok_or_else(|| MeshSieveError::MissingSectionName {
+                name: "labels".to_string(),
+            })?;
+        constrained_section_from_label_specs(point_dofs, labels, constraints)
     }
 
     /// Distribute this DM through the lower-level distribution pipeline and

--- a/src/topology/labels.rs
+++ b/src/topology/labels.rs
@@ -21,6 +21,15 @@ pub struct LabelSet {
     labels: HashMap<String, HashMap<PointId, i32>>,
 }
 
+/// Deterministic iteration order contract for label strata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LabelIterationOrder {
+    /// Sort by `PointId` only.
+    PointAscending,
+    /// Sort by label value ascending, then `PointId`.
+    ValueThenPointAscending,
+}
+
 impl LabelSet {
     /// Creates an empty label set.
     pub fn new() -> Self {
@@ -221,6 +230,104 @@ impl LabelSet {
             map.iter()
                 .map(move |(&point, &value)| (name.as_str(), point, value))
         })
+    }
+
+    /// Apply a label to the closure of a set of seed points.
+    pub fn apply_to_closure<S>(
+        &mut self,
+        sieve: &S,
+        name: &str,
+        value: i32,
+        seeds: impl IntoIterator<Item = PointId>,
+    ) where
+        S: Sieve<Point = PointId>,
+    {
+        for point in sieve.closure_iter(seeds) {
+            self.set_label(point, name, value);
+        }
+    }
+
+    /// Apply a label to the star/support of a set of seed points.
+    pub fn apply_to_star<S>(
+        &mut self,
+        sieve: &S,
+        name: &str,
+        value: i32,
+        seeds: impl IntoIterator<Item = PointId>,
+    ) where
+        S: Sieve<Point = PointId>,
+    {
+        for point in sieve.star_iter(seeds) {
+            self.set_label(point, name, value);
+        }
+    }
+
+    /// Copy all points in `src_name/src_value` into `dst_name/dst_value`.
+    pub fn union_into(
+        &mut self,
+        other: &LabelSet,
+        src_name: &str,
+        src_value: i32,
+        dst_name: &str,
+        dst_value: i32,
+    ) {
+        for point in other.stratum_points(src_name, src_value) {
+            self.set_label(point, dst_name, dst_value);
+        }
+    }
+
+    /// Intersect current `dst_name/dst_value` with `other/src_name/src_value`.
+    pub fn intersect_with(
+        &mut self,
+        other: &LabelSet,
+        src_name: &str,
+        src_value: i32,
+        dst_name: &str,
+        dst_value: i32,
+    ) {
+        let keep: HashSet<PointId> = other
+            .stratum_points(src_name, src_value)
+            .into_iter()
+            .collect();
+        let to_remove: Vec<PointId> = self
+            .stratum_points(dst_name, dst_value)
+            .into_iter()
+            .filter(|p| !keep.contains(p))
+            .collect();
+        for p in to_remove {
+            if let Some(map) = self.labels.get_mut(dst_name) {
+                map.remove(&p);
+            }
+        }
+    }
+
+    /// Subtract points in `other/src_name/src_value` from `dst_name/dst_value`.
+    pub fn subtract(
+        &mut self,
+        other: &LabelSet,
+        src_name: &str,
+        src_value: i32,
+        dst_name: &str,
+        dst_value: i32,
+    ) {
+        let remove: HashSet<PointId> = other
+            .stratum_points(src_name, src_value)
+            .into_iter()
+            .collect();
+        for p in remove {
+            if self.get_label(p, dst_name) == Some(dst_value) {
+                if let Some(map) = self.labels.get_mut(dst_name) {
+                    map.remove(&p);
+                }
+            }
+        }
+    }
+
+    /// Remap all points in one stratum value to another.
+    pub fn remap_value(&mut self, name: &str, from: i32, to: i32) {
+        for p in self.stratum_points(name, from) {
+            self.set_label(p, name, to);
+        }
     }
 }
 

--- a/src/topology/tests/labels_tests.rs
+++ b/src/topology/tests/labels_tests.rs
@@ -113,3 +113,33 @@ fn label_propagation_closure_and_star() {
     seed_pts.sort_unstable();
     assert_eq!(seed_pts, vec![cell, face, vertex]);
 }
+
+#[test]
+fn label_algebra_and_remap_and_seed_propagation() {
+    let mut sieve = InMemorySieve::<PointId, ()>::default();
+    let c = PointId::new(1).unwrap();
+    let f = PointId::new(2).unwrap();
+    let v = PointId::new(3).unwrap();
+    sieve.add_arrow(c, f, ());
+    sieve.add_arrow(f, v, ());
+
+    let mut a = LabelSet::new();
+    let mut b = LabelSet::new();
+    a.set_label(f, "bd", 1);
+    b.set_label(v, "bd", 1);
+
+    a.apply_to_closure(&sieve, "seed", 9, [f]);
+    assert_eq!(a.stratum_points("seed", 9), vec![f, v]);
+    a.apply_to_star(&sieve, "seed", 10, [v]);
+    assert_eq!(a.stratum_points("seed", 10), vec![c, f, v]);
+
+    a.union_into(&b, "bd", 1, "bd", 1);
+    assert_eq!(a.stratum_points("bd", 1), vec![f, v]);
+    a.intersect_with(&b, "bd", 1, "bd", 1);
+    assert_eq!(a.stratum_points("bd", 1), vec![v]);
+    a.subtract(&b, "bd", 1, "bd", 1);
+    assert!(a.stratum_points("bd", 1).is_empty());
+
+    b.remap_value("bd", 1, 5);
+    assert_eq!(b.stratum_points("bd", 5), vec![v]);
+}


### PR DESCRIPTION
### Motivation
- Provide DMPlex-like lifecycle and algebra for point labels so label-driven workflows (boundaries, regions, section constraints) are first-class and deterministic. 
- Allow construction of constrained `Section`/`ConstrainedSection` layouts directly from label constraints to simplify boundary/Dirichlet setup and DM-level orchestration.

### Description
- Expanded `LabelSet` with DMLabel-style APIs: seed-based closure/star propagation via `apply_to_closure` and `apply_to_star`, in-place stratum algebra via `union_into`, `intersect_with`, and `subtract`, and value remapping via `remap_value`, while preserving deterministic stratum ordering via existing sorted accessors (`stratum_points`, etc.). (`src/topology/labels.rs`)
- Added `LabelConstraintSpec` to express label → component constraint mappings for section construction. (`src/data/constrained_section.rs`)
- Implemented `constrained_section_from_label_specs(...)` which builds a `ConstrainedSection` from explicit per-point DOFs plus a list of `LabelConstraintSpec` entries, applying constraints to matching label strata. (`src/data/multi_section.rs`)
- Wired a DM-level entry point `MeshDM::create_constrained_section_from_labels(...)` to expose label-driven constrained-section creation from the `MeshDM` facade and validate field presence against `Discretization` when available. (`src/dm.rs`)
- Exported new APIs via `data::mod` re-exports and added regression tests covering label propagation/algebra and constrained-layout construction. (`src/data/mod.rs`, `src/topology/tests/labels_tests.rs`, `src/data/multi_section.rs`)

### Testing
- Ran `cargo fmt` to ensure formatting consistency and it completed successfully.
- Attempted to run targeted unit tests `label_algebra_and_remap_and_seed_propagation` and `constrained_layout_from_labels`, but the test invocations did not complete in the execution environment (tooling/time-window limits) so their results are inconclusive here; test cases were added in `src/topology/tests/labels_tests.rs` and `src/data/multi_section.rs` for automated verification in CI.
- A local commit was created including these changes so CI should run the full test-suite and report pass/fail for the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c422cf1c832990c447d5476e2b89)