### PR TITLE
Add canonical FV physics module with face loops and interpolation helpers

### DIFF
--- a/Physics_Guide.md
+++ b/Physics_Guide.md
@@ -5,6 +5,10 @@ This guide maps common physics workflows (FEM/FVM/DG, multigrid, domain decompos
 For a focused walkthrough of discretization metadata and element assembly, see
 [`docs/fe-setup.md`](docs/fe-setup.md).
 
+For finite-volume workflows, use [`src/physics/fvm.rs`](src/physics/fvm.rs) as the canonical integration path.
+It provides FV-oriented internal/boundary face loops, geometry metric accessors, interpolation helpers,
+and flux-kernel assembly placeholders separate from finite-element runtime APIs.
+
 ---
 
 ## 0) Core mental model (physics ↔ API)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,10 @@ pub mod prelude {
         evaluate_reference_element, extract_element_closure, extract_oriented_element_closure,
         integrate_reference_scalar,
     };
+    pub use crate::physics::fvm::{
+        FaceKind, FvmFaceLoops, FvmInputs, assemble_convective_fluxes, assemble_diffusive_fluxes,
+        classify_face_loops, interpolate_cell_centered_scalar, interpolate_face_centered_scalar,
+    };
     pub use crate::topology::bounds::{PayloadLike, PointLike};
     pub use crate::topology::cell_type::CellType;
     pub use crate::topology::labels::LabelSet;

