### PR TITLE
Add checked FV boundary-branch resolution and high-level coastal assembly API

### DIFF
--- a/src/data/bc.rs
+++ b/src/data/bc.rs
@@ -4,12 +4,19 @@ use crate::data::constrained_section::ConstrainedSection;
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::mesh_error::MeshSieveError;
-use crate::physics::fvm::{BoundaryCondition, FvBoundaryBranch, boundary_branch_for_face};
-use crate::topology::coastal::CoastalLabelQueries;
+use crate::physics::fvm::{
+    BoundaryBranchError, BoundaryCondition, FvBoundaryBranch, boundary_branch_for_face_checked,
+};
 use crate::topology::cache::InvalidateCache;
+use crate::topology::coastal::CoastalLabelQueries;
 use crate::topology::labels::LabelSet;
 use crate::topology::point::PointId;
 use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CoastalBoundaryAssemblyError {
+    InvalidBoundaryFaceRole(BoundaryBranchError),
+}
 
 /// Label query selector for boundary condition application.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -78,7 +85,7 @@ pub fn coastal_boundary_face_sets(
     boundary_faces: impl IntoIterator<Item = PointId>,
 ) -> CoastalBoundaryFaceSets {
     let faces: HashSet<_> = boundary_faces.into_iter().collect();
-    let mut filter = |pts: Vec<PointId>| -> Vec<PointId> {
+    let filter = |pts: Vec<PointId>| -> Vec<PointId> {
         let mut v: Vec<_> = pts.into_iter().filter(|p| faces.contains(p)).collect();
         v.sort_unstable();
         v
@@ -101,11 +108,42 @@ pub fn map_coastal_boundary_conditions(
 ) -> HashMap<PointId, BoundaryCondition> {
     let mut out = HashMap::new();
     for face in boundary_faces {
-        if let Some(branch) = boundary_branch_for_face(labels, face) {
+        if let Ok(branch) = boundary_branch_for_face_checked(labels, face) {
             out.insert(face, branch_closure(branch, face));
         }
     }
     out
+}
+
+/// Resolved coastal boundary data ready for FV flux assembly.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CoastalBoundaryAssembly {
+    pub face_sets: CoastalBoundaryFaceSets,
+    pub boundary_conditions: HashMap<PointId, BoundaryCondition>,
+    pub branches: HashMap<PointId, FvBoundaryBranch>,
+}
+
+/// High-level coastal API: resolve boundary face groups and BC closures in one pass.
+pub fn resolve_coastal_boundary_assembly(
+    labels: &LabelSet,
+    boundary_faces: impl IntoIterator<Item = PointId>,
+    branch_closure: impl Fn(FvBoundaryBranch, PointId) -> BoundaryCondition,
+) -> Result<CoastalBoundaryAssembly, CoastalBoundaryAssemblyError> {
+    let faces: Vec<_> = boundary_faces.into_iter().collect();
+    let face_sets = coastal_boundary_face_sets(labels, faces.iter().copied());
+    let mut boundary_conditions = HashMap::new();
+    let mut branches = HashMap::new();
+    for face in faces {
+        let branch = boundary_branch_for_face_checked(labels, face)
+            .map_err(CoastalBoundaryAssemblyError::InvalidBoundaryFaceRole)?;
+        boundary_conditions.insert(face, branch_closure(branch, face));
+        branches.insert(face, branch);
+    }
+    Ok(CoastalBoundaryAssembly {
+        face_sets,
+        boundary_conditions,
+        branches,
+    })
 }
 
 fn field_offsets(field_dofs: &[usize]) -> Vec<usize> {
@@ -262,4 +300,116 @@ where
         }
     }
     section.apply_constraints()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discretization::runtime::FluxStencil;
+    use crate::physics::fvm::{FvmInputs, flux_activity_mask_from_wet_dry};
+    use crate::topology::coastal::{
+        BOUNDARY_CLASS_LABEL, BOUNDARY_ROLE_LABEL, BoundaryClass, OpenBoundaryRole,
+        WET_DRY_MASK_LABEL, WetDryMask,
+    };
+
+    fn p(id: u64) -> PointId {
+        PointId::new(id).unwrap()
+    }
+
+    #[test]
+    fn resolves_all_boundary_branches_to_bc_closures() {
+        let mut labels = LabelSet::new();
+        labels.set_label(
+            p(10),
+            BOUNDARY_CLASS_LABEL,
+            BoundaryClass::FreeSurface.code(),
+        );
+        labels.set_label(p(11), BOUNDARY_CLASS_LABEL, BoundaryClass::Bed.code());
+        labels.set_label(p(12), BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+        labels.set_label(p(12), BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Inflow.code());
+        labels.set_label(p(13), BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+        labels.set_label(p(13), BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Outflow.code());
+        labels.set_label(p(14), BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+        labels.set_label(p(14), BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Tidal.code());
+
+        let resolved = resolve_coastal_boundary_assembly(
+            &labels,
+            [p(10), p(11), p(12), p(13), p(14)],
+            |branch, _| match branch {
+                FvBoundaryBranch::FreeSurface => BoundaryCondition::Neumann { gradient: 1.0 },
+                FvBoundaryBranch::Bed => BoundaryCondition::Neumann { gradient: -1.0 },
+                FvBoundaryBranch::Inflow => BoundaryCondition::Dirichlet { value: 10.0 },
+                FvBoundaryBranch::Outflow => BoundaryCondition::Robin {
+                    alpha: 1.0,
+                    beta: 0.5,
+                    gamma: 0.2,
+                },
+                FvBoundaryBranch::Tidal => BoundaryCondition::Dirichlet { value: 7.0 },
+                FvBoundaryBranch::Open => unreachable!(),
+            },
+        )
+        .unwrap();
+        assert_eq!(resolved.face_sets.free_surface, vec![p(10)]);
+        assert_eq!(resolved.face_sets.bed, vec![p(11)]);
+        assert_eq!(resolved.face_sets.inflow, vec![p(12)]);
+        assert_eq!(resolved.face_sets.outflow, vec![p(13)]);
+        assert_eq!(resolved.face_sets.tidal, vec![p(14)]);
+        assert_eq!(resolved.boundary_conditions.len(), 5);
+    }
+
+    #[test]
+    fn errors_on_missing_open_role_in_assembly_faces() {
+        let mut labels = LabelSet::new();
+        labels.set_label(p(12), BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+        let err = resolve_coastal_boundary_assembly(&labels, [p(12)], |_, _| {
+            BoundaryCondition::Dirichlet { value: 0.0 }
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CoastalBoundaryAssemblyError::InvalidBoundaryFaceRole(BoundaryBranchError::OpenBoundaryMissingRole { face }) if face == p(12)
+        ));
+    }
+
+    #[test]
+    fn wet_dry_mask_permutations_and_mixed_boundary_sets() {
+        let c0 = p(1);
+        let c1 = p(2);
+        let c2 = p(3);
+        let b0 = p(10);
+        let b1 = p(11);
+        let i0 = p(20);
+        let inputs = FvmInputs::new(
+            [
+                FluxStencil {
+                    face: b0,
+                    left: c0,
+                    right: None,
+                },
+                FluxStencil {
+                    face: b1,
+                    left: c1,
+                    right: None,
+                },
+                FluxStencil {
+                    face: i0,
+                    left: c1,
+                    right: Some(c2),
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        let mut labels = LabelSet::new();
+        labels.set_label(b0, BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+        labels.set_label(b0, BOUNDARY_ROLE_LABEL, OpenBoundaryRole::Inflow.code());
+        labels.set_label(b1, BOUNDARY_CLASS_LABEL, BoundaryClass::Bed.code());
+        labels.set_label(i0, BOUNDARY_CLASS_LABEL, BoundaryClass::Open.code());
+        labels.set_label(c1, WET_DRY_MASK_LABEL, WetDryMask::Dry.code());
+        labels.set_label(c2, WET_DRY_MASK_LABEL, WetDryMask::Wet.code());
+        let mask = flux_activity_mask_from_wet_dry(&inputs, &labels);
+        assert_eq!(mask.boundary_faces_active.get(&b0), Some(&true));
+        assert_eq!(mask.boundary_faces_active.get(&b1), Some(&false));
+        assert_eq!(mask.near_boundary_faces_active.get(&i0), Some(&false));
+    }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -27,9 +27,11 @@ pub mod refine;
 pub use crate::debug_invariants::DebugInvariants;
 
 pub use bc::{
-    CoastalBoundaryFaceSets, FieldDofIndices, LabelQuery, apply_dirichlet_to_constrained_section,
+    CoastalBoundaryAssembly, CoastalBoundaryAssemblyError, CoastalBoundaryFaceSets,
+    FieldDofIndices, LabelQuery, apply_dirichlet_to_constrained_section,
     apply_dirichlet_to_constrained_section_fields, apply_dirichlet_to_section,
     apply_dirichlet_to_section_fields, coastal_boundary_face_sets, map_coastal_boundary_conditions,
+    resolve_coastal_boundary_assembly,
 };
 pub use closure::{
     ClosureIndex, ClosureIndexCache, ClosureIndexKey, ClosureOrder, ClosurePointIndex,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,10 @@ pub mod prelude {
     };
     pub use crate::data::atlas::Atlas;
     pub use crate::data::bc::{
-        FieldDofIndices, LabelQuery, apply_dirichlet_to_constrained_section,
-        apply_dirichlet_to_constrained_section_fields, apply_dirichlet_to_section,
-        apply_dirichlet_to_section_fields,
+        CoastalBoundaryAssembly, CoastalBoundaryAssemblyError, FieldDofIndices, LabelQuery,
+        apply_dirichlet_to_constrained_section, apply_dirichlet_to_constrained_section_fields,
+        apply_dirichlet_to_section, apply_dirichlet_to_section_fields, coastal_boundary_face_sets,
+        map_coastal_boundary_conditions, resolve_coastal_boundary_assembly,
     };
     pub use crate::data::constrained_section::{
         ConstrainedSection, ConstraintSet, DofConstraint, apply_constraints_to_section,
@@ -163,10 +164,11 @@ pub mod prelude {
         integrate_reference_scalar,
     };
     pub use crate::physics::fvm::{
-        FaceKind, FluxActivityMask, FvBoundaryBranch, FvmFaceLoops, FvmInputs,
+        BoundaryBranchError, FaceKind, FluxActivityMask, FvBoundaryBranch, FvmFaceLoops, FvmInputs,
         assemble_convective_fluxes, assemble_convective_fluxes_masked, assemble_diffusive_fluxes,
-        boundary_branch_for_face, classify_face_loops, flux_activity_mask_from_wet_dry,
-        interpolate_cell_centered_scalar, interpolate_face_centered_scalar,
+        boundary_branch_for_face, boundary_branch_for_face_checked, classify_face_loops,
+        flux_activity_mask_from_wet_dry, interpolate_cell_centered_scalar,
+        interpolate_face_centered_scalar,
     };
     pub use crate::topology::bounds::{PayloadLike, PointLike};
     pub use crate::topology::cell_type::CellType;

--- a/src/physics/fvm.rs
+++ b/src/physics/fvm.rs
@@ -27,9 +27,16 @@ pub enum FaceKind {
 pub enum ConvectiveScheme {
     Upwind,
     Central,
-    BoundedLinear { blend: f64 },
-    BlendUpwindCentral { blend: f64 },
-    HighResolution { blend: f64, limiter: SlopeLimiterFamily },
+    BoundedLinear {
+        blend: f64,
+    },
+    BlendUpwindCentral {
+        blend: f64,
+    },
+    HighResolution {
+        blend: f64,
+        limiter: SlopeLimiterFamily,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -54,7 +61,10 @@ pub struct ReconstructionSettings {
 
 impl Default for ReconstructionSettings {
     fn default() -> Self {
-        Self { gradient: ReconstructionGradient::LeastSquares, limiter: SlopeLimiterFamily::None }
+        Self {
+            gradient: ReconstructionGradient::LeastSquares,
+            limiter: SlopeLimiterFamily::None,
+        }
     }
 }
 
@@ -76,6 +86,21 @@ pub enum FvBoundaryBranch {
     FreeSurface,
 }
 
+/// Runtime errors when resolving boundary branch labels for FV assembly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoundaryBranchError {
+    MissingBoundaryClass {
+        face: PointId,
+    },
+    OpenBoundaryMissingRole {
+        face: PointId,
+    },
+    OpenBoundaryConflictingRoles {
+        face: PointId,
+        roles: Vec<OpenBoundaryRole>,
+    },
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DiffusionSettings {
     pub diffusivity: f64,
@@ -91,15 +116,26 @@ pub enum NonOrthogonalCorrectionMode {
 
 impl Default for DiffusionSettings {
     fn default() -> Self {
-        Self { diffusivity: 1.0, non_orthogonal_mode: NonOrthogonalCorrectionMode::FullyCorrected }
+        Self {
+            diffusivity: 1.0,
+            non_orthogonal_mode: NonOrthogonalCorrectionMode::FullyCorrected,
+        }
     }
 }
 
 pub trait FvmPhysicsHooks {
-    fn turbulence_flux(&self, _stencil: &FluxStencil, _inputs: &FvmInputs) -> f64 { 0.0 }
-    fn free_surface_flux(&self, _stencil: &FluxStencil, _inputs: &FvmInputs) -> f64 { 0.0 }
-    fn turbulence_source(&self, _cell: PointId, _inputs: &FvmInputs) -> f64 { 0.0 }
-    fn free_surface_source(&self, _cell: PointId, _inputs: &FvmInputs) -> f64 { 0.0 }
+    fn turbulence_flux(&self, _stencil: &FluxStencil, _inputs: &FvmInputs) -> f64 {
+        0.0
+    }
+    fn free_surface_flux(&self, _stencil: &FluxStencil, _inputs: &FvmInputs) -> f64 {
+        0.0
+    }
+    fn turbulence_source(&self, _cell: PointId, _inputs: &FvmInputs) -> f64 {
+        0.0
+    }
+    fn free_surface_source(&self, _cell: PointId, _inputs: &FvmInputs) -> f64 {
+        0.0
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -144,52 +180,103 @@ impl FvmInputs {
                 loops.boundary.push(stencil);
             }
         }
-        Self { loops, cell_geometry, face_geometry }
+        Self {
+            loops,
+            cell_geometry,
+            face_geometry,
+        }
     }
 
-    pub fn internal_faces(&self) -> impl Iterator<Item = &FluxStencil> { self.loops.internal.iter() }
-    pub fn boundary_faces(&self) -> impl Iterator<Item = &FluxStencil> { self.loops.boundary.iter() }
-    pub fn cell_metrics(&self, cell: PointId) -> Option<&CellGeometry> { self.cell_geometry.iter().find_map(|(id,m)|(*id==cell).then_some(m)) }
-    pub fn face_metrics(&self, face: PointId) -> Option<&FaceGeometry> { self.face_geometry.iter().find_map(|(id,m)|(*id==face).then_some(m)) }
+    pub fn internal_faces(&self) -> impl Iterator<Item = &FluxStencil> {
+        self.loops.internal.iter()
+    }
+    pub fn boundary_faces(&self) -> impl Iterator<Item = &FluxStencil> {
+        self.loops.boundary.iter()
+    }
+    pub fn cell_metrics(&self, cell: PointId) -> Option<&CellGeometry> {
+        self.cell_geometry
+            .iter()
+            .find_map(|(id, m)| (*id == cell).then_some(m))
+    }
+    pub fn face_metrics(&self, face: PointId) -> Option<&FaceGeometry> {
+        self.face_geometry
+            .iter()
+            .find_map(|(id, m)| (*id == face).then_some(m))
+    }
 }
 
-pub fn classify_face_loops<T>(topology: &T, faces: impl IntoIterator<Item = PointId>) -> Result<FvmFaceLoops, MeshSieveError>
-where T: Sieve<Point = PointId>,
+pub fn classify_face_loops<T>(
+    topology: &T,
+    faces: impl IntoIterator<Item = PointId>,
+) -> Result<FvmFaceLoops, MeshSieveError>
+where
+    T: Sieve<Point = PointId>,
 {
     let mut loops = FvmFaceLoops::default();
     for face in faces {
         let mut cells: Vec<_> = topology.support_points(face).collect();
         cells.sort_unstable();
         match cells.as_slice() {
-            [left] => loops.boundary.push(FluxStencil { face, left: *left, right: None }),
-            [left, right] => loops.internal.push(FluxStencil { face, left: *left, right: Some(*right) }),
-            [] => return Err(MeshSieveError::InvalidGeometry(format!("face {face:?} has no supporting cells"))),
-            _ => return Err(MeshSieveError::InvalidGeometry(format!("non-manifold face {face:?} has {} support cells", cells.len()))),
+            [left] => loops.boundary.push(FluxStencil {
+                face,
+                left: *left,
+                right: None,
+            }),
+            [left, right] => loops.internal.push(FluxStencil {
+                face,
+                left: *left,
+                right: Some(*right),
+            }),
+            [] => {
+                return Err(MeshSieveError::InvalidGeometry(format!(
+                    "face {face:?} has no supporting cells"
+                )));
+            }
+            _ => {
+                return Err(MeshSieveError::InvalidGeometry(format!(
+                    "non-manifold face {face:?} has {} support cells",
+                    cells.len()
+                )));
+            }
         }
     }
     Ok(loops)
 }
 
-pub fn interpolate_face_centered_scalar<S: Storage<f64>>(section: &Section<f64, S>, stencil: &FluxStencil) -> Result<f64, MeshSieveError> {
+pub fn interpolate_face_centered_scalar<S: Storage<f64>>(
+    section: &Section<f64, S>,
+    stencil: &FluxStencil,
+) -> Result<f64, MeshSieveError> {
     let left = section.try_restrict(stencil.left)?;
-    let lval = *left.first().ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar value at cell {}", stencil.left)))?;
+    let lval = *left.first().ok_or_else(|| {
+        MeshSieveError::InvalidGeometry(format!("missing scalar value at cell {}", stencil.left))
+    })?;
     if let Some(right_cell) = stencil.right {
         let right = section.try_restrict(right_cell)?;
-        let rval = *right.first().ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar value at cell {}", right_cell)))?;
+        let rval = *right.first().ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar value at cell {}", right_cell))
+        })?;
         Ok(0.5 * (lval + rval))
     } else {
         Ok(lval)
     }
 }
 
-pub fn interpolate_cell_centered_scalar<S: Storage<f64>>(section: &Section<f64, S>, incident_faces: &[PointId]) -> Result<f64, MeshSieveError> {
+pub fn interpolate_cell_centered_scalar<S: Storage<f64>>(
+    section: &Section<f64, S>,
+    incident_faces: &[PointId],
+) -> Result<f64, MeshSieveError> {
     if incident_faces.is_empty() {
-        return Err(MeshSieveError::InvalidGeometry("cannot interpolate to cell center from zero incident faces".to_string()));
+        return Err(MeshSieveError::InvalidGeometry(
+            "cannot interpolate to cell center from zero incident faces".to_string(),
+        ));
     }
     let mut accum = 0.0;
     for face in incident_faces {
         let value = section.try_restrict(*face)?;
-        let scalar = *value.first().ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar value at face {}", face)))?;
+        let scalar = *value.first().ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar value at face {}", face))
+        })?;
         accum += scalar;
     }
     Ok(accum / incident_faces.len() as f64)
@@ -241,19 +328,25 @@ pub struct FluxActivityMask {
 fn face_is_active(mask: Option<&FluxActivityMask>, stencil: &FluxStencil, boundary: bool) -> bool {
     let Some(mask) = mask else { return true };
     if boundary {
-        return mask.boundary_faces_active.get(&stencil.face).copied().unwrap_or(true);
+        return mask
+            .boundary_faces_active
+            .get(&stencil.face)
+            .copied()
+            .unwrap_or(true);
     }
-    if mask.near_boundary_faces_active.get(&stencil.face).copied().unwrap_or(true) {
+    if mask
+        .near_boundary_faces_active
+        .get(&stencil.face)
+        .copied()
+        .unwrap_or(true)
+    {
         return true;
     }
     false
 }
 
 /// Build a flux-activity mask from coastal wet/dry labels on cells.
-pub fn flux_activity_mask_from_wet_dry(
-    inputs: &FvmInputs,
-    labels: &LabelSet,
-) -> FluxActivityMask {
+pub fn flux_activity_mask_from_wet_dry(inputs: &FvmInputs, labels: &LabelSet) -> FluxActivityMask {
     let mut mask = FluxActivityMask::default();
     let dry = WetDryMask::Dry.code();
     let cell_is_dry = |cell: PointId| labels.get_label(cell, WET_DRY_MASK_LABEL) == Some(dry);
@@ -262,7 +355,9 @@ pub fn flux_activity_mask_from_wet_dry(
             .insert(stencil.face, !cell_is_dry(stencil.left));
     }
     for stencil in inputs.internal_faces() {
-        let near_boundary = labels.get_label(stencil.face, BOUNDARY_CLASS_LABEL).is_some();
+        let near_boundary = labels
+            .get_label(stencil.face, BOUNDARY_CLASS_LABEL)
+            .is_some();
         if near_boundary {
             let left_dry = cell_is_dry(stencil.left);
             let right_dry = stencil.right.map(cell_is_dry).unwrap_or(true);
@@ -288,10 +383,16 @@ pub fn assemble_convective_fluxes_masked(
         if !face_is_active(activity_mask, stencil, false) {
             continue;
         }
-        let mdot = *face_mass_flux.get(&stencil.face).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing mass flux for face {}", stencil.face)))?;
-        let l = *cell_scalar.get(&stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left)))?;
+        let mdot = *face_mass_flux.get(&stencil.face).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing mass flux for face {}", stencil.face))
+        })?;
+        let l = *cell_scalar.get(&stencil.left).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left))
+        })?;
         let rcell = stencil.right.expect("internal face must have neighbor");
-        let r = *cell_scalar.get(&rcell).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", rcell)))?;
+        let r = *cell_scalar.get(&rcell).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", rcell))
+        })?;
         let phi_f = convective_face_value(l, r, mdot, scheme, reconstruction.limiter);
         let flux = mdot * phi_f;
         assembly.add_residual(stencil.left, flux);
@@ -301,10 +402,35 @@ pub fn assemble_convective_fluxes_masked(
         if !face_is_active(activity_mask, stencil, true) {
             continue;
         }
-        let mdot = *face_mass_flux.get(&stencil.face).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing mass flux for boundary face {}", stencil.face)))?;
-        let phi_i = *cell_scalar.get(&stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left)))?;
-        let bc = boundary_conditions.get(&stencil.face).copied().ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing boundary condition for face {}", stencil.face)))?;
-        let phi_b = match bc { BoundaryCondition::Dirichlet { value } => value, BoundaryCondition::Neumann { .. } => phi_i, BoundaryCondition::Robin { alpha, beta, gamma } => if alpha.abs() < 1e-14 { phi_i } else { (gamma - beta * phi_i) / alpha } };
+        let mdot = *face_mass_flux.get(&stencil.face).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!(
+                "missing mass flux for boundary face {}",
+                stencil.face
+            ))
+        })?;
+        let phi_i = *cell_scalar.get(&stencil.left).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left))
+        })?;
+        let bc = boundary_conditions
+            .get(&stencil.face)
+            .copied()
+            .ok_or_else(|| {
+                MeshSieveError::InvalidGeometry(format!(
+                    "missing boundary condition for face {}",
+                    stencil.face
+                ))
+            })?;
+        let phi_b = match bc {
+            BoundaryCondition::Dirichlet { value } => value,
+            BoundaryCondition::Neumann { .. } => phi_i,
+            BoundaryCondition::Robin { alpha, beta, gamma } => {
+                if alpha.abs() < 1e-14 {
+                    phi_i
+                } else {
+                    (gamma - beta * phi_i) / alpha
+                }
+            }
+        };
         let phi_f = convective_face_value(phi_i, phi_b, mdot, scheme, reconstruction.limiter);
         assembly.add_residual(stencil.left, mdot * phi_f);
     }
@@ -315,13 +441,56 @@ pub fn boundary_branch_for_face(labels: &LabelSet, face: PointId) -> Option<FvBo
     match labels.get_label(face, BOUNDARY_CLASS_LABEL) {
         Some(v) if v == BoundaryClass::FreeSurface.code() => Some(FvBoundaryBranch::FreeSurface),
         Some(v) if v == BoundaryClass::Bed.code() => Some(FvBoundaryBranch::Bed),
-        Some(v) if v == BoundaryClass::Open.code() => match labels.get_label(face, BOUNDARY_ROLE_LABEL) {
-            Some(v) if v == OpenBoundaryRole::Inflow.code() => Some(FvBoundaryBranch::Inflow),
-            Some(v) if v == OpenBoundaryRole::Outflow.code() => Some(FvBoundaryBranch::Outflow),
-            Some(v) if v == OpenBoundaryRole::Tidal.code() => Some(FvBoundaryBranch::Tidal),
-            _ => Some(FvBoundaryBranch::Open),
-        },
+        Some(v) if v == BoundaryClass::Open.code() => {
+            match labels.get_label(face, BOUNDARY_ROLE_LABEL) {
+                Some(v) if v == OpenBoundaryRole::Inflow.code() => Some(FvBoundaryBranch::Inflow),
+                Some(v) if v == OpenBoundaryRole::Outflow.code() => Some(FvBoundaryBranch::Outflow),
+                Some(v) if v == OpenBoundaryRole::Tidal.code() => Some(FvBoundaryBranch::Tidal),
+                _ => Some(FvBoundaryBranch::Open),
+            }
+        }
         _ => None,
+    }
+}
+
+/// Resolve a boundary branch with explicit runtime validation for open-boundary roles.
+pub fn boundary_branch_for_face_checked(
+    labels: &LabelSet,
+    face: PointId,
+) -> Result<FvBoundaryBranch, BoundaryBranchError> {
+    let Some(class) = labels.get_label(face, BOUNDARY_CLASS_LABEL) else {
+        return Err(BoundaryBranchError::MissingBoundaryClass { face });
+    };
+    if class == BoundaryClass::FreeSurface.code() {
+        return Ok(FvBoundaryBranch::FreeSurface);
+    }
+    if class == BoundaryClass::Bed.code() {
+        return Ok(FvBoundaryBranch::Bed);
+    }
+    if class != BoundaryClass::Open.code() {
+        return Err(BoundaryBranchError::MissingBoundaryClass { face });
+    }
+    let inflow =
+        labels.get_label(face, BOUNDARY_ROLE_LABEL) == Some(OpenBoundaryRole::Inflow.code());
+    let outflow =
+        labels.get_label(face, BOUNDARY_ROLE_LABEL) == Some(OpenBoundaryRole::Outflow.code());
+    let tidal = labels.get_label(face, BOUNDARY_ROLE_LABEL) == Some(OpenBoundaryRole::Tidal.code());
+    let mut roles = Vec::new();
+    if inflow {
+        roles.push(OpenBoundaryRole::Inflow);
+    }
+    if outflow {
+        roles.push(OpenBoundaryRole::Outflow);
+    }
+    if tidal {
+        roles.push(OpenBoundaryRole::Tidal);
+    }
+    match roles.as_slice() {
+        [OpenBoundaryRole::Inflow] => Ok(FvBoundaryBranch::Inflow),
+        [OpenBoundaryRole::Outflow] => Ok(FvBoundaryBranch::Outflow),
+        [OpenBoundaryRole::Tidal] => Ok(FvBoundaryBranch::Tidal),
+        [] => Err(BoundaryBranchError::OpenBoundaryMissingRole { face }),
+        _ => Err(BoundaryBranchError::OpenBoundaryConflictingRoles { face, roles }),
     }
 }
 
@@ -332,7 +501,14 @@ pub fn assemble_diffusive_fluxes(
     boundary_conditions: &HashMap<PointId, BoundaryCondition>,
     settings: DiffusionSettings,
 ) -> Result<FluxAssembly, MeshSieveError> {
-    assemble_diffusive_fluxes_with_hooks(inputs, cell_scalar, cell_gradient, boundary_conditions, settings, None)
+    assemble_diffusive_fluxes_with_hooks(
+        inputs,
+        cell_scalar,
+        cell_gradient,
+        boundary_conditions,
+        settings,
+        None,
+    )
 }
 
 pub fn assemble_diffusive_fluxes_with_hooks(
@@ -345,38 +521,90 @@ pub fn assemble_diffusive_fluxes_with_hooks(
 ) -> Result<FluxAssembly, MeshSieveError> {
     let mut assembly = FluxAssembly::default();
     for stencil in inputs.internal_faces() {
-        let fg = inputs.face_metrics(stencil.face).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing face geometry for face {}", stencil.face)))?;
-        let lc = inputs.cell_metrics(stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing cell geometry for cell {}", stencil.left)))?;
+        let fg = inputs.face_metrics(stencil.face).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!(
+                "missing face geometry for face {}",
+                stencil.face
+            ))
+        })?;
+        let lc = inputs.cell_metrics(stencil.left).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!(
+                "missing cell geometry for cell {}",
+                stencil.left
+            ))
+        })?;
         let rcell = stencil.right.expect("internal face");
-        let rc = inputs.cell_metrics(rcell).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing cell geometry for cell {}", rcell)))?;
-        let phi_l = *cell_scalar.get(&stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left)))?;
-        let phi_r = *cell_scalar.get(&rcell).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", rcell)))?;
+        let rc = inputs.cell_metrics(rcell).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing cell geometry for cell {}", rcell))
+        })?;
+        let phi_l = *cell_scalar.get(&stencil.left).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left))
+        })?;
+        let phi_r = *cell_scalar.get(&rcell).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", rcell))
+        })?;
         let d = sub(&rc.centroid, &lc.centroid);
         let d2 = dot(&d, &d);
         let a = &fg.normal;
