### PR TITLE
Add FVM quality diagnostics and JSON output

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,10 +1,12 @@
 //! Centralized mesh diagnostics and DMPLEX-style validation options.
 
+use serde::Serialize;
 use std::fmt::Write as _;
 
 use crate::data::coordinates::Coordinates;
 use crate::data::section::Section;
 use crate::data::storage::Storage;
+use crate::geometry::fvm::build_fvm_face_metrics;
 use crate::mesh_error::MeshSieveError;
 use crate::overlap::overlap::Overlap;
 use crate::topology::cell_type::CellType;
@@ -13,8 +15,24 @@ use crate::topology::point::PointId;
 use crate::topology::sieve::strata::compute_strata;
 use crate::topology::sieve::{MeshSieve, Sieve};
 use crate::topology::validation::{
-    TopologyValidationOptions, validate_oriented_sieve_topology, validate_overlap_ownership_topology,
+    TopologyValidationOptions, validate_oriented_sieve_topology,
+    validate_overlap_ownership_topology,
 };
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct MetricSummary {
+    pub max: f64,
+    pub p95: f64,
+    pub mean: f64,
+    pub count: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct FvmQualityDiagnostics {
+    pub non_orthogonality_deg: MetricSummary,
+    pub skewness: MetricSummary,
+    pub cell_char_length: MetricSummary,
+}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct MeshCheckOptions {
@@ -101,11 +119,135 @@ where
     Ok(())
 }
 
+pub fn run_mesh_checks_f64_with_report<'a, St, CtSt>(
+    sieve: &mut MeshSieve,
+    cell_types: Option<&Section<CellType, CtSt>>,
+    coords: Option<&Coordinates<f64, St>>,
+    ownership: Option<&PointOwnership>,
+    overlap: Option<&Overlap>,
+    sections: impl Iterator<Item = &'a Section<f64, St>>,
+    options: MeshCheckOptions,
+) -> Result<Option<FvmQualityDiagnostics>, MeshSieveError>
+where
+    St: Storage<f64> + Clone + 'a,
+    CtSt: Storage<CellType>,
+{
+    run_mesh_checks(
+        sieve, cell_types, coords, ownership, overlap, sections, options,
+    )?;
+    if let (Some(ct), Some(cd)) = (cell_types, coords) {
+        Ok(Some(fvm_quality_diagnostics(sieve, ct, cd)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn fvm_quality_diagnostics<CT, CS>(
+    sieve: &MeshSieve,
+    cell_types: &Section<CellType, CT>,
+    coordinates: &Coordinates<f64, CS>,
+) -> Result<FvmQualityDiagnostics, MeshSieveError>
+where
+    CT: Storage<CellType>,
+    CS: Storage<f64>,
+{
+    let face_metrics = build_fvm_face_metrics(sieve, cell_types, coordinates)?;
+    let non_ortho: Vec<f64> = face_metrics
+        .iter()
+        .filter_map(|m| m.non_orthogonality_deg)
+        .collect();
+    let skewness: Vec<f64> = face_metrics
+        .iter()
+        .map(|m| {
+            let denom = m
+                .owner_to_neighbor
+                .map(norm3)
+                .unwrap_or_else(|| norm3(m.owner_to_face));
+            if denom > 1e-12 {
+                norm3(m.skewness_vector) / denom
+            } else {
+                0.0
+            }
+        })
+        .collect();
+    let mut cell_area_sum: std::collections::BTreeMap<PointId, f64> =
+        std::collections::BTreeMap::new();
+    for fm in &face_metrics {
+        *cell_area_sum.entry(fm.owner).or_insert(0.0) += fm.area_magnitude;
+        if let Some(n) = fm.neighbor {
+            *cell_area_sum.entry(n).or_insert(0.0) += fm.area_magnitude;
+        }
+    }
+    let mut char_lengths = Vec::with_capacity(cell_area_sum.len());
+    for (cell, area_sum) in cell_area_sum {
+        if let Some(cell_type) = cell_types
+            .try_restrict(cell)
+            .ok()
+            .and_then(|v| v.first().copied())
+        {
+            let mut verts: Vec<_> = sieve
+                .closure_iter([cell])
+                .filter(|p| sieve.cone_points(*p).next().is_none())
+                .collect();
+            verts.sort_unstable();
+            verts.dedup();
+            let quality = crate::geometry::quality::cell_quality_from_section(
+                cell_type,
+                &verts,
+                coordinates,
+            )?;
+            if area_sum > 1e-12 {
+                char_lengths.push(quality.jacobian_sign.abs() / area_sum);
+            }
+        }
+    }
+    Ok(FvmQualityDiagnostics {
+        non_orthogonality_deg: summarize(&non_ortho),
+        skewness: summarize(&skewness),
+        cell_char_length: summarize(&char_lengths),
+    })
+}
+
+pub fn fvm_quality_diagnostics_json<CT, CS>(
+    sieve: &MeshSieve,
+    cell_types: &Section<CellType, CT>,
+    coordinates: &Coordinates<f64, CS>,
+) -> Result<String, MeshSieveError>
+where
+    CT: Storage<CellType>,
+    CS: Storage<f64>,
+{
+    let report = fvm_quality_diagnostics(sieve, cell_types, coordinates)?;
+    serde_json::to_string(&report)
+        .map_err(|e| MeshSieveError::InvalidGeometry(format!("serialize diagnostics: {e}")))
+}
+
+fn summarize(values: &[f64]) -> MetricSummary {
+    if values.is_empty() {
+        return MetricSummary::default();
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let p95_idx = ((sorted.len() - 1) as f64 * 0.95).round() as usize;
+    MetricSummary {
+        max: *sorted.last().unwrap_or(&0.0),
+        p95: sorted[p95_idx.min(sorted.len() - 1)],
+        mean: sorted.iter().sum::<f64>() / (sorted.len() as f64),
+        count: sorted.len(),
+    }
+}
+
+fn norm3(v: [f64; 3]) -> f64 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
 pub fn mesh_text_summary<S: Sieve<Point = PointId>>(sieve: &S) -> Result<String, MeshSieveError> {
     let strata = compute_strata(sieve)?;
     Ok(format!(
         "points={}, topological_dimension={}, strata={:?}",
-        strata.chart_points.len(), strata.diameter, strata.strata
+        strata.chart_points.len(),
+        strata.diameter,
+        strata.strata
     ))
 }
 
@@ -137,7 +279,13 @@ pub fn mesh_tikz_viewer<S: Sieve<Point = PointId>>(sieve: &S, max_points: usize)
     }
     let mut out = String::from("\\begin{tikzpicture}[scale=1.0]\n");
     for (i, p) in points.iter().enumerate() {
-        let _ = writeln!(&mut out, "\\node (p{}) at ({},0) {{{}}};", p.get(), i, p.get());
+        let _ = writeln!(
+            &mut out,
+            "\\node (p{}) at ({},0) {{{}}};",
+            p.get(),
+            i,
+            p.get()
+        );
     }
     for src in sieve.points() {
         for dst in sieve.cone_points(src) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,10 @@ pub mod prelude {
     pub use crate::data::section::Section;
     pub use crate::debug_invariants::DebugInvariants;
     pub use crate::diagnostics::{
-        MeshCheckOptions, fem_diagnostics_report, fvm_flux_diagnostics, mesh_dot_graph,
-        mesh_json_debug_dump, mesh_text_summary, mesh_tikz_viewer, run_mesh_checks,
+        FvmQualityDiagnostics, MeshCheckOptions, MetricSummary, fem_diagnostics_report,
+        fvm_flux_diagnostics, fvm_quality_diagnostics, fvm_quality_diagnostics_json,
+        mesh_dot_graph, mesh_json_debug_dump, mesh_text_summary, mesh_tikz_viewer, run_mesh_checks,
+        run_mesh_checks_f64_with_report,
     };
     pub use crate::discretization::runtime::{
         Basis, BasisFamily, CellGeometry, ClosureDof, CsrPattern, DofMap, ElementRuntime,


### PR DESCRIPTION
### Motivation
- Provide FVM-oriented mesh-quality diagnostics suitable for solver readiness and automated QA pipelines by aggregating per-face and per-cell measures into statistical summaries.
- Expose machine-readable output so external tooling can ingest diagnostics for gating and monitoring.

### Description
- Added serializable diagnostics types `MetricSummary` and `FvmQualityDiagnostics` to `src/diagnostics.rs` and implemented statistical summaries (`max`, `p95`, `mean`, `count`).
- Implemented `fvm_quality_diagnostics(...)` which uses `build_fvm_face_metrics(...)` to compute per-face non-orthogonality angles, face skewness (centroid/midpoint projection proxy), and a per-cell characteristic length defined as `|jacobian_sign| / summed_face_area` and converts these into metric summaries.
- Added `fvm_quality_diagnostics_json(...)` to produce JSON-encoded diagnostics for automated pipelines and `run_mesh_checks_f64_with_report(...)` which runs the existing mesh checks and returns optional FVM diagnostics when float `Coordinates<f64, _>` and cell-type data are present.
- Re-exported the new types and functions in the public prelude in `src/lib.rs`.

### Testing
- Ran `cargo test --test diagnostics_checks -- --nocapture`; the targeted test binary completed successfully and both tests passed (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e9d329dc832999f672fa492021fc)