### PR TITLE
Add focused FV preflight error-path test coverage

### DIFF
--- a/src/physics/fvm.rs
+++ b/src/physics/fvm.rs
@@ -1629,4 +1629,105 @@ mod tests {
             FvmAssemblyError::LabelMappedToUnknownFace { .. }
         ));
     }
+
+    #[test]
+    fn preflight_reports_missing_metrics_and_internal_label_mapping() {
+        let c0 = pid(1);
+        let c1 = pid(2);
+        let fi = pid(41);
+        let fb = pid(42);
+
+        let inputs_missing_face_metric = FvmInputs::new(
+            [FluxStencil {
+                face: fb,
+                left: c0,
+                right: None,
+            }],
+            vec![(
+                c0,
+                CellGeometry {
+                    centroid: vec![0.0, 0.0],
+                    volume: 1.0,
+                },
+            )],
+            vec![],
+        );
+        let err = preflight_fv_assembly(
+            &inputs_missing_face_metric,
+            &HashMap::new(),
+            &HashSet::new(),
+        )
+        .unwrap_err();
+        assert_eq!(err, FvmAssemblyError::MissingFaceMetric { face: fb });
+
+        let inputs_missing_cell_metric = FvmInputs::new(
+            [FluxStencil {
+                face: fb,
+                left: c0,
+                right: None,
+            }],
+            vec![],
+            vec![(
+                fb,
+                FaceGeometry {
+                    face: fb,
+                    centroid: vec![0.0, 0.0],
+                    normal: vec![1.0, 0.0],
+                    area: 1.0,
+                    neighbors: vec![c0],
+                },
+            )],
+        );
+        let err = preflight_fv_assembly(
+            &inputs_missing_cell_metric,
+            &HashMap::new(),
+            &HashSet::new(),
+        )
+        .unwrap_err();
+        assert_eq!(err, FvmAssemblyError::MissingCellMetric { cell: c0 });
+
+        let inputs_internal_face_label = FvmInputs::new(
+            [FluxStencil {
+                face: fi,
+                left: c0,
+                right: Some(c1),
+            }],
+            vec![
+                (
+                    c0,
+                    CellGeometry {
+                        centroid: vec![0.0, 0.0],
+                        volume: 1.0,
+                    },
+                ),
+                (
+                    c1,
+                    CellGeometry {
+                        centroid: vec![1.0, 0.0],
+                        volume: 1.0,
+                    },
+                ),
+            ],
+            vec![(
+                fi,
+                FaceGeometry {
+                    face: fi,
+                    centroid: vec![0.5, 0.0],
+                    normal: vec![1.0, 0.0],
+                    area: 1.0,
+                    neighbors: vec![c0, c1],
+                },
+            )],
+        );
+        let err = preflight_fv_assembly(
+            &inputs_internal_face_label,
+            &HashMap::from([(fi, FvBoundaryBranch::Open)]),
+            &HashSet::new(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            FvmAssemblyError::LabelMappedToInternalFace { face: fi }
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure there is a single canonical `preflight_fv_assembly` signature and add unit coverage for its error paths to improve correctness and maintainability.

### Description
- Confirmed the `preflight_fv_assembly` declaration adjacent to `assemble_fv_system` is canonical (single signature) and left public behavior unchanged.
- Added a focused unit test `preflight_reports_missing_metrics_and_internal_label_mapping` in `src/physics/fvm.rs` that exercises missing face metrics, missing cell metrics, and a boundary label mapped to an internal face.
- Applied formatting to `src/physics/fvm.rs` to keep style consistent.

### Testing
- Ran `cargo fmt -- src/physics/fvm.rs` which completed successfully.
- Ran the targeted unit test with `cargo test preflight_reports_missing_metrics_and_internal_label_mapping --lib` which passed.
- Ran `cargo clippy --lib` for lint checks which failed due to pre-existing repository-wide clippy issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1737bb33248329a8f499b1e865470d)