-        let orth = if d2 > 0.0 { (phi_r - phi_l) * dot(a, &d) / d2 } else { 0.0 };
+        let orth = if d2 > 0.0 {
+            (phi_r - phi_l) * dot(a, &d) / d2
+        } else {
+            0.0
+        };
         let mut flux = -settings.diffusivity * orth;
         let mut non_orth_flux = 0.0;
         if settings.non_orthogonal_mode != NonOrthogonalCorrectionMode::OrthogonalOnly {
-            let gf = avg(cell_gradient.get(&stencil.left), cell_gradient.get(&rcell), a.len())?;
-            let a_orth = if d2 > 0.0 { scale(&d, dot(a, &d) / d2) } else { vec![0.0; a.len()] };
+            let gf = avg(
+                cell_gradient.get(&stencil.left),
+                cell_gradient.get(&rcell),
+                a.len(),
+            )?;
+            let a_orth = if d2 > 0.0 {
+                scale(&d, dot(a, &d) / d2)
+            } else {
+                vec![0.0; a.len()]
+            };
             let a_non = sub(a, &a_orth);
             non_orth_flux = -settings.diffusivity * dot(&gf, &a_non);
         }
         match settings.non_orthogonal_mode {
             NonOrthogonalCorrectionMode::OrthogonalOnly => {}
-            NonOrthogonalCorrectionMode::Deferred => assembly.add_source(stencil.left, -non_orth_flux),
+            NonOrthogonalCorrectionMode::Deferred => {
+                assembly.add_source(stencil.left, -non_orth_flux)
+            }
             NonOrthogonalCorrectionMode::FullyCorrected => flux += non_orth_flux,
         }
