### PR TITLE
Bridge FVM diagnostics into DM adaptation workflow

### DIFF
--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -21,6 +21,7 @@ use crate::topology::refine::{
 };
 use crate::topology::sieve::Sieve;
 use std::collections::HashMap;
+use crate::diagnostics::FvmCellDiagnostic;
 
 /// Aggregated quality metrics used for adaptivity decisions.
 #[derive(Clone, Copy, Debug)]
@@ -195,6 +196,51 @@ pub struct MetricThresholds {
     pub split_face_length: f64,
     /// When enabled, enforce geometry checks during refinement.
     pub check_geometry: bool,
+}
+
+/// FV-stability-driven thresholds mapped from diagnostics.
+#[derive(Clone, Copy, Debug)]
+pub struct FvStabilityThresholds {
+    pub refine_non_orthogonality_deg: f64,
+    pub refine_skewness: f64,
+    pub refine_min_char_length: f64,
+    pub coarsen_non_orthogonality_deg: f64,
+    pub coarsen_skewness: f64,
+    pub coarsen_min_char_length: f64,
+}
+
+impl Default for FvStabilityThresholds {
+    fn default() -> Self {
+        Self {
+            refine_non_orthogonality_deg: 75.0,
+            refine_skewness: 4.0,
+            refine_min_char_length: 1.0e-8,
+            coarsen_non_orthogonality_deg: 35.0,
+            coarsen_skewness: 1.5,
+            coarsen_min_char_length: 1.0e-4,
+        }
+    }
+}
+
+pub fn select_cells_from_fvm_diagnostics(
+    cell_diags: &[FvmCellDiagnostic],
+    thresholds: FvStabilityThresholds,
+) -> AdaptivitySelection {
+    let mut selection = AdaptivitySelection::default();
+    for d in cell_diags {
+        if d.max_non_orthogonality_deg > thresholds.refine_non_orthogonality_deg
+            || d.max_skewness > thresholds.refine_skewness
+            || d.char_length < thresholds.refine_min_char_length
+        {
+            selection.refine_cells.push(d.cell);
+        } else if d.max_non_orthogonality_deg <= thresholds.coarsen_non_orthogonality_deg
+            && d.max_skewness <= thresholds.coarsen_skewness
+            && d.char_length >= thresholds.coarsen_min_char_length
+        {
+            selection.coarsen_cells.push(d.cell);
+        }
+    }
+    selection
 }
 
 impl Default for MetricThresholds {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -34,6 +34,15 @@ pub struct FvmQualityDiagnostics {
     pub cell_char_length: MetricSummary,
 }
 
+#[derive(Clone, Debug, Serialize)]
+pub struct FvmCellDiagnostic {
+    pub cell: PointId,
+    pub max_non_orthogonality_deg: f64,
+    pub max_skewness: f64,
+    pub char_length: f64,
+    pub boundary_face_count: usize,
+}
+
 #[derive(Clone, Copy, Debug, Serialize)]
 pub struct FvReadinessThresholds {
     pub max_non_orthogonality_deg: f64,
@@ -252,6 +261,78 @@ where
         skewness: summarize(&skewness),
         cell_char_length: summarize(&char_lengths),
     })
