### PR TITLE
Improve PETSc HDF5 DMPlex compatibility and regression coverage

### DIFF
--- a/src/io/petsc_hdf5.rs
+++ b/src/io/petsc_hdf5.rs
@@ -92,6 +92,7 @@ const DATASET_SECTION_POINTS: &str = "points";
 const DATASET_SECTION_DOFS: &str = "dofs";
 const DATASET_SECTION_OFFSETS: &str = "offsets";
 const DATASET_CELL_TYPES: &str = "cell_types";
+const DATASET_REDISTRIBUTION_MAP_ID: &str = "redistribution_map_id";
 
 /// Options controlling DMPlex HDF5 path names.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -292,21 +293,26 @@ pub fn read_mesh_from_petsc_hdf5_with_options(
     ),
     MeshSieveError,
 > {
-    if let Ok(dataset) = file.dataset(DATASET_VERSION) {
-        let version: Vec<i32> = dataset.read_raw()?;
-        if matches!(options.mode, PetscLoadMode::Strict)
-            && !version.is_empty()
-            && version[0] != DMPLEX_STORAGE_VERSION
-        {
-            return Err(MeshSieveError::MeshIoParse(format!(
-                "unsupported DMPlex HDF5 storage version {}; expected {DMPLEX_STORAGE_VERSION}",
-                version[0]
-            )));
-        }
+    let file_storage_version = file
+        .dataset(DATASET_VERSION)
+        .ok()
+        .and_then(|d| d.read_raw::<i32>().ok())
+        .and_then(|v| v.first().copied())
+        .unwrap_or(DMPLEX_STORAGE_VERSION);
+    if matches!(options.mode, PetscLoadMode::Strict) && !matches!(file_storage_version, 2 | 3) {
+        return Err(MeshSieveError::MeshIoParse(format!(
+            "unsupported DMPlex HDF5 storage version {file_storage_version}; expected one of [2, 3]"
+        )));
     }
 
     let topology_root = file.group(&format!("/{GROUP_TOPOLOGIES}/{mesh_name}"))?;
-    let topology = topology_root.group(GROUP_TOPOLOGY)?;
+    let topology = if let Ok(group) = topology_root.group(GROUP_TOPOLOGY) {
+        group
+    } else if let Ok(group) = topology_root.group("mesh") {
+        group
+    } else {
+        topology_root.clone()
+    };
     let order = read_permutation_checked(&topology, options.mode)?;
     let mut sieve = MeshSieve::default();
     read_strata(&topology, &order, &mut sieve)?;
@@ -334,16 +340,15 @@ pub fn read_mesh_from_petsc_hdf5_with_options(
             discretization: None,
         },
         PetscProvenance {
-            storage_version: file
-                .dataset(DATASET_VERSION)
-                .ok()
-                .and_then(|d| d.read_raw::<i32>().ok())
-                .and_then(|v| v.first().copied())
-                .unwrap_or(DMPLEX_STORAGE_VERSION),
+            storage_version: file_storage_version,
             permutation_source: format!(
                 "/{GROUP_TOPOLOGIES}/{mesh_name}/{GROUP_TOPOLOGY}/{DATASET_PERMUTATION}"
             ),
-            redistribution_map_id: None,
+            redistribution_map_id: file
+                .dataset(DATASET_REDISTRIBUTION_MAP_ID)
+                .ok()
+                .and_then(|d| d.read_raw::<hdf5::types::VarLenUnicode>().ok())
+                .and_then(|v| v.first().map(|s| s.as_str().to_owned())),
         },
     ))
 }