-        if let Some(h) = hooks { flux += h.turbulence_flux(stencil, inputs) + h.free_surface_flux(stencil, inputs); }
+        if let Some(h) = hooks {
+            flux += h.turbulence_flux(stencil, inputs) + h.free_surface_flux(stencil, inputs);
+        }
         assembly.add_residual(stencil.left, flux);
         assembly.add_residual(rcell, -flux);
     }
     for stencil in inputs.boundary_faces() {
-        let fg = inputs.face_metrics(stencil.face).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing face geometry for boundary face {}", stencil.face)))?;
-        let lc = inputs.cell_metrics(stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing cell geometry for cell {}", stencil.left)))?;
-        let phi_i = *cell_scalar.get(&stencil.left).ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left)))?;
-        let bc = boundary_conditions.get(&stencil.face).copied().ok_or_else(|| MeshSieveError::InvalidGeometry(format!("missing boundary condition for face {}", stencil.face)))?;
+        let fg = inputs.face_metrics(stencil.face).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!(
+                "missing face geometry for boundary face {}",
+                stencil.face
+            ))
+        })?;
+        let lc = inputs.cell_metrics(stencil.left).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!(
+                "missing cell geometry for cell {}",
+                stencil.left
+            ))
+        })?;
+        let phi_i = *cell_scalar.get(&stencil.left).ok_or_else(|| {
+            MeshSieveError::InvalidGeometry(format!("missing scalar for cell {}", stencil.left))
+        })?;
+        let bc = boundary_conditions
+            .get(&stencil.face)
+            .copied()
+            .ok_or_else(|| {
+                MeshSieveError::InvalidGeometry(format!(
+                    "missing boundary condition for face {}",
+                    stencil.face
+                ))
+            })?;
         let n = normalize(&fg.normal);
         let d = norm(&sub(&fg.centroid, &lc.centroid)).max(1e-14);
         match bc {
@@ -393,19 +621,31 @@ pub fn assemble_diffusive_fluxes_with_hooks(
                 let flux = -settings.diffusivity * grad_n * fg.area;
                 let _ = n;
                 assembly.add_residual(stencil.left, flux);
-                assembly.add_source(stencil.left, settings.diffusivity * gamma * fg.area / beta.max(1e-14));
+                assembly.add_source(
+                    stencil.left,
+                    settings.diffusivity * gamma * fg.area / beta.max(1e-14),
+                );
             }
         }
     }
     if let Some(h) = hooks {
         for (cell, _) in &inputs.cell_geometry {
-            assembly.add_source(*cell, h.turbulence_source(*cell, inputs) + h.free_surface_source(*cell, inputs));
+            assembly.add_source(
+                *cell,
+                h.turbulence_source(*cell, inputs) + h.free_surface_source(*cell, inputs),
+            );
         }
     }
     Ok(assembly)
 }
 