+}
+
+pub fn fvm_cell_diagnostics<CT, CS>(
+    sieve: &MeshSieve,
+    cell_types: &Section<CellType, CT>,
+    coordinates: &Coordinates<f64, CS>,
+) -> Result<Vec<FvmCellDiagnostic>, MeshSieveError>
+where
+    CT: Storage<CellType>,
+    CS: Storage<f64>,
+{
+    let face_metrics = build_fvm_face_metrics(sieve, cell_types, coordinates)?;
+    let mut by_cell: std::collections::BTreeMap<PointId, FvmCellDiagnostic> =
+        std::collections::BTreeMap::new();
+    let mut cell_area_sum: std::collections::BTreeMap<PointId, f64> =
+        std::collections::BTreeMap::new();
+    for fm in &face_metrics {
+        let denom = fm
+            .owner_to_neighbor
+            .map(norm3)
+            .unwrap_or_else(|| norm3(fm.owner_to_face));
+        let skewness = if denom > 1e-12 {
+            norm3(fm.skewness_vector) / denom
+        } else {
+            0.0
+        };
+        let owner = by_cell.entry(fm.owner).or_insert(FvmCellDiagnostic {
+            cell: fm.owner,
+            max_non_orthogonality_deg: 0.0,
+            max_skewness: 0.0,
+            char_length: 0.0,
+            boundary_face_count: 0,
+        });
+        owner.max_non_orthogonality_deg = owner
+            .max_non_orthogonality_deg
+            .max(fm.non_orthogonality_deg.unwrap_or(0.0));
+        owner.max_skewness = owner.max_skewness.max(skewness);
+        if fm.neighbor.is_none() {
+            owner.boundary_face_count += 1;
+        }
+        *cell_area_sum.entry(fm.owner).or_insert(0.0) += fm.area_magnitude;
+        if let Some(n) = fm.neighbor {
+            let neigh = by_cell.entry(n).or_insert(FvmCellDiagnostic {
+                cell: n,
+                max_non_orthogonality_deg: 0.0,
+                max_skewness: 0.0,
+                char_length: 0.0,
+                boundary_face_count: 0,
+            });
+            neigh.max_non_orthogonality_deg = neigh
+                .max_non_orthogonality_deg
+                .max(fm.non_orthogonality_deg.unwrap_or(0.0));
+            neigh.max_skewness = neigh.max_skewness.max(skewness);
+            *cell_area_sum.entry(n).or_insert(0.0) += fm.area_magnitude;
+        }
+    }
+    for (cell, diag) in &mut by_cell {
+        if let Some(cell_type) = cell_types.try_restrict(*cell).ok().and_then(|v| v.first().copied()) {
+            let mut verts: Vec<_> = sieve
+                .closure_iter([*cell])
+                .filter(|p| sieve.cone_points(*p).next().is_none())
+                .collect();
+            verts.sort_unstable();
+            verts.dedup();
+            let quality = crate::geometry::quality::cell_quality_from_section(cell_type, &verts, coordinates)?;
+            let area_sum = *cell_area_sum.get(cell).unwrap_or(&0.0);
+            if area_sum > 1e-12 {
+                diag.char_length = quality.jacobian_sign.abs() / area_sum;
+            }
+        }
+    }
+    Ok(by_cell.into_values().collect())
 }
 
 pub fn fvm_quality_diagnostics_json<CT, CS>(

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -10,9 +10,9 @@
 use std::collections::BTreeMap;
 
 use crate::adapt::{
-    BoundaryRemeshingPolicy, MetricAdaptationAction, MetricAdaptationOptions,
-    MetricAdaptationResult, MetricSplitHint, MetricTensor, MetricThresholds,
-    adapt_with_metric_policy,
+    BoundaryRemeshingPolicy, FvStabilityThresholds, MetricAdaptationAction,
+    MetricAdaptationOptions, MetricAdaptationResult, MetricSplitHint, MetricTensor,
+    MetricThresholds, adapt_with_metric_policy, select_cells_from_fvm_diagnostics,
 };
 use crate::algs::communicator::Communicator;
 use crate::algs::distribute::{
@@ -29,7 +29,8 @@ use crate::data::multi_section::constrained_section_from_label_specs;
 use crate::data::section::Section;
 use crate::data::storage::{Storage, VecStorage};
 use crate::data::{ConstrainedSection, LabelConstraintSpec};
-use crate::diagnostics::{MeshCheckOptions, run_mesh_checks};
+use crate::diagnostics::{MeshCheckOptions, fvm_cell_diagnostics, run_mesh_checks};
+use crate::geometry::fvm::build_fvm_face_metrics;
 use crate::io::MeshData;
 use crate::mesh_error::MeshSieveError;
 use crate::mesh_graph::{AdjacencyWeighting, MeshGraph, cell_adjacency_graph_with_cells};
@@ -271,6 +272,8 @@ pub struct MeshDMAdaptDiagnostics {
     pub preserved_labels: usize,
     pub failed_transfer_points: Vec<PointId>,
     pub split_hint_cells: usize,
+    pub fvm_face_metrics_cached: usize,
+    pub boundary_faces: usize,
 }
 
 /// Result of a DM-level metric adaptation call.
@@ -279,6 +282,13 @@ pub struct MeshDMMetricAdaptResult {
     pub action: MetricAdaptationAction,
     pub metrics: Vec<(PointId, crate::adapt::MetricCellMetrics)>,
     pub diagnostics: MeshDMAdaptDiagnostics,
+    pub fv_selection: Option<(Vec<PointId>, Vec<PointId>)>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MeshDMAdaptIterationOptions {
+    pub max_iterations: usize,
+    pub stop_when_below_threshold: bool,
 }
 
 /// Provenance SF maps tracking load/redistribute/section movement.
@@ -337,7 +347,45 @@ where
             action: result.action,
             metrics: result.metrics,
             diagnostics,
+            fv_selection: None,
         })
+    }
+
+    pub fn adapt_until_fv_thresholds<C>(
+        &mut self,
+        metric_section_name: &str,
+        metric: &Section<MetricTensor, VecStorage<MetricTensor>>,
+        coarsen_plan: C,
+        options: MeshDMMetricAdaptOptions,
+        fv_thresholds: FvStabilityThresholds,
+        iter: MeshDMAdaptIterationOptions,
+    ) -> Result<Vec<MeshDMMetricAdaptResult>, MeshSieveError>
+    where
+        C: Fn(&[MetricSplitHint]) -> Vec<crate::topology::coarsen::CoarsenEntity> + Copy,
+    {
+        let mut history = Vec::new();
+        for _ in 0..iter.max_iterations.max(1) {
+            let mut pass = self.adapt_with_attached_metric(
+                metric_section_name,
+                metric,
+                coarsen_plan,
+                options.clone(),
+            )?;
+            let coords = self.mesh_data.coordinates.as_ref().ok_or_else(|| MeshSieveError::MissingSectionName { name: "coordinates".into() })?;
+            let cell_types = self.mesh_data.cell_types.as_ref().ok_or_else(|| MeshSieveError::MissingSectionName { name: "cell_types".into() })?;
+            let cell_diags = fvm_cell_diagnostics(&self.mesh_data.sieve, cell_types, coords)?;
+            let selection = select_cells_from_fvm_diagnostics(&cell_diags, fv_thresholds);
+            pass.fv_selection = Some((selection.refine_cells.clone(), selection.coarsen_cells.clone()));
+            history.push(pass.clone());
+            let stop_by_action = matches!(pass.action, MetricAdaptationAction::NoChange);
+            let stop_by_threshold = iter.stop_when_below_threshold
+                && selection.refine_cells.is_empty()
+                && selection.coarsen_cells.is_empty();
+            if stop_by_action || stop_by_threshold {
+                break;
+            }
+        }
+        Ok(history)
     }
 
     /// Iteratively adapt until no action is taken or iteration budget is exhausted.
