### PR TITLE
Refactor FvmInputs lookups and add face-loop microbenchmarks

### DIFF
--- a/benches/fvm_face_loop_bench.rs
+++ b/benches/fvm_face_loop_bench.rs
@@ -1,0 +1,116 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use mesh_sieve::discretization::runtime::{CellGeometry, FaceGeometry, FluxStencil};
+use mesh_sieve::physics::fvm::FvmInputs;
+use mesh_sieve::topology::point::PointId;
+
+fn pid(raw: u64) -> PointId {
+    PointId::new(raw + 1).expect("nonzero PointId")
+}
+
+fn synthetic_inputs(n_internal: usize, n_boundary: usize) -> FvmInputs {
+    let n_cells = n_internal + 2;
+    let mut stencils = Vec::with_capacity(n_internal + n_boundary);
+    let mut cell_geometry = Vec::with_capacity(n_cells);
+    let mut face_geometry = Vec::with_capacity(n_internal + n_boundary);
+
+    for c in 0..n_cells {
+        let cpid = pid(c as u64);
+        cell_geometry.push((
+            cpid,
+            CellGeometry {
+                centroid: vec![c as f64, 0.0, 0.0],
+                volume: 1.0,
+            },
+        ));
+    }
+
+    for i in 0..n_internal {
+        let face = pid((100_000 + i) as u64);
+        let left = pid(i as u64);
+        let right = pid((i + 1) as u64);
+        stencils.push(FluxStencil {
+            face,
+            left,
+            right: Some(right),
+        });
+        face_geometry.push((
+            face,
+            FaceGeometry {
+                face,
+                centroid: vec![i as f64 + 0.5, 0.0, 0.0],
+                normal: vec![1.0, 0.0, 0.0],
+                area: 1.0,
+                neighbors: vec![left, right],
+            },
+        ));
+    }
+
+    for i in 0..n_boundary {
+        let face = pid((200_000 + i) as u64);
+        let left = pid((i % n_cells) as u64);
+        stencils.push(FluxStencil {
+            face,
+            left,
+            right: None,
+        });
+        face_geometry.push((
+            face,
+            FaceGeometry {
+                face,
+                centroid: vec![i as f64, 1.0, 0.0],
+                normal: vec![0.0, 1.0, 0.0],
+                area: 1.0,
+                neighbors: vec![left],
+            },
+        ));
+    }
+
+    FvmInputs::new(stencils, cell_geometry, face_geometry)
+}
+
+fn bench_fvm_face_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fvm_face_loop");
+    for &(internal, boundary) in &[(100_000usize, 10_000usize), (500_000, 50_000)] {
+        let mut inputs = synthetic_inputs(internal, boundary);
+        inputs.build_packed_cache();
+
+        group.bench_with_input(
+            BenchmarkId::new("lookup_maps", internal),
+            &internal,
+            |b, _| {
+                b.iter(|| {
+                    let mut accum = 0.0;
+                    for s in inputs.internal_faces() {
+                        let fg = inputs.face_metrics(s.face).unwrap();
+                        let lc = inputs.cell_metrics(s.left).unwrap();
+                        let rc = inputs.cell_metrics(s.right.unwrap()).unwrap();
+                        accum += fg.area + lc.volume + rc.volume;
+                    }
+                    black_box(accum);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("packed_cache", internal),
+            &internal,
+            |b, _| {
+                let packed = inputs.packed().unwrap();
+                b.iter(|| {
+                    let mut accum = 0.0;
+                    for s in &packed.internal_faces {
+                        let fg = &inputs.face_geometry[s.face_geom_idx].1;
+                        let lc = &inputs.cell_geometry[s.owner_cell_geom_idx].1;
+                        let rc = &inputs.cell_geometry[s.neighbor_cell_geom_idx].1;
+                        accum += fg.area + lc.volume + rc.volume;
+                    }
+                    black_box(accum);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_fvm_face_loop);
+criterion_main!(benches);

--- a/src/physics/fvm.rs
+++ b/src/physics/fvm.rs
@@ -164,6 +164,35 @@ pub struct FvmInputs {
     pub loops: FvmFaceLoops,
     pub cell_geometry: Vec<(PointId, CellGeometry)>,
     pub face_geometry: Vec<(PointId, FaceGeometry)>,
+    cell_index: HashMap<PointId, usize>,
+    face_index: HashMap<PointId, usize>,
+    internal_owner_neighbor_idx: Vec<(usize, usize)>,
+    boundary_owner_idx: Vec<usize>,
+    packed_cache: Option<PackedFvmInputs>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PackedFvmInputs {
+    pub internal_faces: Vec<PackedInternalFace>,
+    pub boundary_faces: Vec<PackedBoundaryFace>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PackedInternalFace {
+    pub face: PointId,
+    pub owner: PointId,
+    pub neighbor: PointId,
+    pub face_geom_idx: usize,
+    pub owner_cell_geom_idx: usize,
+    pub neighbor_cell_geom_idx: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct PackedBoundaryFace {
+    pub face: PointId,
+    pub owner: PointId,
+    pub face_geom_idx: usize,
+    pub owner_cell_geom_idx: usize,
 }
 
 impl FvmInputs {
@@ -180,11 +209,18 @@ impl FvmInputs {
                 loops.boundary.push(stencil);
             }
         }
-        Self {
+        let mut inputs = Self {
             loops,
             cell_geometry,
             face_geometry,
-        }
+            cell_index: HashMap::new(),
+            face_index: HashMap::new(),
+            internal_owner_neighbor_idx: Vec::new(),
+            boundary_owner_idx: Vec::new(),
+            packed_cache: None,
+        };
+        inputs.rebuild_indices();
+        inputs
     }
 
     pub fn internal_faces(&self) -> impl Iterator<Item = &FluxStencil> {
@@ -194,14 +230,96 @@ impl FvmInputs {
         self.loops.boundary.iter()
     }
     pub fn cell_metrics(&self, cell: PointId) -> Option<&CellGeometry> {
-        self.cell_geometry
-            .iter()
-            .find_map(|(id, m)| (*id == cell).then_some(m))
+        self.cell_index
+            .get(&cell)
+            .and_then(|&idx| self.cell_geometry.get(idx).map(|(_, m)| m))
     }
     pub fn face_metrics(&self, face: PointId) -> Option<&FaceGeometry> {
-        self.face_geometry
-            .iter()
-            .find_map(|(id, m)| (*id == face).then_some(m))
+        self.face_index
+            .get(&face)
+            .and_then(|&idx| self.face_geometry.get(idx).map(|(_, m)| m))
+    }
+
+    pub fn internal_owner_neighbor_indices(&self) -> &[(usize, usize)] {
+        &self.internal_owner_neighbor_idx
+    }
+
+    pub fn boundary_owner_indices(&self) -> &[usize] {
+        &self.boundary_owner_idx
+    }
+
+    pub fn packed(&self) -> Option<&PackedFvmInputs> {
+        self.packed_cache.as_ref()
+    }
+
+    pub fn build_packed_cache(&mut self) {
+        let mut internal_faces = Vec::with_capacity(self.loops.internal.len());
+        let mut boundary_faces = Vec::with_capacity(self.loops.boundary.len());
+        for stencil in &self.loops.internal {
+            if let (Some(&fi), Some(&oi), Some(neighbor), Some(&ni)) = (
+                self.face_index.get(&stencil.face),
+                self.cell_index.get(&stencil.left),
+                stencil.right,
+                stencil.right.and_then(|r| self.cell_index.get(&r)),
+            ) {
+                internal_faces.push(PackedInternalFace {
+                    face: stencil.face,
+                    owner: stencil.left,
+                    neighbor,
+                    face_geom_idx: fi,
+                    owner_cell_geom_idx: oi,
+                    neighbor_cell_geom_idx: ni,
+                });
+            }
+        }
+        for stencil in &self.loops.boundary {
+            if let (Some(&fi), Some(&oi)) = (
+                self.face_index.get(&stencil.face),
+                self.cell_index.get(&stencil.left),
+            ) {
+                boundary_faces.push(PackedBoundaryFace {
+                    face: stencil.face,
+                    owner: stencil.left,
+                    face_geom_idx: fi,
+                    owner_cell_geom_idx: oi,
+                });
+            }
+        }
+        self.packed_cache = Some(PackedFvmInputs {
+            internal_faces,
+            boundary_faces,
+        });
+    }
+
+    fn rebuild_indices(&mut self) {
+        self.cell_index.clear();
+        self.face_index.clear();
+        for (idx, (id, _)) in self.cell_geometry.iter().enumerate() {
+            self.cell_index.insert(*id, idx);
+        }
+        for (idx, (id, _)) in self.face_geometry.iter().enumerate() {
+            self.face_index.insert(*id, idx);
+        }
+        self.internal_owner_neighbor_idx.clear();
+        self.internal_owner_neighbor_idx
+            .reserve(self.loops.internal.len());
+        for stencil in &self.loops.internal {
+            if let (Some(&owner), Some(neighbor), Some(&neigh)) = (
+                self.cell_index.get(&stencil.left),
+                stencil.right,
+                stencil.right.and_then(|r| self.cell_index.get(&r)),
+            ) {
+                let _ = neighbor;
+                self.internal_owner_neighbor_idx.push((owner, neigh));
+            }
+        }
+        self.boundary_owner_idx.clear();
+        self.boundary_owner_idx.reserve(self.loops.boundary.len());
+        for stencil in &self.loops.boundary {
+            if let Some(&owner) = self.cell_index.get(&stencil.left) {
+                self.boundary_owner_idx.push(owner);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

- Remove repeated linear searches over `cell_geometry` / `face_geometry` to enable O(1) geometry lookups in hot face loops.  
- Precompute owner/neighbor index tables to avoid repeated id-to-index resolution during internal and boundary assembly loops.  
- Provide an optional packed representation to feed hot assembly kernels and measure the performance impact with micro-benchmarks.

### Description

- Add `cell_index: HashMap<PointId, usize>` and `face_index: HashMap<PointId, usize>` and change `cell_metrics` / `face_metrics` to use these maps for O(1) lookups.  
- Add precomputed index tables `internal_owner_neighbor_idx: Vec<(usize, usize)>` and `boundary_owner_idx: Vec<usize>` with accessors to drive indexed loop kernels.  
- Introduce `PackedFvmInputs`, `PackedInternalFace`, and `PackedBoundaryFace` plus `build_packed_cache()` to create an optional contiguous, index-based cache for hot paths.  
- Add a Criterion micro-benchmark `benches/fvm_face_loop_bench.rs` that synthesizes large input sets and compares `lookup_maps` vs `packed_cache` face-loop throughput.

### Testing

- Ran `cargo fmt` successfully.  
- Ran `cargo test --lib` which executed the library test-suite and passed (`215` tests passed).  
- A full `cargo test -q` (including examples) surfaced a pre-existing, unrelated example compile error in `examples/dm_metric_label_adapt.rs` that is outside the scope of this refactor.  
- Built the new micro-benchmark with `cargo bench --bench fvm_face_loop_bench --no-run` as part of validation to ensure bench compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160c2f844483298c8bd61036a12542)