### PR TITLE
Integrate coastal labels with FV boundary handling

### DIFF
--- a/docs/coastal-mesh-labels.md
+++ b/docs/coastal-mesh-labels.md
@@ -64,3 +64,53 @@ let opts = CoastalValidationOptions::default();
 validate_coastal_metadata(&labels, None, None, opts)?;
 # Ok::<(), mesh_sieve::topology::CoastalMetadataError>(())
 ```
+
+## Finite-volume boundary mapping
+
+For FV boundary assembly (`src/physics/fvm.rs`), coastal labels map to boundary branches as:
+
+- `boundary_class=1` (`FreeSurface`) → `FvBoundaryBranch::FreeSurface`
+- `boundary_class=2` (`Bed`) → `FvBoundaryBranch::Bed`
+- `boundary_class=3` (`Open`) + no role → `FvBoundaryBranch::Open`
+- `boundary_class=3` + `boundary_role=11` (`Inflow`) → `FvBoundaryBranch::Inflow`
+- `boundary_class=3` + `boundary_role=12` (`Outflow`) → `FvBoundaryBranch::Outflow`
+- `boundary_class=3` + `boundary_role=13` (`Tidal`) → `FvBoundaryBranch::Tidal`
+
+Use `data::bc::coastal_boundary_face_sets(...)` to fetch per-class/role boundary face IDs from labels and a boundary-face iterator.
+
+Use `data::bc::map_coastal_boundary_conditions(...)` to produce per-face `BoundaryCondition` values from a closure over `FvBoundaryBranch`.
+
+### Example: coastal labels + FV assembly
+
+```rust
+use mesh_sieve::data::bc::{coastal_boundary_face_sets, map_coastal_boundary_conditions};
+use mesh_sieve::physics::fvm::{
+    ConvectiveScheme, assemble_convective_fluxes_masked, flux_activity_mask_from_wet_dry,
+};
+
+let face_sets = coastal_boundary_face_sets(&labels, inputs.boundary_faces().map(|s| s.face));
+assert!(!face_sets.open.is_empty() || !face_sets.bed.is_empty() || !face_sets.free_surface.is_empty());
+
+let bcs = map_coastal_boundary_conditions(&labels, inputs.boundary_faces().map(|s| s.face), |branch, _face| {
+    match branch {
+        mesh_sieve::physics::fvm::FvBoundaryBranch::Inflow => mesh_sieve::physics::fvm::BoundaryCondition::Dirichlet { value: 1.0 },
+        mesh_sieve::physics::fvm::FvBoundaryBranch::Outflow => mesh_sieve::physics::fvm::BoundaryCondition::Neumann { gradient: 0.0 },
+        mesh_sieve::physics::fvm::FvBoundaryBranch::Tidal => mesh_sieve::physics::fvm::BoundaryCondition::Dirichlet { value: 0.2 },
+        mesh_sieve::physics::fvm::FvBoundaryBranch::Bed => mesh_sieve::physics::fvm::BoundaryCondition::Neumann { gradient: 0.0 },
+        mesh_sieve::physics::fvm::FvBoundaryBranch::FreeSurface => mesh_sieve::physics::fvm::BoundaryCondition::Neumann { gradient: 0.0 },
+        mesh_sieve::physics::fvm::FvBoundaryBranch::Open => mesh_sieve::physics::fvm::BoundaryCondition::Neumann { gradient: 0.0 },
+    }
+});
+
+let wet_dry_mask = flux_activity_mask_from_wet_dry(&inputs, &labels);
+let flux = assemble_convective_fluxes_masked(
+    &inputs,
+    &cell_scalar,
+    &face_mass_flux,
+    &bcs,
+    ConvectiveScheme::Upwind,
+    Some(&wet_dry_mask),
+)?;
+```
+
+`FluxActivityMask` gates both boundary faces and near-boundary internal faces, so dry cells can suppress boundary and adjacent flux contributions.

--- a/src/data/bc.rs
+++ b/src/data/bc.rs
@@ -4,9 +4,12 @@ use crate::data::constrained_section::ConstrainedSection;
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::mesh_error::MeshSieveError;
+use crate::physics::fvm::{BoundaryCondition, FvBoundaryBranch, boundary_branch_for_face};
+use crate::topology::coastal::CoastalLabelQueries;
 use crate::topology::cache::InvalidateCache;
 use crate::topology::labels::LabelSet;
 use crate::topology::point::PointId;
+use std::collections::{HashMap, HashSet};
 
 /// Label query selector for boundary condition application.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -56,6 +59,53 @@ impl FieldDofIndices {
 
 fn label_points(labels: &LabelSet, query: &LabelQuery) -> Vec<PointId> {
     labels.stratum_points(query.name(), query.value())
+}
+
+/// Boundary face sets derived from canonical coastal labels.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CoastalBoundaryFaceSets {
+    pub free_surface: Vec<PointId>,
+    pub bed: Vec<PointId>,
+    pub open: Vec<PointId>,
+    pub inflow: Vec<PointId>,
+    pub outflow: Vec<PointId>,
+    pub tidal: Vec<PointId>,
+}
+
+/// Build boundary-face sets by intersecting supplied boundary faces with coastal labels.
+pub fn coastal_boundary_face_sets(
+    labels: &LabelSet,
+    boundary_faces: impl IntoIterator<Item = PointId>,
+) -> CoastalBoundaryFaceSets {
+    let faces: HashSet<_> = boundary_faces.into_iter().collect();
+    let mut filter = |pts: Vec<PointId>| -> Vec<PointId> {
+        let mut v: Vec<_> = pts.into_iter().filter(|p| faces.contains(p)).collect();
+        v.sort_unstable();
+        v
+    };
+    CoastalBoundaryFaceSets {
+        free_surface: filter(labels.free_surface_points()),
+        bed: filter(labels.bed_points()),
+        open: filter(labels.open_boundary_points()),
+        inflow: filter(labels.inflow_points()),
+        outflow: filter(labels.outflow_points()),
+        tidal: filter(labels.tidal_points()),
+    }
+}
+
+/// Assign per-face boundary conditions using coastal boundary class/role labels.
+pub fn map_coastal_boundary_conditions(
+    labels: &LabelSet,
+    boundary_faces: impl IntoIterator<Item = PointId>,
+    branch_closure: impl Fn(FvBoundaryBranch, PointId) -> BoundaryCondition,
+) -> HashMap<PointId, BoundaryCondition> {
+    let mut out = HashMap::new();
+    for face in boundary_faces {
+        if let Some(branch) = boundary_branch_for_face(labels, face) {
+            out.insert(face, branch_closure(branch, face));
+        }
+    }
+    out
 }
 
 fn field_offsets(field_dofs: &[usize]) -> Vec<usize> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -27,9 +27,9 @@ pub mod refine;
 pub use crate::debug_invariants::DebugInvariants;
 
 pub use bc::{
-    FieldDofIndices, LabelQuery, apply_dirichlet_to_constrained_section,
+    CoastalBoundaryFaceSets, FieldDofIndices, LabelQuery, apply_dirichlet_to_constrained_section,
     apply_dirichlet_to_constrained_section_fields, apply_dirichlet_to_section,
-    apply_dirichlet_to_section_fields,
+    apply_dirichlet_to_section_fields, coastal_boundary_face_sets, map_coastal_boundary_conditions,
 };
 pub use closure::{
     ClosureIndex, ClosureIndexCache, ClosureIndexKey, ClosureOrder, ClosurePointIndex,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,10 @@ pub mod prelude {
         integrate_reference_scalar,
     };
     pub use crate::physics::fvm::{
-        FaceKind, FvmFaceLoops, FvmInputs, assemble_convective_fluxes, assemble_diffusive_fluxes,
-        classify_face_loops, interpolate_cell_centered_scalar, interpolate_face_centered_scalar,
+        FaceKind, FluxActivityMask, FvBoundaryBranch, FvmFaceLoops, FvmInputs,
+        assemble_convective_fluxes, assemble_convective_fluxes_masked, assemble_diffusive_fluxes,
+        boundary_branch_for_face, classify_face_loops, flux_activity_mask_from_wet_dry,
+        interpolate_cell_centered_scalar, interpolate_face_centered_scalar,
     };
     pub use crate::topology::bounds::{PayloadLike, PointLike};
     pub use crate::topology::cell_type::CellType;

--- a/src/physics/fvm.rs
+++ b/src/physics/fvm.rs
@@ -8,6 +8,11 @@ use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::discretization::runtime::{CellGeometry, FaceGeometry, FluxStencil};
 use crate::mesh_error::MeshSieveError;
+use crate::topology::coastal::{
+    BOUNDARY_CLASS_LABEL, BOUNDARY_ROLE_LABEL, BoundaryClass, OpenBoundaryRole, WET_DRY_MASK_LABEL,
+    WetDryMask,
+};
+use crate::topology::labels::LabelSet;
 use crate::topology::point::PointId;
 use crate::topology::sieve::Sieve;
 use std::collections::HashMap;
@@ -29,6 +34,17 @@ pub enum BoundaryCondition {
     Dirichlet { value: f64 },
     Neumann { gradient: f64 },
     Robin { alpha: f64, beta: f64, gamma: f64 },
+}
+
+/// FV-oriented coastal boundary branch used to select flux closure behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum FvBoundaryBranch {
+    Open,
+    Inflow,
+    Outflow,
+    Tidal,
+    Bed,
+    FreeSurface,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -143,8 +159,72 @@ pub fn assemble_convective_fluxes(
     boundary_conditions: &HashMap<PointId, BoundaryCondition>,
     scheme: ConvectiveScheme,
 ) -> Result<FluxAssembly, MeshSieveError> {
+    assemble_convective_fluxes_masked(
+        inputs,
+        cell_scalar,
+        face_mass_flux,
+        boundary_conditions,
+        scheme,
+        None,
+    )
+}
+
+/// Optional face-activity mask used to gate FV flux contributions.
+#[derive(Clone, Debug, Default)]
+pub struct FluxActivityMask {
+    pub boundary_faces_active: HashMap<PointId, bool>,
+    pub near_boundary_faces_active: HashMap<PointId, bool>,
+}
+
+fn face_is_active(mask: Option<&FluxActivityMask>, stencil: &FluxStencil, boundary: bool) -> bool {
+    let Some(mask) = mask else { return true };
+    if boundary {
+        return mask.boundary_faces_active.get(&stencil.face).copied().unwrap_or(true);
+    }
+    if mask.near_boundary_faces_active.get(&stencil.face).copied().unwrap_or(true) {
+        return true;
+    }
+    false
+}
+
+/// Build a flux-activity mask from coastal wet/dry labels on cells.
+pub fn flux_activity_mask_from_wet_dry(
+    inputs: &FvmInputs,
+    labels: &LabelSet,
+) -> FluxActivityMask {
+    let mut mask = FluxActivityMask::default();
+    let dry = WetDryMask::Dry.code();
+    let cell_is_dry = |cell: PointId| labels.get_label(cell, WET_DRY_MASK_LABEL) == Some(dry);
+    for stencil in inputs.boundary_faces() {
+        mask.boundary_faces_active
+            .insert(stencil.face, !cell_is_dry(stencil.left));
+    }
+    for stencil in inputs.internal_faces() {
+        let near_boundary = labels.get_label(stencil.face, BOUNDARY_CLASS_LABEL).is_some();
+        if near_boundary {
+            let left_dry = cell_is_dry(stencil.left);
+            let right_dry = stencil.right.map(cell_is_dry).unwrap_or(true);
+            mask.near_boundary_faces_active
+                .insert(stencil.face, !(left_dry || right_dry));
+        }
+    }
+    mask
+}
+
+/// Assemble convective fluxes with optional wet/dry gating.
+pub fn assemble_convective_fluxes_masked(
+    inputs: &FvmInputs,
+    cell_scalar: &HashMap<PointId, f64>,
+    face_mass_flux: &HashMap<PointId, f64>,
+    boundary_conditions: &HashMap<PointId, BoundaryCondition>,
+    scheme: ConvectiveScheme,
+    activity_mask: Option<&FluxActivityMask>,
+) -> Result<FluxAssembly, MeshSieveError> {
     let mut assembly = FluxAssembly::default();
     for stencil in inputs.internal_faces() {
+        if !face_is_active(activity_mask, stencil, false) {
+            continue;
+        }
         let mdot = *face_mass_flux.get(&stencil.face).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing mass flux for face {}", stencil.face)))?;
         let l = *cell_scalar.get(&stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left)))?;
         let rcell = stencil.right.expect("internal face must have neighbor");
@@ -155,20 +235,31 @@ pub fn assemble_convective_fluxes(
         assembly.add_residual(rcell, -flux);
     }
     for stencil in inputs.boundary_faces() {
+        if !face_is_active(activity_mask, stencil, true) {
+            continue;
+        }
         let mdot = *face_mass_flux.get(&stencil.face).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing mass flux for boundary face {}", stencil.face)))?;
         let phi_i = *cell_scalar.get(&stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left)))?;
         let bc = boundary_conditions.get(&stencil.face).copied().ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing boundary condition for face {}", stencil.face)))?;
-        let phi_b = match bc {
-            BoundaryCondition::Dirichlet { value } => value,
-            BoundaryCondition::Neumann { .. } => phi_i,
-            BoundaryCondition::Robin { alpha, beta, gamma } => {
-                if alpha.abs() < 1e-14 { phi_i } else { (gamma - beta * phi_i) / alpha }
-            }
-        };
+        let phi_b = match bc { BoundaryCondition::Dirichlet { value } => value, BoundaryCondition::Neumann { .. } => phi_i, BoundaryCondition::Robin { alpha, beta, gamma } => if alpha.abs() < 1e-14 { phi_i } else { (gamma - beta * phi_i) / alpha } };
         let phi_f = if mdot >= 0.0 { phi_i } else { phi_b };
         assembly.add_residual(stencil.left, mdot * phi_f);
     }
     Ok(assembly)
+}
+
+pub fn boundary_branch_for_face(labels: &LabelSet, face: PointId) -> Option<FvBoundaryBranch> {
+    match labels.get_label(face, BOUNDARY_CLASS_LABEL) {
+        Some(v) if v == BoundaryClass::FreeSurface.code() => Some(FvBoundaryBranch::FreeSurface),
+        Some(v) if v == BoundaryClass::Bed.code() => Some(FvBoundaryBranch::Bed),
+        Some(v) if v == BoundaryClass::Open.code() => match labels.get_label(face, BOUNDARY_ROLE_LABEL) {
+            Some(v) if v == OpenBoundaryRole::Inflow.code() => Some(FvBoundaryBranch::Inflow),
+            Some(v) if v == OpenBoundaryRole::Outflow.code() => Some(FvBoundaryBranch::Outflow),
+            Some(v) if v == OpenBoundaryRole::Tidal.code() => Some(FvBoundaryBranch::Tidal),
+            _ => Some(FvBoundaryBranch::Open),
+        },
+        _ => None,
+    }
 }
 
 pub fn assemble_diffusive_fluxes(


### PR DESCRIPTION
### Motivation
- Provide a clear mapping from coastal mesh labels (`boundary_class`/`boundary_role`) into FV boundary treatment branches so boundary handling can be chosen by label semantics.
- Allow per-class/role BC assignment and per-face flux closures for coastal/inlet/bed/free-surface boundaries.
- Gate boundary and near-boundary flux contributions with optional wet/dry masks so dry cells can suppress fluxes.
- Document expected label→BC mapping and show an example FV assembly workflow using coastal labels.

### Description
- Added `FvBoundaryBranch` and `boundary_branch_for_face(...)` to `src/physics/fvm.rs` to map `boundary_class`/`boundary_role` to FV branches (open/inflow/outflow/tidal/bed/free-surface).
- Introduced `FluxActivityMask`, `flux_activity_mask_from_wet_dry(...)`, and `assemble_convective_fluxes_masked(...)` in `src/physics/fvm.rs` and made `assemble_convective_fluxes(...)` delegate to the masked implementation when no mask is provided.
- Added BC utilities in `src/data/bc.rs`: `CoastalBoundaryFaceSets`, `coastal_boundary_face_sets(...)`, and `map_coastal_boundary_conditions(...)` to extract boundary face sets from labels and produce per-face `BoundaryCondition` values from a closure over `FvBoundaryBranch`.
- Re-exported the new APIs via `src/data/mod.rs` and `src/lib.rs` for downstream use, and extended `docs/coastal-mesh-labels.md` with the FV label-to-branch mapping and a usage example that ties face set extraction, BC mapping, wet/dry mask creation, and masked convective assembly together.

### Testing
- Attempted to run the focused unit test `cargo test -q physics::fvm::tests::convective_two_cell_conservation`, but the test invocation did not complete within the environment session timeout (no success/failure result available).
- Attempted `cargo check -q` to validate build, but the operation did not complete within the environment session timeout (no success/failure result available).
- No new automated tests were added in this change; existing FV unit tests remain present and unchanged in `src/physics/fvm.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f3fadc688329829f0ba0f029e895)