### PR TITLE
Add first-class PointSF composition pipeline and DM provenance maps

### DIFF
--- a/examples/petsc_sf_composed_pipeline.rs
+++ b/examples/petsc_sf_composed_pipeline.rs
@@ -1,0 +1,38 @@
+use mesh_sieve::algs::communicator::NoComm;
+use mesh_sieve::algs::{create_migration_sf, create_point_sf, create_process_sf};
+use mesh_sieve::io::petsc_hdf5::compose_migration_pipeline;
+use mesh_sieve::overlap::overlap::Overlap;
+use mesh_sieve::topology::ownership::PointOwnership;
+use mesh_sieve::topology::point::PointId;
+use std::collections::BTreeMap;
+
+fn p(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+fn main() {
+    let mut ownership = PointOwnership::default();
+    ownership.set(p(1), 0, false).unwrap();
+    ownership.set(p(2), 1, true).unwrap();
+
+    let mut overlap = Overlap::default();
+    overlap.try_add_link(p(2), 1, p(20)).unwrap();
+
+    let load_sf = create_point_sf::<NoComm>(&overlap, &ownership, 0);
+
+    let mut owners = BTreeMap::new();
+    owners.insert(p(1), 0usize);
+    owners.insert(p(2), 0usize);
+    let redistribute_sf = create_migration_sf::<NoComm, _>([p(1), p(2)], &owners, 0);
+
+    let section_sf = create_process_sf::<NoComm>(&ownership, 0);
+    let composed = compose_migration_pipeline(&load_sf, &redistribute_sf, &section_sf);
+    let report = composed.validate_mapping();
+    println!(
+        "composed leaves={}, domain={}, range={}, unmapped_ghosts={}",
+        composed.leaves().count(),
+        report.domain_points,
+        report.range_points,
+        report.unmapped_ghosts.len()
+    );
+}

--- a/src/algs/point_sf.rs
+++ b/src/algs/point_sf.rs
@@ -22,6 +22,15 @@ use crate::topology::point::PointId;
 use crate::topology::sieve::{MeshSieve, OrientedSieve, Sieve};
 use std::collections::{BTreeMap, BTreeSet};
 
+/// Diagnostics for SF map validation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SfValidationReport {
+    pub domain_points: usize,
+    pub range_points: usize,
+    pub duplicate_leaves: Vec<PointId>,
+    pub unmapped_ghosts: Vec<PointId>,
+}
+
 /// A remote root in a star forest.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct RemotePoint {
@@ -239,6 +248,99 @@ where
             }
         }
         Ok(())