-fn convective_face_value(l: f64, r: f64, mdot: f64, scheme: ConvectiveScheme, _limiter: SlopeLimiterFamily) -> f64 {
+fn convective_face_value(
+    l: f64,
+    r: f64,
+    mdot: f64,
+    scheme: ConvectiveScheme,
+    _limiter: SlopeLimiterFamily,
+) -> f64 {
     let up = if mdot >= 0.0 { l } else { r };
     let dn = if mdot >= 0.0 { r } else { l };
     let central = 0.5 * (l + r);
@@ -413,9 +653,16 @@ fn convective_face_value(l: f64, r: f64, mdot: f64, scheme: ConvectiveScheme, _l
     match scheme {
         ConvectiveScheme::Upwind => up,
         ConvectiveScheme::Central => central,
-        ConvectiveScheme::BoundedLinear { blend } => clamp(up + clamp01(blend) * (central - up), mn, mx),
-        ConvectiveScheme::BlendUpwindCentral { blend } => (1.0 - clamp01(blend)) * up + clamp01(blend) * central,
-        ConvectiveScheme::HighResolution { blend, limiter: lim } => {
+        ConvectiveScheme::BoundedLinear { blend } => {
+            clamp(up + clamp01(blend) * (central - up), mn, mx)
+        }
+        ConvectiveScheme::BlendUpwindCentral { blend } => {
+            (1.0 - clamp01(blend)) * up + clamp01(blend) * central
+        }
+        ConvectiveScheme::HighResolution {
+            blend,
+            limiter: lim,
+        } => {
             let psi = slope_limiter(lim, up, dn);
             let hr = up + 0.5 * psi * (dn - up);
             let b = clamp01(blend);
@@ -424,7 +671,11 @@ fn convective_face_value(l: f64, r: f64, mdot: f64, scheme: ConvectiveScheme, _l
     }
 }
 fn slope_limiter(limiter: SlopeLimiterFamily, up: f64, dn: f64) -> f64 {
-    let r = if (dn - up).abs() < 1e-14 { 1.0 } else { ((up - dn) / (dn - up)).abs() };
+    let r = if (dn - up).abs() < 1e-14 {
+        1.0
+    } else {
+        ((up - dn) / (dn - up)).abs()
+    };
     match limiter {
         SlopeLimiterFamily::None => 1.0,
         SlopeLimiterFamily::Minmod => r.clamp(0.0, 1.0),
@@ -432,55 +683,168 @@ fn slope_limiter(limiter: SlopeLimiterFamily, up: f64, dn: f64) -> f64 {
         SlopeLimiterFamily::Superbee => (2.0 * r).min(1.0).max(r.min(2.0)).max(0.0),
     }
 }
-fn clamp(x: f64, lo: f64, hi: f64) -> f64 { x.max(lo).min(hi) }
-fn clamp01(x: f64) -> f64 { clamp(x, 0.0, 1.0) }
+fn clamp(x: f64, lo: f64, hi: f64) -> f64 {
+    x.max(lo).min(hi)
+}
+fn clamp01(x: f64) -> f64 {
+    clamp(x, 0.0, 1.0)
+}
 
-fn dot(a: &[f64], b: &[f64]) -> f64 { a.iter().zip(b.iter()).map(|(x,y)| x*y).sum() }
-fn sub(a: &[f64], b: &[f64]) -> Vec<f64> { a.iter().zip(b.iter()).map(|(x,y)| x-y).collect() }
-fn scale(a: &[f64], s: f64) -> Vec<f64> { a.iter().map(|x| x*s).collect() }
-fn norm(a: &[f64]) -> f64 { dot(a,a).sqrt() }
-fn normalize(a:&[f64])->Vec<f64>{ let n=norm(a).max(1e-14); scale(a,1.0/n)}
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+fn sub(a: &[f64], b: &[f64]) -> Vec<f64> {
+    a.iter().zip(b.iter()).map(|(x, y)| x - y).collect()
+}
+fn scale(a: &[f64], s: f64) -> Vec<f64> {
+    a.iter().map(|x| x * s).collect()
+}
+fn norm(a: &[f64]) -> f64 {
+    dot(a, a).sqrt()
+}
+fn normalize(a: &[f64]) -> Vec<f64> {
+    let n = norm(a).max(1e-14);
+    scale(a, 1.0 / n)
+}
 fn avg(a: Option<&Vec<f64>>, b: Option<&Vec<f64>>, n: usize) -> Result<Vec<f64>, MeshSieveError> {
     let la = a.ok_or_else(|| MeshSieveError::InvalidGeometry("missing left gradient".into()))?;
     let lb = b.ok_or_else(|| MeshSieveError::InvalidGeometry("missing right gradient".into()))?;
-    if la.len() != n || lb.len() != n { return Err(MeshSieveError::InvalidGeometry("gradient dimension mismatch".into())); }
-    Ok(la.iter().zip(lb.iter()).map(|(x,y)|0.5*(x+y)).collect())
+    if la.len() != n || lb.len() != n {
+        return Err(MeshSieveError::InvalidGeometry(
+            "gradient dimension mismatch".into(),
+        ));
+    }
+    Ok(la
+        .iter()
+        .zip(lb.iter())
+        .map(|(x, y)| 0.5 * (x + y))
+        .collect())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn pid(id: u64) -> PointId { PointId::new(id).unwrap() }
+    fn pid(id: u64) -> PointId {
+        PointId::new(id).unwrap()
+    }
 
     #[test]
     fn convective_two_cell_conservation() {
-        let c0 = pid(1); let c1 = pid(2); let f = pid(10);
-        let inputs = FvmInputs::new([FluxStencil{face:f,left:c0,right:Some(c1)}], vec![], vec![]);
+        let c0 = pid(1);
+        let c1 = pid(2);
+        let f = pid(10);
+        let inputs = FvmInputs::new(
+            [FluxStencil {
+                face: f,
+                left: c0,
+                right: Some(c1),
+            }],
+            vec![],
+            vec![],
+        );
         let phi = HashMap::from([(c0, 2.0), (c1, 6.0)]);
         let mdot = HashMap::from([(f, 3.0)]);
-        let r = assemble_convective_fluxes(&inputs, &phi, &mdot, &HashMap::new(), ConvectiveScheme::Central).unwrap();
+        let r = assemble_convective_fluxes(
+            &inputs,
+            &phi,
+            &mdot,
+            &HashMap::new(),
+            ConvectiveScheme::Central,
+        )
+        .unwrap();
         assert!((r.residual[&c0] + r.residual[&c1]).abs() < 1e-12);
         assert_eq!(r.residual[&c0], 12.0);
     }
 
     #[test]
     fn diffusive_two_cell_symmetry() {
-        let c0=pid(1); let c1=pid(2); let f=pid(9);
-        let inputs = FvmInputs::new([FluxStencil{face:f,left:c0,right:Some(c1)}], vec![(c0,CellGeometry{centroid:vec![0.0,0.0],volume:1.0}),(c1,CellGeometry{centroid:vec![1.0,0.0],volume:1.0})], vec![(f,FaceGeometry{face:f,centroid:vec![0.5,0.0],normal:vec![1.0,0.0],area:1.0,neighbors:vec![c0,c1]})]);
-        let phi = HashMap::from([(c0,1.0),(c1,3.0)]);
-        let grad = HashMap::from([(c0,vec![2.0,0.0]),(c1,vec![2.0,0.0])]);
-        let r = assemble_diffusive_fluxes(&inputs,&phi,&grad,&HashMap::new(),DiffusionSettings::default()).unwrap();
+        let c0 = pid(1);
+        let c1 = pid(2);
+        let f = pid(9);
+        let inputs = FvmInputs::new(
+            [FluxStencil {
+                face: f,
+                left: c0,
+                right: Some(c1),
+            }],
+            vec![
+                (
+                    c0,
+                    CellGeometry {
+                        centroid: vec![0.0, 0.0],
+                        volume: 1.0,
+                    },
+                ),
+                (
+                    c1,
+                    CellGeometry {
+                        centroid: vec![1.0, 0.0],
+                        volume: 1.0,
+                    },
+                ),
+            ],
+            vec![(
+                f,
+                FaceGeometry {
+                    face: f,
+                    centroid: vec![0.5, 0.0],
+                    normal: vec![1.0, 0.0],
+                    area: 1.0,
+                    neighbors: vec![c0, c1],
+                },
+            )],
+        );
+        let phi = HashMap::from([(c0, 1.0), (c1, 3.0)]);
+        let grad = HashMap::from([(c0, vec![2.0, 0.0]), (c1, vec![2.0, 0.0])]);
+        let r = assemble_diffusive_fluxes(
+            &inputs,
+            &phi,
+            &grad,
+            &HashMap::new(),
+            DiffusionSettings::default(),
+        )
+        .unwrap();
         assert!((r.residual[&c0] + r.residual[&c1]).abs() < 1e-12);
     }
 
     #[test]
     fn convective_bounded_linear_is_bounded_on_skewed_pair() {
-        let c0 = pid(1); let c1 = pid(2); let f = pid(10);
+        let c0 = pid(1);
+        let c1 = pid(2);
+        let f = pid(10);
         let inputs = FvmInputs::new(
-            [FluxStencil{face:f,left:c0,right:Some(c1)}],
-            vec![(c0,CellGeometry{centroid:vec![0.0,0.0],volume:1.0}),(c1,CellGeometry{centroid:vec![1.2,0.3],volume:1.0})],
-            vec![(f,FaceGeometry{face:f,centroid:vec![0.55,0.2],normal:vec![0.9,0.4],area:0.98,neighbors:vec![c0,c1]})]
+            [FluxStencil {
+                face: f,
+                left: c0,
+                right: Some(c1),
+            }],
+            vec![
+                (
+                    c0,
+                    CellGeometry {
+                        centroid: vec![0.0, 0.0],
+                        volume: 1.0,
+                    },
+                ),
+                (
+                    c1,
+                    CellGeometry {
+                        centroid: vec![1.2, 0.3],
+                        volume: 1.0,
+                    },
+                ),
+            ],
+            vec![(
+                f,
+                FaceGeometry {
+                    face: f,
+                    centroid: vec![0.55, 0.2],
+                    normal: vec![0.9, 0.4],
+                    area: 0.98,
+                    neighbors: vec![c0, c1],
+                },
+            )],
         );
         let phi = HashMap::from([(c0, 0.0), (c1, 1.0)]);
         let mdot = HashMap::from([(f, 4.0)]);
@@ -490,8 +854,12 @@ mod tests {
             &mdot,
             &HashMap::new(),
             ConvectiveScheme::BoundedLinear { blend: 1.0 },
-            ReconstructionSettings { gradient: ReconstructionGradient::GreenGauss, limiter: SlopeLimiterFamily::VanLeer },
-        ).unwrap();
+            ReconstructionSettings {
+                gradient: ReconstructionGradient::GreenGauss,
+                limiter: SlopeLimiterFamily::VanLeer,
+            },
+        )
+        .unwrap();
         let face_value = r.residual[&c0] / mdot[&f];
         assert!((0.0..=1.0).contains(&face_value));
         assert!((r.residual[&c0] + r.residual[&c1]).abs() < 1e-12);
@@ -499,19 +867,60 @@ mod tests {
 
     #[test]
     fn diffusive_non_orthogonal_modes_preserve_pair_conservation() {
-        let c0=pid(1); let c1=pid(2); let f=pid(9);
+        let c0 = pid(1);
+        let c1 = pid(2);
+        let f = pid(9);
         let inputs = FvmInputs::new(
-            [FluxStencil{face:f,left:c0,right:Some(c1)}],
-            vec![(c0,CellGeometry{centroid:vec![0.0,0.0],volume:1.0}),(c1,CellGeometry{centroid:vec![1.0,0.25],volume:1.0})],
-            vec![(f,FaceGeometry{face:f,centroid:vec![0.45,0.15],normal:vec![0.8,0.6],area:1.0,neighbors:vec![c0,c1]})]
+            [FluxStencil {
+                face: f,
+                left: c0,
+                right: Some(c1),
+            }],
+            vec![
+                (
+                    c0,
+                    CellGeometry {
+                        centroid: vec![0.0, 0.0],
+                        volume: 1.0,
+                    },
+                ),
+                (
+                    c1,
+                    CellGeometry {
+                        centroid: vec![1.0, 0.25],
+                        volume: 1.0,
+                    },
+                ),
+            ],
+            vec![(
+                f,
+                FaceGeometry {
+                    face: f,
+                    centroid: vec![0.45, 0.15],
+                    normal: vec![0.8, 0.6],
+                    area: 1.0,
+                    neighbors: vec![c0, c1],
+                },
+            )],
         );
-        let phi = HashMap::from([(c0,1.0),(c1,3.0)]);
-        let grad = HashMap::from([(c0,vec![2.0,0.2]),(c1,vec![2.0,0.2])]);
-        for mode in [NonOrthogonalCorrectionMode::OrthogonalOnly, NonOrthogonalCorrectionMode::Deferred, NonOrthogonalCorrectionMode::FullyCorrected] {
+        let phi = HashMap::from([(c0, 1.0), (c1, 3.0)]);
+        let grad = HashMap::from([(c0, vec![2.0, 0.2]), (c1, vec![2.0, 0.2])]);
+        for mode in [
+            NonOrthogonalCorrectionMode::OrthogonalOnly,
+            NonOrthogonalCorrectionMode::Deferred,
+            NonOrthogonalCorrectionMode::FullyCorrected,
+        ] {
             let r = assemble_diffusive_fluxes(
-                &inputs,&phi,&grad,&HashMap::new(),
-                DiffusionSettings { diffusivity: 1.0, non_orthogonal_mode: mode }
-            ).unwrap();
+                &inputs,
+                &phi,
+                &grad,
+                &HashMap::new(),
+                DiffusionSettings {
+                    diffusivity: 1.0,
+                    non_orthogonal_mode: mode,
+                },
+            )
+            .unwrap();
             assert!((r.residual[&c0] + r.residual[&c1]).abs() < 1e-12);
         }
     }


### PR DESCRIPTION
### Motivation
- Make coastal boundary labels map deterministically to FV flux/gradient closure behavior with consistent sign/orientation and fail-fast validation for missing or conflicting metadata.
- Provide a single high-level API that yields grouped boundary face sets and resolved BC closures ready for flux assembly.
- Add coverage for wet/dry mask permutations and mixed boundary/internal sets so assembly logic is exercised across common permutations.

### Description
- Add `BoundaryBranchError` and `boundary_branch_for_face_checked(...)` in `src/physics/fvm.rs` to return explicit runtime errors for missing boundary class or missing/conflicting open-boundary role labels and preserve the original `boundary_branch_for_face` for compatibility.
- Update coastal BC helpers in `src/data/bc.rs` to use the checked resolver and introduce `CoastalBoundaryAssembly`, `CoastalBoundaryAssemblyError`, and `resolve_coastal_boundary_assembly(...)` which returns `CoastalBoundaryFaceSets`, per-face `FvBoundaryBranch` map, and per-face `BoundaryCondition` closures in one pass.
- Update `map_coastal_boundary_conditions(...)` to use the checked resolver and adjust imports/exports; re-export new types/functions via `src/data/mod.rs` and the crate prelude in `src/lib.rs`.
- Add unit tests in `src/data/bc.rs` that exercise all coastal boundary branches (free-surface, bed, inflow, outflow, tidal), validate missing-role error behavior, and verify `flux_activity_mask_from_wet_dry` for wet/dry permutations and mixed boundary sets.

### Testing
- Ran code formatting with `cargo fmt` and iteratively fixed compilation issues discovered during early test runs.
- Executed the new unit tests for the BC module with targeted `cargo test` runs (module `data::bc`) after fixes, and they passed locally in the development run.
- Performed `cargo check -q` during the rollout to validate the library built after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1602e5193c83298c320395429a21d9)