@@ -396,11 +444,22 @@ where
             .labels
             .as_ref()
             .map_or(0, |l| l.iter().count());
+        let coords = self.mesh_data.coordinates.as_ref();
+        let cell_types = self.mesh_data.cell_types.as_ref();
+        let (fvm_face_metrics_cached, boundary_faces) = if let (Some(coords), Some(cell_types)) = (coords, cell_types) {
+            let face_metrics = build_fvm_face_metrics(&self.mesh_data.sieve, cell_types, coords)?;
+            let bfaces = face_metrics.iter().filter(|m| m.neighbor.is_none()).count();
+            (face_metrics.len(), bfaces)
+        } else {
+            (0, 0)
+        };
         let diagnostics = MeshDMAdaptDiagnostics {
             changed_cells,
             preserved_labels,
             failed_transfer_points: Vec::new(),
             split_hint_cells: changed_cells,
+            fvm_face_metrics_cached,
+            boundary_faces,
         };
         match strategy {
             MeshDMTransferStrategy::TopologyOnly => {}


### PR DESCRIPTION
### Motivation
- Surface FVM (finite-volume) quality signals to the adaptation pipeline so refinement/coarsening decisions can be tied to FV solver stability targets.
- Provide DM-level iterative adapt loops that stop on FV-quality-based criteria and expose per-pass FV diagnostic history for debugging and policy tuning.

### Description
- Added `FvmCellDiagnostic` and `fvm_cell_diagnostics(...)` in `src/diagnostics.rs` to produce per-cell diagnostics (max non-orthogonality, max skewness, characteristic length, boundary-face count) derived from `build_fvm_face_metrics`.
- Added `FvStabilityThresholds` and `select_cells_from_fvm_diagnostics(...)` in `src/adapt/mod.rs` to map FVM diagnostics to `AdaptivitySelection` (refine/coarsen lists) using FV-stability-driven thresholds.
- Extended DM-level adapt data structures and workflow in `src/dm.rs` by adding `MeshDMAdaptIterationOptions`, `adapt_until_fv_thresholds(...)`, and `fv_selection` in `MeshDMMetricAdaptResult` to run iterative metric adaptation with stop criteria based on FVM diagnostics.
- Updated DM adapt diagnostics to refresh FVM geometry/face-metrics counts and boundary-face classifications after each adapt step (fields `fvm_face_metrics_cached` and `boundary_faces`), and to attach per-pass FV selection history (refine/coarsen lists) to the returned results.

### Testing
- Ran `cargo check -q` in the repository, which completed successfully (build succeeded) while emitting the repository's existing warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1607c35d888329b26bf024001f3ca0)