+    }
+
+    /// Compose `self` with `next`, i.e. `next ∘ self`.
+    pub fn compose(&self, next: &PointSF<'_, C>) -> PointSF<'static, C> {
+        let mut composed = Vec::new();
+        let next_by_local: BTreeMap<PointId, RemotePoint> = next
+            .leaves
+            .iter()
+            .map(|leaf| (leaf.local, leaf.remote))
+            .collect();
+        for leaf in &self.leaves {
+            let remote = next_by_local
+                .get(&leaf.remote.point)
+                .copied()
+                .unwrap_or(leaf.remote);
+            composed.push(PointSfLeaf {
+                local: leaf.local,
+                remote,
+                owner_rank: remote.rank,
+                is_ghost: remote.rank != self.my_rank,
+            });
+        }
+        let roots: Vec<_> = composed
+            .iter()
+            .filter_map(|leaf| (leaf.remote.rank == self.my_rank).then_some(leaf.remote.point))
+            .collect();
+        PointSF::from_leaves(self.my_rank, roots, composed)
+    }
+
+    /// Invert this SF if leaves map uniquely by remote point.
+    pub fn invert(&self) -> Result<PointSF<'static, C>, MeshSieveError> {
+        let mut seen = BTreeSet::new();
+        let mut inv = Vec::with_capacity(self.leaves.len());
+        for leaf in &self.leaves {
+            if !seen.insert(leaf.remote.point) {
+                return Err(MeshSieveError::MeshIoParse(
+                    "cannot invert SF with duplicate remote points".to_string(),
+                ));
+            }
+            inv.push(PointSfLeaf {
+                local: leaf.remote.point,
+                remote: RemotePoint {
+                    rank: self.my_rank,
+                    point: leaf.local,
+                },
+                owner_rank: self.my_rank,
+                is_ghost: false,
+            });
+        }
+        let roots = self.leaves.iter().map(|l| l.local);
+        Ok(PointSF::from_leaves(self.my_rank, roots, inv))
+    }
+
+    /// Restrict this SF to points in a label value.
+    pub fn restrict_to_label(
+        &self,
+        labels: &LabelSet,
+        name: &str,
+        value: i32,
+    ) -> PointSF<'static, C> {
+        let leaves: Vec<_> = self
+            .leaves
+            .iter()
+            .copied()
+            .filter(|leaf| labels.get_label(leaf.local, name) == Some(value))
+            .collect();
+        let roots: Vec<_> = leaves.iter().map(|leaf| leaf.remote.point).collect();
+        PointSF::from_leaves(self.my_rank, roots, leaves)
+    }
+
+    /// Validate cardinality and mapping coherence, reporting duplicates and unmapped ghosts.
+    pub fn validate_mapping(&self) -> SfValidationReport {
+        let mut report = SfValidationReport::default();
+        let mut domain = BTreeSet::new();
+        let mut range = BTreeSet::new();
+        let mut counts: BTreeMap<PointId, usize> = BTreeMap::new();
+        for leaf in &self.leaves {
+            domain.insert(leaf.local);
+            range.insert(leaf.remote.point);
+            *counts.entry(leaf.local).or_insert(0) += 1;
+        }
+        report.domain_points = domain.len();
+        report.range_points = range.len();
+        report.duplicate_leaves = counts
+            .into_iter()
+            .filter_map(|(p, n)| (n > 1).then_some(p))
+            .collect();
+        report.unmapped_ghosts = self
+            .owner
+            .iter()
+            .filter_map(|(&p, entry)| (entry.is_ghost && !domain.contains(&p)).then_some(p))
+            .collect();
+        report
     }
 
     /// Complete a section using CopyDelta and optional ownership metadata.

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -14,6 +14,7 @@ use crate::algs::distribute::{
     CellPartitioner, DistributedMeshData, DistributionConfig, distribute_with_overlap,
 };
 use crate::algs::dual_graph::{DualGraph, build_dual};
+use crate::algs::point_sf::PointSF;
 use crate::algs::renumber::{StratifiedOrdering, stratified_permutation};
 use crate::data::atlas::Atlas;
 use crate::data::coordinates::Coordinates;
@@ -220,6 +221,14 @@ pub struct MeshDMDistribution {
     pub size: usize,
 }
 
+/// Provenance SF maps tracking load/redistribute/section movement.
+#[derive(Clone, Debug, Default)]
+pub struct MeshDMProvenance<C: Communicator + Sync + 'static> {
+    pub load_map: Option<PointSF<'static, C>>,
+    pub redistribute_map: Option<PointSF<'static, C>>,
+    pub section_map: Option<PointSF<'static, C>>,
+}
+
 /// DMPLEX-like facade owning topology, coordinates, labels, sections,
 /// discretization metadata, distribution state, and solver numbering maps.
 #[derive(Debug)]
@@ -234,6 +243,7 @@ where
     overlap: Option<Overlap>,
     global_sections: BTreeMap<String, LocalToGlobalMap>,
     distribution: Option<MeshDMDistribution>,
+    provenance_maps: MeshDMProvenance<crate::algs::communicator::NoComm>,
 }
 
 impl<V, St, CtSt> MeshDM<V, St, CtSt>
@@ -264,6 +274,7 @@ where
             overlap: None,
             global_sections: BTreeMap::new(),
             distribution: None,
+            provenance_maps: MeshDMProvenance::default(),
         }
     }
 