@@ -788,6 +793,10 @@ fn dmplex_to_cell_type(code: i32) -> Result<CellType, MeshSieveError> {
         5 => Ok(CellType::Hexahedron),
         6 => Ok(CellType::Prism),
         7 => Ok(CellType::Pyramid),
+        8 => Ok(CellType::Polygon(0)),
+        9 => Ok(CellType::Polyhedron),
+        10 => Ok(CellType::Simplex(4)),
+        11 => Ok(CellType::Simplex(5)),
         _ => Err(MeshSieveError::MeshIoParse(format!(
             "unknown DMPlex cell type code {code}"
         ))),

--- a/tests/petsc_hdf5_roundtrip.rs
+++ b/tests/petsc_hdf5_roundtrip.rs
@@ -13,6 +13,7 @@ use mesh_sieve::topology::labels::LabelSet;
 use mesh_sieve::topology::point::PointId;
 use mesh_sieve::topology::sieve::{MeshSieve, OrientedSieve, Sieve};
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
 fn p(id: u64) -> PointId {
     PointId::new(id).unwrap()
@@ -209,5 +210,67 @@ fn permissive_mode_tolerates_vector_layout_mismatch() {
         filter: PetscLoadFilter::default(),
     };
     assert!(read_mesh_from_petsc_hdf5_with_options(&file, "mesh", "dm", &permissive).is_ok());
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn strict_mode_accepts_legacy_storage_version_2() {
+    let mesh = fixture_mesh(false);
+    let path = std::env::temp_dir().join("mesh_sieve_legacy_version2_fixture.h5");
+    let _ = std::fs::remove_file(&path);
+    let file = File::create(&path).unwrap();
+    write_mesh_to_petsc_hdf5(&file, &mesh, "mesh", "dm").unwrap();
+    file.dataset("dmplex_storage_version")
+        .unwrap()
+        .write(&[2i32])
+        .unwrap();
+    assert!(read_mesh_from_petsc_hdf5(&file, "mesh", "dm").is_ok());
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn reader_supports_topology_dataset_layout_at_mesh_root() {
+    let mesh = fixture_mesh(false);
+    let path = std::env::temp_dir().join("mesh_sieve_mesh_root_layout_fixture.h5");
+    let _ = std::fs::remove_file(&path);
+    let file = File::create(&path).unwrap();
+    write_mesh_to_petsc_hdf5(&file, &mesh, "mesh", "dm").unwrap();
+    let root = file.group("/topologies/mesh").unwrap();
+    root.link_hard("topology/permutation", "permutation").unwrap();
+    root.link_hard("topology/strata", "strata").unwrap();
+    root.link_hard("topology/cell_types", "cell_types").unwrap();
+    root.unlink("topology").unwrap();
+    assert!(read_mesh_from_petsc_hdf5(&file, "mesh", "dm").is_ok());
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn reads_additional_dmplex_cell_type_codes_and_provenance_map_id() {
+    let mesh = fixture_mesh(false);
+    let path = std::env::temp_dir().join("mesh_sieve_dmplex_celltype_compat_fixture.h5");
+    let _ = std::fs::remove_file(&path);
+    let file = File::create(&path).unwrap();
+    write_mesh_to_petsc_hdf5(&file, &mesh, "mesh", "dm").unwrap();
+    let mut codes = file
+        .dataset("/topologies/mesh/topology/cell_types")
+        .unwrap()
+        .read_raw::<i32>()
+        .unwrap();
+    if let Some(first) = codes.first_mut() {
+        *first = 8;
+    }
+    file.dataset("/topologies/mesh/topology/cell_types")
+        .unwrap()
+        .write(&codes)
+        .unwrap();
+    file.new_dataset_builder()
+        .with_data(&[hdf5::types::VarLenUnicode::from_str("redistribute:rank0").unwrap()])
+        .create("redistribution_map_id")
+        .unwrap();
+    let (_loaded, provenance) =
+        read_mesh_from_petsc_hdf5_with_options(&file, "mesh", "dm", &PetscLoadOptions::default())
+            .unwrap();
+    assert_eq!(provenance.storage_version, DMPLEX_STORAGE_VERSION);
+    assert_eq!(provenance.redistribution_map_id.as_deref(), Some("redistribute:rank0"));
     let _ = std::fs::remove_file(&path);
 }


### PR DESCRIPTION
### Motivation
- Make the PETSc DMPlex HDF5 reader tolerant of known layout and storage-version variants so meshes exported by different PETSc workflows can be loaded without brittle errors. 
- Preserve provenance fields (storage version and redistribution identifiers) so downstream DM workflows can observe how a mesh was produced/redistributed. 

### Description
- Relax strict storage-version checking so `read_mesh_from_petsc_hdf5_with_options` accepts known compatible versions `2` and `3` in `Strict` mode instead of only matching `DMPLEX_STORAGE_VERSION` exactly. 
- Add topology-group fallbacks so the reader will try `/topologies/<mesh>/topology`, `/topologies/<mesh>/mesh`, and `/topologies/<mesh>` to handle alternate DMPlex hierarchy layouts. 
- Read and surface provenance metadata by returning `storage_version` from the file and reading an optional `redistribution_map_id` dataset into `PetscProvenance`. 
- Extend DMPlex cell-type decoding in `dmplex_to_cell_type` to cover additional known numeric codes (`8`, `9`, `10`, `11`) so imports no longer error on those variants. 
- Add regression fixtures/tests in `tests/petsc_hdf5_roundtrip.rs` to cover legacy storage version `2`, alternate topology layout at mesh-root, and a roundtrip/read check for additional DMPlex cell-type codes plus redistribution provenance. 

### Testing
- Ran `cargo test --test petsc_hdf5_roundtrip` and all tests passed (`7` tests, `0` failed). 
- The new tests are `strict_mode_accepts_legacy_storage_version_2`, `reader_supports_topology_dataset_layout_at_mesh_root`, and `reads_additional_dmplex_cell_type_codes_and_provenance_map_id` (added under `tests/petsc_hdf5_roundtrip.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174b24e1e8832990527288683f8683)