### PR TITLE
Add FV readiness threshold evaluation and CI-friendly reports

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -34,6 +34,52 @@ pub struct FvmQualityDiagnostics {
     pub cell_char_length: MetricSummary,
 }
 
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct FvReadinessThresholds {
+    pub max_non_orthogonality_deg: f64,
+    pub max_skewness: f64,
+    pub min_cell_char_length: f64,
+}
+
+impl Default for FvReadinessThresholds {
+    fn default() -> Self {
+        Self {
+            max_non_orthogonality_deg: 75.0,
+            max_skewness: 4.0,
+            min_cell_char_length: 1.0e-8,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FvReadinessOptions {
+    pub strict: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FvReadinessViolation {
+    pub metric: &'static str,
+    pub point: PointId,
+    pub value: f64,
+    pub threshold: f64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct FvReadinessSummary {
+    pub failed: usize,
+    pub total: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct FvReadinessReport {
+    pub passed: bool,
+    pub thresholds: FvReadinessThresholds,
+    pub non_orthogonality: FvReadinessSummary,
+    pub skewness: FvReadinessSummary,
+    pub cell_char_length: FvReadinessSummary,
+    pub violations: Vec<FvReadinessViolation>,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct MeshCheckOptions {
     pub check_symmetry: bool,
@@ -220,6 +266,156 @@ where
     let report = fvm_quality_diagnostics(sieve, cell_types, coordinates)?;
     serde_json::to_string(&report)
         .map_err(|e| MeshSieveError::InvalidGeometry(format!("serialize diagnostics: {e}")))
+}
+
+pub fn fv_readiness_report<CT, CS>(
+    sieve: &MeshSieve,
+    cell_types: &Section<CellType, CT>,
+    coordinates: &Coordinates<f64, CS>,
+    thresholds: FvReadinessThresholds,
+    options: FvReadinessOptions,
+) -> Result<FvReadinessReport, MeshSieveError>
+where
+    CT: Storage<CellType>,
+    CS: Storage<f64>,
+{
+    let face_metrics = build_fvm_face_metrics(sieve, cell_types, coordinates)?;
+    let mut report = FvReadinessReport {
+        passed: true,
+        thresholds,
+        non_orthogonality: FvReadinessSummary {
+            total: face_metrics.len(),
+            ..FvReadinessSummary::default()
+        },
+        skewness: FvReadinessSummary {
+            total: face_metrics.len(),
+            ..FvReadinessSummary::default()
+        },
+        ..FvReadinessReport::default()
+    };
+    for fm in &face_metrics {
+        let non_ortho = fm.non_orthogonality_deg.unwrap_or(0.0);
+        if non_ortho > thresholds.max_non_orthogonality_deg {
+            report.non_orthogonality.failed += 1;
+            report.violations.push(FvReadinessViolation {
+                metric: "non_orthogonality_deg",
+                point: fm.face,
+                value: non_ortho,
+                threshold: thresholds.max_non_orthogonality_deg,
+            });
+        }
+        let denom = fm
+            .owner_to_neighbor
+            .map(norm3)
+            .unwrap_or_else(|| norm3(fm.owner_to_face));
+        let skewness = if denom > 1e-12 {
+            norm3(fm.skewness_vector) / denom
+        } else {
+            0.0
+        };
+        if skewness > thresholds.max_skewness {
+            report.skewness.failed += 1;
+            report.violations.push(FvReadinessViolation {
+                metric: "skewness",
+                point: fm.face,
+                value: skewness,
+                threshold: thresholds.max_skewness,
+            });
+        }
+    }
+    let mut cell_area_sum: std::collections::BTreeMap<PointId, f64> =
+        std::collections::BTreeMap::new();
+    for fm in &face_metrics {
+        *cell_area_sum.entry(fm.owner).or_insert(0.0) += fm.area_magnitude;
+        if let Some(n) = fm.neighbor {
+            *cell_area_sum.entry(n).or_insert(0.0) += fm.area_magnitude;
+        }
+    }
+    report.cell_char_length.total = cell_area_sum.len();
+    for (cell, area_sum) in cell_area_sum {
+        if let Some(cell_type) = cell_types
+            .try_restrict(cell)
+            .ok()
+            .and_then(|v| v.first().copied())
+        {
+            let mut verts: Vec<_> = sieve
+                .closure_iter([cell])
+                .filter(|p| sieve.cone_points(*p).next().is_none())
+                .collect();
+            verts.sort_unstable();
+            verts.dedup();
+            let quality = crate::geometry::quality::cell_quality_from_section(
+                cell_type,
+                &verts,
+                coordinates,
+            )?;
+            let char_len = if area_sum > 1e-12 {
+                quality.jacobian_sign.abs() / area_sum
+            } else {
+                0.0
+            };
+            if char_len < thresholds.min_cell_char_length {
+                report.cell_char_length.failed += 1;
+                report.violations.push(FvReadinessViolation {
+                    metric: "cell_char_length",
+                    point: cell,
+                    value: char_len,
+                    threshold: thresholds.min_cell_char_length,
+                });
+            }
+        }
+    }
+    report.passed = report.violations.is_empty();
+    if options.strict && !report.passed {
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "FV readiness failed with {} violation(s)",
+            report.violations.len()
+        )));
+    }
+    Ok(report)
+}
+
+pub fn fv_readiness_report_json(report: &FvReadinessReport) -> Result<String, MeshSieveError> {
+    serde_json::to_string(report)
+        .map_err(|e| MeshSieveError::InvalidGeometry(format!("serialize readiness report: {e}")))
+}
+
+pub fn fv_readiness_report_text(report: &FvReadinessReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "fv_readiness_passed={}", report.passed);
+    let _ = writeln!(
+        &mut out,
+        "thresholds: max_non_orthogonality_deg={}, max_skewness={}, min_cell_char_length={}",
+        report.thresholds.max_non_orthogonality_deg,
+        report.thresholds.max_skewness,
+        report.thresholds.min_cell_char_length
+    );
+    let _ = writeln!(
+        &mut out,
+        "non_orthogonality_failed={}/{}",
+        report.non_orthogonality.failed, report.non_orthogonality.total
+    );
+    let _ = writeln!(
+        &mut out,
+        "skewness_failed={}/{}",
+        report.skewness.failed, report.skewness.total
+    );
+    let _ = writeln!(
+        &mut out,
+        "cell_char_length_failed={}/{}",
+        report.cell_char_length.failed, report.cell_char_length.total
+    );
+    for v in &report.violations {
+        let _ = writeln!(
+            &mut out,
+            "violation metric={} point={} value={} threshold={}",
+            v.metric,
+            v.point.get(),
+            v.value,
+            v.threshold
+        );
+    }
+    out
 }
 
 fn summarize(values: &[f64]) -> MetricSummary {

--- a/tests/diagnostics_checks.rs
+++ b/tests/diagnostics_checks.rs
@@ -1,11 +1,17 @@
 use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::coordinates::Coordinates;
 use mesh_sieve::data::section::Section;
 use mesh_sieve::data::storage::VecStorage;
-use mesh_sieve::diagnostics::{MeshCheckOptions, mesh_dot_graph, mesh_json_debug_dump, run_mesh_checks};
+use mesh_sieve::diagnostics::{
+    FvReadinessOptions, FvReadinessThresholds, MeshCheckOptions, fv_readiness_report,
+    fv_readiness_report_json, fv_readiness_report_text, mesh_dot_graph, mesh_json_debug_dump,
+    run_mesh_checks,
+};
 use mesh_sieve::mesh_error::MeshSieveError;
+use mesh_sieve::topology::cell_type::CellType;
 use mesh_sieve::topology::ownership::PointOwnership;
 use mesh_sieve::topology::point::PointId;
-use mesh_sieve::topology::sieve::{MeshSieve, Sieve};
+use mesh_sieve::topology::sieve::{MeshSieve, MutableSieve, Sieve};
 
 fn pid(id: u64) -> PointId { PointId::new(id).unwrap() }
 
@@ -14,6 +20,70 @@ fn tiny_mesh() -> MeshSieve {
     mesh.add_arrow(pid(3), pid(1), ());
     mesh.add_arrow(pid(3), pid(2), ());
     mesh
+}
+
+fn triangle_pair_fixture(
+) -> Result<
+    (
+        MeshSieve,
+        Section<CellType, VecStorage<CellType>>,
+        Coordinates<f64, VecStorage<f64>>,
+    ),
+    MeshSieveError,
+> {
+    let mut s = MeshSieve::default();
+    for id in 1..=11 {
+        MutableSieve::add_point(&mut s, pid(id));
+    }
+    let (v1, v2, v3, v4, e12, e23, e31, e24, e43, c1, c2) = (
+        pid(1),
+        pid(2),
+        pid(3),
+        pid(4),
+        pid(5),
+        pid(6),
+        pid(7),
+        pid(8),
+        pid(9),
+        pid(10),
+        pid(11),
+    );
+    for (e, a, b) in [
+        (e12, v1, v2),
+        (e23, v2, v3),
+        (e31, v3, v1),
+        (e24, v2, v4),
+        (e43, v4, v3),
+    ] {
+        s.add_arrow(e, a, ());
+        s.add_arrow(e, b, ());
+    }
+    for e in [e12, e23, e31] {
+        s.add_arrow(c1, e, ());
+    }
+    for e in [e23, e24, e43] {
+        s.add_arrow(c2, e, ());
+    }
+    let mut a = Atlas::default();
+    for v in [v1, v2, v3, v4] {
+        a.try_insert(v, 2)?;
+    }
+    let mut coords = Coordinates::<f64, VecStorage<f64>>::try_new(2, 2, a)?;
+    coords.section_mut().try_set(v1, &[0.0, 0.0])?;
+    coords.section_mut().try_set(v2, &[1.0, 0.0])?;
+    coords.section_mut().try_set(v3, &[0.0, 1.0])?;
+    coords.section_mut().try_set(v4, &[1.0, 1.0])?;
+    let mut ta = Atlas::default();
+    for q in [c1, c2, e12, e23, e31, e24, e43] {
+        ta.try_insert(q, 1)?;
+    }
+    let mut types = Section::<CellType, VecStorage<CellType>>::new(ta);
+    types.try_set(c1, &[CellType::Triangle])?;
+    types.try_set(c2, &[CellType::Triangle])?;
+    for e in [e12, e23, e31, e24, e43] {
+        types.try_set(e, &[CellType::Segment])?;
+    }
+    Ok((s, types, coords))
 }
 
 #[test]
@@ -47,4 +117,70 @@ fn viewers_emit_expected_formats() {
     let mut atlas = Atlas::default();
     atlas.try_insert(pid(1), 1).unwrap();
     let _section: Section<f64, VecStorage<f64>> = Section::new(atlas);
+}
+
+#[test]
+fn fv_readiness_pass_and_output_formats_are_deterministic() -> Result<(), MeshSieveError> {
+    let (sieve, cell_types, coords) = triangle_pair_fixture()?;
+    let thresholds = FvReadinessThresholds {
+        max_non_orthogonality_deg: 180.0,
+        max_skewness: 10.0,
+        min_cell_char_length: 0.0,
+    };
+    let report = fv_readiness_report(
+        &sieve,
+        &cell_types,
+        &coords,
+        thresholds,
+        FvReadinessOptions::default(),
+    )?;
+    assert!(report.passed);
+    assert_eq!(report.violations.len(), 0);
+    let json = fv_readiness_report_json(&report)?;
+    assert_eq!(
+        json,
+        "{\"passed\":true,\"thresholds\":{\"max_non_orthogonality_deg\":180.0,\"max_skewness\":10.0,\"min_cell_char_length\":0.0},\"non_orthogonality\":{\"failed\":0,\"total\":5},\"skewness\":{\"failed\":0,\"total\":5},\"cell_char_length\":{\"failed\":0,\"total\":2},\"violations\":[]}"
+    );
+    let text = fv_readiness_report_text(&report);
+    assert!(text.contains("fv_readiness_passed=true"));
+    assert!(text.contains("non_orthogonality_failed=0/5"));
+    Ok(())
+}
+
+#[test]
+fn fv_readiness_violation_and_strict_mode_error() -> Result<(), MeshSieveError> {
+    let (sieve, cell_types, coords) = triangle_pair_fixture()?;
+    let thresholds = FvReadinessThresholds {
+        max_non_orthogonality_deg: 0.0,
+        max_skewness: 0.0,
+        min_cell_char_length: 1.0,
+    };
+    let report = fv_readiness_report(
+        &sieve,
+        &cell_types,
+        &coords,
+        thresholds,
+        FvReadinessOptions::default(),
+    )?;
+    assert!(!report.passed);
+    assert!(!report.violations.is_empty());
+    assert!(report
+        .violations
+        .iter()
+        .any(|v| v.metric == "non_orthogonality_deg"));
+    assert!(report.violations.iter().any(|v| v.metric == "skewness"));
+    assert!(report
+        .violations
+        .iter()
+        .any(|v| v.metric == "cell_char_length"));
+    let err = fv_readiness_report(
+        &sieve,
+        &cell_types,
+        &coords,
+        thresholds,
+        FvReadinessOptions { strict: true },
+    )
+    .unwrap_err();
+    assert!(matches!(err, MeshSieveError::InvalidGeometry(_)));
+    Ok(())
 }


### PR DESCRIPTION
### Motivation
- Provide a pass/fail readiness check for finite-volume (FVM) workflows that evaluates computed face/cell metrics against configurable thresholds before simulation or in CI.
- Produce structured, machine- and human-readable outputs so CI systems and pre-simulation tools can reliably detect and report mesh issues.
- Allow an optional strict mode that fails fast with a `MeshSieveError` when readiness checks detect violations.

### Description
- Added `FvReadinessThresholds` with defaults and `FvReadinessOptions` (includes `strict`) to `src/diagnostics.rs` for configurable thresholds and behavior.
- Introduced structured types `FvReadinessViolation`, `FvReadinessSummary`, and `FvReadinessReport` to record per-metric summaries and explicit violated points/values.
- Implemented `fv_readiness_report(...)` which computes face metrics via `build_fvm_face_metrics`, evaluates non-orthogonality, skewness, and per-cell characteristic length against thresholds, and populates the structured report, returning an error when `strict` is set and violations exist.
- Added CI-friendly serializers `fv_readiness_report_json(...)` and `fv_readiness_report_text(...)` that emit deterministic JSON and concise text suitable for logs and automated checks.
- Added deterministic tests and a reusable triangle-pair fixture in `tests/diagnostics_checks.rs` to validate passing and failing scenarios, JSON stability, text output presence, and strict-mode error behavior.

### Testing
- Ran the targeted test binary with `cargo test --test diagnostics_checks` and observed all tests in that file pass (4 passed; 0 failed). 
- Tests include a deterministic JSON equality assertion for the passing case and explicit violation checks and strict-mode error assertion for the failing case.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f6a376fc83298fc7c035649e59bb)