### PR TITLE
Add coastal mesh metadata label/query utilities

### DIFF
--- a/docs/coastal-mesh-labels.md
+++ b/docs/coastal-mesh-labels.md
@@ -1,0 +1,66 @@
+# Coastal Mesh Label Schema
+
+This document recommends a consistent metadata schema for coastal/ocean meshes when using `mesh-sieve` labels.
+
+## Canonical label names
+
+- `boundary_class`
+  - `1` = free surface
+  - `2` = bed
+  - `3` = open boundary
+- `boundary_role` (used for points/entities that are also `boundary_class=3`)
+  - `11` = inflow
+  - `12` = outflow
+  - `13` = tidal
+- `vertical_layer`
+  - integer index for sigma/z layer (for example: `0..nz-1`)
+- `wet_dry_mask` (optional)
+  - `1` = wet
+  - `0` = dry
+
+These constants are available in `src/topology/coastal.rs`.
+
+## Recommended usage
+
+1. Assign exactly one `boundary_class` value to each boundary entity where classification is required.
+2. For `boundary_class=3` entities, add one `boundary_role` value.
+3. Assign `vertical_layer` to points/entities where vertical indexing is required by your discretization.
+4. Optionally add `wet_dry_mask` for inundation/exposure workflows.
+
+## Query helpers
+
+`CoastalLabelQueries` provides convenience methods on `LabelSet`:
+
+- `free_surface_points()`
+- `bed_points()`
+- `open_boundary_points()`
+- `inflow_points()`, `outflow_points()`, `tidal_points()`
+- `vertical_layer_points(layer_index)`
+- `wet_points()`, `dry_points()`
+
+## Consistency validation
+
+Use `validate_coastal_metadata(...)` with `CoastalValidationOptions`:
+
+- open-boundary role checks (`boundary_role` should only appear on open boundaries)
+- optional complete boundary partition checks against an expected boundary set
+- optional complete vertical coverage checks against an expected point set
+
+## Example
+
+```rust
+use mesh_sieve::topology::{
+    LabelSet, BOUNDARY_CLASS_LABEL, BOUNDARY_ROLE_LABEL, VERTICAL_LAYER_LABEL,
+    BoundaryClass, OpenBoundaryRole, CoastalValidationOptions, validate_coastal_metadata,
+};
+
+let mut labels = LabelSet::new();
+let p = mesh_sieve::topology::point::PointId::new(101)?;
+labels.set_label(p, BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+labels.set_label(p, BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Tidal.code());
+labels.set_label(p, VERTICAL_LAYER_LABEL, 0);
+
+let opts = CoastalValidationOptions::default();
+validate_coastal_metadata(&labels, None, None, opts)?;
+# Ok::<(), mesh_sieve::topology::CoastalMetadataError>(())
+```