--- a/src/physics/fvm.rs
+++ b/src/physics/fvm.rs
@@ -1,0 +1,158 @@
+//! Finite-volume oriented wrappers over mesh-sieve topology/data/geometry primitives.
+//!
+//! This module is the canonical entrypoint for finite-volume (FV) callers.
+//! It intentionally exposes FV-ready mesh loops and interpolation helpers without
+//! requiring users to couple directly to finite-element runtime APIs.
+
+use crate::data::section::Section;
+use crate::data::storage::Storage;
+use crate::discretization::runtime::{CellGeometry, FaceGeometry, FluxStencil};
+use crate::mesh_error::MeshSieveError;
+use crate::topology::point::PointId;
+use crate::topology::sieve::Sieve;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FaceKind {
+    Internal,
+    Boundary,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FvmFaceLoops {
+    pub internal: Vec<FluxStencil>,
+    pub boundary: Vec<FluxStencil>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FvmInputs {
+    pub loops: FvmFaceLoops,
+    pub cell_geometry: Vec<(PointId, CellGeometry)>,
+    pub face_geometry: Vec<(PointId, FaceGeometry)>,
+}
+
+impl FvmInputs {
+    pub fn new(
+        stencils: impl IntoIterator<Item = FluxStencil>,
+        cell_geometry: Vec<(PointId, CellGeometry)>,
+        face_geometry: Vec<(PointId, FaceGeometry)>,
+    ) -> Self {
+        let mut loops = FvmFaceLoops::default();
+        for stencil in stencils {
+            if stencil.right.is_some() {
+                loops.internal.push(stencil);
+            } else {
+                loops.boundary.push(stencil);
+            }
+        }
+        Self {
+            loops,
+            cell_geometry,
+            face_geometry,
+        }
+    }
+
+    pub fn internal_faces(&self) -> impl Iterator<Item = &FluxStencil> {
+        self.loops.internal.iter()
+    }
+
+    pub fn boundary_faces(&self) -> impl Iterator<Item = &FluxStencil> {
+        self.loops.boundary.iter()
+    }
+
+    pub fn cell_metrics(&self, cell: PointId) -> Option<&CellGeometry> {
+        self.cell_geometry
+            .iter()
+            .find_map(|(id, metrics)| (*id == cell).then_some(metrics))
+    }
+
+    pub fn face_metrics(&self, face: PointId) -> Option<&FaceGeometry> {
+        self.face_geometry
+            .iter()
+            .find_map(|(id, metrics)| (*id == face).then_some(metrics))
+    }
+}
+
+pub fn classify_face_loops<T>(
+    topology: &T,
+    faces: impl IntoIterator<Item = PointId>,
+) -> Result<FvmFaceLoops, MeshSieveError>
+where
+    T: Sieve<Point = PointId>,
+{
+    let mut loops = FvmFaceLoops::default();
+    for face in faces {
+        let mut cells: Vec<_> = topology.support_points(face).collect();
+        cells.sort_unstable();
+        match cells.as_slice() {
+            [left] => loops.boundary.push(FluxStencil {
+                face,
+                left: *left,
+                right: None,
+            }),
+            [left, right] => loops.internal.push(FluxStencil {
+                face,
+                left: *left,
+                right: Some(*right),
+            }),
+            [] => {
+                return Err(MeshSieveError::InvalidGeometry(format!(
+                    "face {face:?} has no supporting cells"
+                )));
+            }
+            _ => {
+                return Err(MeshSieveError::InvalidGeometry(format!(
+                    "non-manifold face {face:?} has {} support cells",
+                    cells.len()
+                )));
+            }
+        }
+    }
+    Ok(loops)
+}
+
+pub fn interpolate_face_centered_scalar<S: Storage<f64>>(
+    section: &Section<f64, S>,
+    stencil: &FluxStencil,
+) -> Result<f64, MeshSieveError> {
+    let left = section.try_restrict(stencil.left)?;
+    let lval = *left.first().ok_or_else(|| {
+        MeshSieveError::InvalidGeometry(format!("missing scalar value at cell {}", stencil.left))
+    })?;
+    if let Some(right_cell) = stencil.right {
+        let right = section.try_restrict(right_cell)?;
+        let rval = *right.first().ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar value at cell {}", right_cell))
+        })?;
+        Ok(0.5 * (lval + rval))
+    } else {
+        Ok(lval)
+    }
+}
+
+pub fn interpolate_cell_centered_scalar<S: Storage<f64>>(
+    section: &Section<f64, S>,
+    incident_faces: &[PointId],
+) -> Result<f64, MeshSieveError> {
+    if incident_faces.is_empty() {
+        return Err(MeshSieveError::InvalidGeometry(
+            "cannot interpolate to cell center from zero incident faces".to_string(),
+        ));
+    }
+    let mut accum = 0.0;
+    for face in incident_faces {
+        let value = section.try_restrict(*face)?;
+        let scalar = *value.first().ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar value at face {}", face))
+        })?;
+        accum += scalar;
+    }
+    Ok(accum / incident_faces.len() as f64)
+}
+
+pub fn assemble_convective_fluxes(_inputs: &FvmInputs) -> Result<(), MeshSieveError> {
+    Ok(())
+}
+
+pub fn assemble_diffusive_fluxes(_inputs: &FvmInputs) -> Result<(), MeshSieveError> {
+    Ok(())
+}

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,3 +1,4 @@
 //! Physics helpers built on mesh-sieve data structures.
 
 pub mod fe;
+pub mod fvm;


### PR DESCRIPTION
### Motivation
- Provide a finite-volume (FV) focused entrypoint that wraps mesh topology, geometry, and data into FV-ready inputs so FV callers do not need to couple to FE runtime APIs.
- Expose common FV primitives (internal/boundary face loops, cell/face geometry access, simple interpolation stencils) and placeholders for flux assembly to standardize FV workflows.

### Description
- Add `src/physics/fvm.rs` implementing FV-facing types and helpers: `FaceKind`, `FvmFaceLoops`, `FvmInputs`, `classify_face_loops`, `interpolate_face_centered_scalar`, `interpolate_cell_centered_scalar`, and placeholder kernels `assemble_convective_fluxes` / `assemble_diffusive_fluxes`.
- Wire the module into the physics runtime by adding `pub mod fvm;` in `src/physics/mod.rs`.
- Export the new FV APIs from the crate prelude in `src/lib.rs` so downstream users can import FV helpers directly.
- Document the canonical FV integration path in `Physics_Guide.md` pointing to `src/physics/fvm.rs` and noting separation from FE runtime APIs.

### Testing
- Ran `cargo fmt --all` (success).
- Ran `cargo check -q` (success; only existing repository warnings reported, no new compile errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12172dac6c8329a547b23bde5587d2)