@@ -339,6 +350,10 @@ where
     /// Borrow distribution metadata, if this DM has been distributed.
     pub fn distribution(&self) -> Option<&MeshDMDistribution> {
         self.distribution.as_ref()
+    }
+
+    pub fn provenance_maps(&self) -> &MeshDMProvenance<crate::algs::communicator::NoComm> {
+        &self.provenance_maps
     }
 
     /// Borrow DM setup options.
@@ -566,6 +581,9 @@ where
         let sf =
             crate::algs::point_sf::PointSF::with_ownership(overlap, ownership, comm, comm.rank());
         sf.validate()?;
+        self.provenance_maps.section_map = Some(crate::algs::point_sf::create_process_sf::<
+            crate::algs::communicator::NoComm,
+        >(ownership, comm.rank()));
         if let Some(coords) = &mut self.mesh_data.coordinates {
             sf.complete_section(coords.section_mut())?;
             if let Some(high_order) = coords.high_order_mut() {
@@ -584,6 +602,9 @@ where
         rank: usize,
         size: usize,
     ) -> Self {
+        let redistribute_map = crate::algs::point_sf::create_process_sf::<
+            crate::algs::communicator::NoComm,
+        >(&data.ownership, rank);
         let mesh_data = MeshData {
             sieve: data.sieve,
             coordinates: data.coordinates,
@@ -605,6 +626,11 @@ where
                 rank,
                 size,
             }),
+            provenance_maps: MeshDMProvenance {
+                load_map: None,
+                redistribute_map: Some(redistribute_map),
+                section_map: None,
+            },
         }
     }
 

--- a/src/io/petsc_hdf5.rs
+++ b/src/io/petsc_hdf5.rs
@@ -6,6 +6,7 @@
 //! mesh/section/vector data to be written, loaded independently, and
 //! re-associated by the preserved point permutation/order.
 
+use crate::algs::point_sf::PointSF;
 use crate::data::atlas::Atlas;
 use crate::data::section::Section;
 use crate::data::storage::VecStorage;
@@ -22,6 +23,19 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Compose load/redistribute/section SF maps for DMPlex-style migration workflows.
+pub fn compose_migration_pipeline<C>(
+    load_map: &PointSF<'_, C>,
+    redistribute_map: &PointSF<'_, C>,
+    section_map: &PointSF<'_, C>,
+) -> PointSF<'static, C>
+where
+    C: crate::algs::communicator::Communicator + Sync,
+{
+    let topo = load_map.compose(redistribute_map);
+    topo.compose(section_map)
+}
 
 /// PETSc DMPlex HDF5 storage version written by this module.
 pub const DMPLEX_STORAGE_VERSION: i32 = 3;


### PR DESCRIPTION
### Motivation

- DMPlex-style workflows rely on composing SFs for load → redistribute → section placement, so SF composition and provenance must be first-class to improve parity and traceability.
- Mapping diagnostics and invert/restrict helpers are needed to validate and reason about migration maps during topology and data I/O.

### Description

- Add `SfValidationReport` and mapping diagnostics with `validate_mapping()` in `src/algs/point_sf.rs` to report domain/range cardinality, duplicate leaves, and unmapped ghost points.
- Implement a stable SF composition API in `src/algs/point_sf.rs` with `compose()`, `invert()`, and `restrict_to_label()` for chaining and manipulating `PointSF` maps.
- Add DM-level provenance storage `MeshDMProvenance` and a `provenance_maps` field on `MeshDM` in `src/dm.rs`, and populate `redistribute_map` during distribution and `section_map` during field synchronization.
- Wire a composable migration helper `compose_migration_pipeline()` into `src/io/petsc_hdf5.rs` and provide an example `examples/petsc_sf_composed_pipeline.rs` demonstrating load + redistribute + section map composition.

### Testing

- Ran `cargo test -q --test point_sf_migration`, which completed successfully (4 tests passed).
- Ran `cargo check -q --example petsc_sf_composed_pipeline`, which completed successfully (example builds with warnings but no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c7740abc8329884358e98283bf33)