--- a/src/topology/coastal.rs
+++ b/src/topology/coastal.rs
@@ -1,0 +1,255 @@
+//! Coastal mesh metadata utilities.
+//!
+//! This module standardizes common label names/values used by coastal and ocean
+//! meshes and provides helpers to query point sets and validate consistency.
+
+use std::collections::BTreeSet;
+
+use crate::topology::labels::LabelSet;
+use crate::topology::point::PointId;
+
+/// Canonical label name for boundary class tags.
+pub const BOUNDARY_CLASS_LABEL: &str = "boundary_class";
+/// Canonical label name for boundary role tags (open boundary sub-type).
+pub const BOUNDARY_ROLE_LABEL: &str = "boundary_role";
+/// Canonical label name for vertical layer indices.
+pub const VERTICAL_LAYER_LABEL: &str = "vertical_layer";
+/// Canonical label name for optional wet/dry masks.
+pub const WET_DRY_MASK_LABEL: &str = "wet_dry_mask";
+
+/// Boundary class values for [`BOUNDARY_CLASS_LABEL`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum BoundaryClass {
+    /// Free surface boundary entities.
+    FreeSurface = 1,
+    /// Bed boundary entities.
+    Bed = 2,
+    /// Open boundary entities.
+    Open = 3,
+}
+
+impl BoundaryClass {
+    /// Integer code for this boundary class.
+    pub const fn code(self) -> i32 {
+        self as i32
+    }
+}
+
+/// Open-boundary role values for [`BOUNDARY_ROLE_LABEL`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum OpenBoundaryRole {
+    /// Inflow boundary.
+    Inflow = 11,
+    /// Outflow boundary.
+    Outflow = 12,
+    /// Tidal forcing boundary.
+    Tidal = 13,
+}
+
+impl OpenBoundaryRole {
+    /// Integer code for this open-boundary role.
+    pub const fn code(self) -> i32 {
+        self as i32
+    }
+}
+
+/// Wet/dry mask values for [`WET_DRY_MASK_LABEL`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum WetDryMask {
+    /// Wet point/entity.
+    Wet = 1,
+    /// Dry point/entity.
+    Dry = 0,
+}
+
+impl WetDryMask {
+    /// Integer code for this wet/dry value.
+    pub const fn code(self) -> i32 {
+        self as i32
+    }
+}
+
+/// Vertical coordinate system conventions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerticalCoordinateSystem {
+    /// Terrain-following sigma layers.
+    Sigma,
+    /// Fixed z layers.
+    ZLayer,
+}
+
+/// Validation options for coastal metadata checks.
+#[derive(Clone, Copy, Debug)]
+pub struct CoastalValidationOptions {
+    /// Require free-surface, bed, and open classes to exactly partition `expected_boundary_points`.
+    pub require_complete_boundary_partition: bool,
+    /// Require every open-boundary point to have at least one open role.
+    pub require_open_role_on_open_boundary: bool,
+    /// Require vertical layer labels on every point in `expected_vertical_points`.
+    pub require_complete_vertical_coverage: bool,
+}
+
+impl Default for CoastalValidationOptions {
+    fn default() -> Self {
+        Self {
+            require_complete_boundary_partition: false,
+            require_open_role_on_open_boundary: true,
+            require_complete_vertical_coverage: false,
+        }
+    }
+}
+
+/// Validation errors emitted by coastal metadata checks.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CoastalMetadataError {
+    /// A point appears in multiple incompatible boundary classes.
+    BoundaryClassOverlap { points: Vec<PointId> },
+    /// A boundary point was expected but left unlabeled.
+    MissingBoundaryClass { points: Vec<PointId> },
+    /// A non-boundary point was unexpectedly labeled as a boundary class.
+    UnexpectedBoundaryClass { points: Vec<PointId> },
+    /// Open boundary points were missing an explicit role label.
+    MissingOpenBoundaryRole { points: Vec<PointId> },
+    /// A point carried an open-boundary role but was not in open boundary class.
+    OpenRoleWithoutOpenClass { points: Vec<PointId> },
+    /// Missing vertical layer labels on expected points.
+    MissingVerticalLayer { points: Vec<PointId> },
+}
+
+/// Point-set queries for canonical coastal labels.
+pub trait CoastalLabelQueries {
+    /// Returns free-surface boundary points.
+    fn free_surface_points(&self) -> Vec<PointId>;
+    /// Returns bed boundary points.
+    fn bed_points(&self) -> Vec<PointId>;
+    /// Returns open-boundary points.
+    fn open_boundary_points(&self) -> Vec<PointId>;
+    /// Returns open-boundary inflow points.
+    fn inflow_points(&self) -> Vec<PointId>;
+    /// Returns open-boundary outflow points.
+    fn outflow_points(&self) -> Vec<PointId>;
+    /// Returns open-boundary tidal points.
+    fn tidal_points(&self) -> Vec<PointId>;
+    /// Returns points for the supplied vertical layer index.
+    fn vertical_layer_points(&self, layer_index: i32) -> Vec<PointId>;
+    /// Returns wet points from optional wet/dry mask.
+    fn wet_points(&self) -> Vec<PointId>;
+    /// Returns dry points from optional wet/dry mask.
+    fn dry_points(&self) -> Vec<PointId>;
+}
+
+impl CoastalLabelQueries for LabelSet {
+    fn free_surface_points(&self) -> Vec<PointId> {
+        self.stratum_points(BOUNDARY_CLASS_LABEL, BoundaryClass::FreeSurface.code())
+    }
+    fn bed_points(&self) -> Vec<PointId> {
+        self.stratum_points(BOUNDARY_CLASS_LABEL, BoundaryClass::Bed.code())
+    }
+    fn open_boundary_points(&self) -> Vec<PointId> {
+        self.stratum_points(BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code())
+    }
+    fn inflow_points(&self) -> Vec<PointId> {
+        self.stratum_points(BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Inflow.code())
+    }
+    fn outflow_points(&self) -> Vec<PointId> {
+        self.stratum_points(BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Outflow.code())
+    }
+    fn tidal_points(&self) -> Vec<PointId> {
+        self.stratum_points(BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Tidal.code())
+    }
+    fn vertical_layer_points(&self, layer_index: i32) -> Vec<PointId> {
+        self.stratum_points(VERTICAL_LAYER_LABEL, layer_index)
+    }
+    fn wet_points(&self) -> Vec<PointId> {
+        self.stratum_points(WET_DRY_MASK_LABEL, WetDryMask::Wet.code())
+    }
+    fn dry_points(&self) -> Vec<PointId> {
+        self.stratum_points(WET_DRY_MASK_LABEL, WetDryMask::Dry.code())
+    }
+}
+
+/// Validate coastal metadata consistency.
+pub fn validate_coastal_metadata(
+    labels: &LabelSet,
+    expected_boundary_points: Option<&[PointId]>,
+    expected_vertical_points: Option<&[PointId]>,
+    options: CoastalValidationOptions,
+) -> Result<(), CoastalMetadataError> {
+    let fs: BTreeSet<_> = labels.free_surface_points().into_iter().collect();
+    let bed: BTreeSet<_> = labels.bed_points().into_iter().collect();
+    let open: BTreeSet<_> = labels.open_boundary_points().into_iter().collect();
+
+    let mut overlaps = BTreeSet::new();
+    overlaps.extend(fs.intersection(&bed).copied());
+    overlaps.extend(fs.intersection(&open).copied());
+    overlaps.extend(bed.intersection(&open).copied());
+    if !overlaps.is_empty() {
+        return Err(CoastalMetadataError::BoundaryClassOverlap {
+            points: overlaps.into_iter().collect(),
+        });
+    }
+
+    if options.require_complete_boundary_partition {
+        if let Some(expected) = expected_boundary_points {
+            let expected: BTreeSet<_> = expected.iter().copied().collect();
+            let mut labeled = BTreeSet::new();
+            labeled.extend(fs.iter().copied());
+            labeled.extend(bed.iter().copied());
+            labeled.extend(open.iter().copied());
+
+            let missing: Vec<_> = expected.difference(&labeled).copied().collect();
+            if !missing.is_empty() {
+                return Err(CoastalMetadataError::MissingBoundaryClass { points: missing });
+            }
+
+            let extra: Vec<_> = labeled.difference(&expected).copied().collect();
+            if !extra.is_empty() {
+                return Err(CoastalMetadataError::UnexpectedBoundaryClass { points: extra });
+            }
+        }
+    }
+
+    let inflow: BTreeSet<_> = labels.inflow_points().into_iter().collect();
+    let outflow: BTreeSet<_> = labels.outflow_points().into_iter().collect();
+    let tidal: BTreeSet<_> = labels.tidal_points().into_iter().collect();
+
+    let mut open_roles = BTreeSet::new();
+    open_roles.extend(inflow.iter().copied());
+    open_roles.extend(outflow.iter().copied());
+    open_roles.extend(tidal.iter().copied());
+
+    if options.require_open_role_on_open_boundary {
+        let missing_roles: Vec<_> = open.difference(&open_roles).copied().collect();
+        if !missing_roles.is_empty() {
+            return Err(CoastalMetadataError::MissingOpenBoundaryRole {
+                points: missing_roles,
+            });
+        }
+    }
+
+    let non_open_role_points: Vec<_> = open_roles.difference(&open).copied().collect();
+    if !non_open_role_points.is_empty() {
+        return Err(CoastalMetadataError::OpenRoleWithoutOpenClass {
+            points: non_open_role_points,
+        });
+    }
+
+    if options.require_complete_vertical_coverage {
+        if let Some(expected) = expected_vertical_points {
+            let expected: BTreeSet<_> = expected.iter().copied().collect();
+            let labeled: BTreeSet<_> = labels
+                .iter()
+                .filter_map(|(name, point, _)| (name == VERTICAL_LAYER_LABEL).then_some(point))
+                .collect();
+            let missing: Vec<_> = expected.difference(&labeled).copied().collect();
+            if !missing.is_empty() {
+                return Err(CoastalMetadataError::MissingVerticalLayer { points: missing });
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -22,6 +22,7 @@ pub mod bounds;
 pub mod cache;
 pub mod cell_type;
 pub mod coarsen;
+pub mod coastal;
 pub mod labels;
 pub mod orientation;
 pub mod ownership;
@@ -36,6 +37,11 @@ pub mod validation;
 pub use anchors::{AnchorKind, PointAnchor, TopologicalAnchors};
 pub use cache::InvalidateCache;
 pub use cell_type::CellType;
+pub use coastal::{
+    BOUNDARY_CLASS_LABEL, BOUNDARY_ROLE_LABEL, BoundaryClass, CoastalLabelQueries,
+    CoastalMetadataError, CoastalValidationOptions, OpenBoundaryRole, VERTICAL_LAYER_LABEL,
+    VerticalCoordinateSystem, WET_DRY_MASK_LABEL, WetDryMask, validate_coastal_metadata,
+};
 pub use labels::LabelSet;
 pub use orientation::*;
 pub use ownership::{OwnershipEntry, PointOwnership};

--- a/src/topology/tests/coastal_tests.rs
+++ b/src/topology/tests/coastal_tests.rs
@@ -1,0 +1,67 @@
+use crate::topology::point::PointId;
+use crate::topology::{
+    BOUNDARY_CLASS_LABEL, BOUNDARY_ROLE_LABEL, BoundaryClass, CoastalLabelQueries,
+    CoastalMetadataError, CoastalValidationOptions, LabelSet, OpenBoundaryRole,
+    VERTICAL_LAYER_LABEL, validate_coastal_metadata,
+};
+
+#[test]
+fn canonical_coastal_queries_return_expected_points() {
+    let p = |v| PointId::new(v).unwrap();
+    let mut labels = LabelSet::new();
+    labels.set_label(p(1), BOUNDARY_CLASS_LABEL, BoundaryClass::FreeSurface.code());
+    labels.set_label(p(2), BOUNDARY_CLASS_LABEL, BoundaryClass::Bed.code());
+    labels.set_label(p(3), BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+    labels.set_label(p(3), BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Inflow.code());
+    labels.set_label(p(10), VERTICAL_LAYER_LABEL, 0);
+    labels.set_label(p(11), VERTICAL_LAYER_LABEL, 1);
+
+    assert_eq!(labels.free_surface_points(), vec![p(1)]);
+    assert_eq!(labels.bed_points(), vec![p(2)]);
+    assert_eq!(labels.open_boundary_points(), vec![p(3)]);
+    assert_eq!(labels.inflow_points(), vec![p(3)]);
+    assert_eq!(labels.vertical_layer_points(0), vec![p(10)]);
+}
+
+#[test]
+fn validates_open_role_membership() {
+    let p = |v| PointId::new(v).unwrap();
+    let mut labels = LabelSet::new();
+    labels.set_label(p(9), BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Outflow.code());
+
+    let err = validate_coastal_metadata(&labels, None, None, CoastalValidationOptions::default())
+        .expect_err("open role without open class should fail");
+    assert_eq!(
+        err,
+        CoastalMetadataError::OpenRoleWithoutOpenClass { points: vec![p(9)] }
+    );
+}
+
+#[test]
+fn validates_open_role_and_coverage() {
+    let p = |v| PointId::new(v).unwrap();
+    let mut labels = LabelSet::new();
+    labels.set_label(p(2), BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+
+    let err = validate_coastal_metadata(&labels, None, None, CoastalValidationOptions::default())
+        .expect_err("open boundary role is required by default");
+    assert_eq!(
+        err,
+        CoastalMetadataError::MissingOpenBoundaryRole { points: vec![p(2)] }
+    );
+
+    labels.set_label(p(2), BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Tidal.code());
+
+    let opts = CoastalValidationOptions {
+        require_complete_boundary_partition: true,
+        require_open_role_on_open_boundary: true,
+        require_complete_vertical_coverage: true,
+    };
+
+    let err = validate_coastal_metadata(&labels, Some(&[p(1), p(2)]), Some(&[p(10)]), opts)
+        .expect_err("missing coverage should fail");
+    assert_eq!(
+        err,
+        CoastalMetadataError::MissingBoundaryClass { points: vec![p(1)] }
+    );
+}

--- a/src/topology/tests/mod.rs
+++ b/src/topology/tests/mod.rs
@@ -2,3 +2,5 @@ mod debug_invariants;
 mod labels_tests;
 mod utils_tests;
 mod validation_tests;
+
+mod coastal_tests;


### PR DESCRIPTION
### Motivation
- Provide a canonical, reusable schema and helpers for coastal/ocean meshes to standardize boundary, open-boundary role, vertical layer, and wet/dry labeling. 
- Make it easy to map label values to point sets and to validate common consistency rules (no incompatible overlaps, required role membership, expected coverage). 
- Reduce duplication and errors in code that consumes coastal metadata by centralizing label names, integer codes, queries, and validation logic.

### Description
- Add `src/topology/coastal.rs` containing canonical label names (`BOUNDARY_CLASS_LABEL`, `BOUNDARY_ROLE_LABEL`, `VERTICAL_LAYER_LABEL`, `WET_DRY_MASK_LABEL`), enums with integer codes (`BoundaryClass`, `OpenBoundaryRole`, `WetDryMask`, `VerticalCoordinateSystem`), the `CoastalLabelQueries` trait (implemented for `LabelSet`), and the `validate_coastal_metadata` function with `CoastalValidationOptions` and `CoastalMetadataError` results. 
- Export the coastal API from `src/topology/mod.rs` so callers can use the symbols directly from `mesh_sieve::topology`. 
- Add unit tests in `src/topology/tests/coastal_tests.rs` that exercise the query helpers and validation behavior. 
- Add documentation `docs/coastal-mesh-labels.md` with the recommended label schema, usage guidance, query examples, and a code snippet.

### Testing
- Ran `cargo test coastal_tests --lib`, which executed the new topology tests and returned `3 passed; 0 failed`. 
- Formatting applied with `cargo fmt` prior to testing and compilation completed successfully for the tested unit set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e7f438348329aad37185e512dc14)