### PR TITLE
Add DM prepare-for-solve diagnostics

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -19,6 +19,194 @@ use crate::topology::validation::{
     validate_overlap_ownership_topology,
 };
 
+/// Options controlling the DM-level prepare-for-solve diagnostic gate.
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct PrepareForSolveOptions {
+    /// Require coordinate metadata before solve preparation can proceed.
+    pub require_coordinates: bool,
+    /// Require cell-type metadata before solve preparation can proceed.
+    pub require_cell_types: bool,
+    /// Require ownership metadata before solve preparation can proceed.
+    pub require_ownership: bool,
+    /// Require an overlap graph even when no local ghost points are present.
+    pub require_overlap: bool,
+    /// Complete/synchronize coordinate and field sections for ghost points when overlap is available.
+    pub synchronize_ghost_sections: bool,
+    /// In a serial communicator, synthesize rank-local ownership when the DM has none.
+    pub create_serial_ownership: bool,
+}
+
+impl Default for PrepareForSolveOptions {
+    fn default() -> Self {
+        Self {
+            require_coordinates: true,
+            require_cell_types: true,
+            require_ownership: true,
+            require_overlap: false,
+            synchronize_ghost_sections: true,
+            create_serial_ownership: true,
+        }
+    }
+}
+
+/// Structured status for one prepare-for-solve prerequisite.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PrepareForSolvePrerequisiteDiagnostic {
+    pub name: &'static str,
+    pub required: bool,
+    pub present: bool,
+    pub complete: bool,
+    pub detail: String,
+}
+
+/// Structured status for one prepare-for-solve pipeline step.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PrepareForSolveStepDiagnostic {
+    pub name: &'static str,
+    pub status: &'static str,
+    pub detail: String,
+}
+
+/// Stable summary of the generated matrix-preallocation graph.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct PrepareForSolvePreallocationDiagnostic {
+    pub rows: usize,
+    pub edges: usize,
+    pub order: Vec<PointId>,
+    pub row_nnz: Vec<usize>,
+}
+
+/// Structured, serializable output of the DM prepare-for-solve pipeline.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct PrepareForSolveDiagnostics {
+    pub ready: bool,
+    pub prerequisites: Vec<PrepareForSolvePrerequisiteDiagnostic>,
+    pub steps: Vec<PrepareForSolveStepDiagnostic>,
+    pub global_sections: Vec<String>,
+    pub preallocation: Option<PrepareForSolvePreallocationDiagnostic>,
+    pub synchronized_sections: Vec<String>,
+}
+
+impl PrepareForSolveDiagnostics {
+    /// Return true if any required prerequisite is absent or incomplete.
+    pub fn has_missing_required_prerequisites(&self) -> bool {
+        self.prerequisites
+            .iter()
+            .any(|p| p.required && (!p.present || !p.complete))
+    }
+}
+
+/// Serialize prepare-for-solve diagnostics with stable field ordering.
+pub fn prepare_for_solve_diagnostics_json(
+    diagnostics: &PrepareForSolveDiagnostics,
+) -> Result<String, MeshSieveError> {
+    serde_json::to_string(diagnostics)
+        .map_err(|e| MeshSieveError::InvalidGeometry(format!("serialize prepare diagnostics: {e}")))
+}
+
+/// Build prerequisite diagnostics for a DM-level solve-preparation gate.
+pub fn prepare_for_solve_prerequisites<V, St, CtSt>(
+    sieve: &MeshSieve,
+    coords: Option<&Coordinates<V, St>>,
+    cell_types: Option<&Section<CellType, CtSt>>,
+    ownership: Option<&PointOwnership>,
+    overlap: Option<&Overlap>,
+    options: PrepareForSolveOptions,
+) -> Result<Vec<PrepareForSolvePrerequisiteDiagnostic>, MeshSieveError>
+where
+    St: Storage<V>,
+    CtSt: Storage<CellType>,
+{
+    let strata = compute_strata(sieve)?;
+    let vertices: Vec<PointId> = strata
+        .depth
+        .iter()
+        .filter_map(|(&point, &depth)| (depth == 0).then_some(point))
+        .collect();
+    let cells = strata.strata.first().cloned().unwrap_or_default();
+    let points = sieve.points_sorted();
+    let ghost_count = ownership
+        .map(|o| o.ghost_points().count())
+        .unwrap_or_default();
+    let overlap_required = options.require_overlap || ghost_count > 0;
+
+    let mut diagnostics = Vec::new();
+
+    let missing_coords = coords.map_or(vertices.len(), |coords| {
+        vertices
+            .iter()
+            .filter(|point| !coords.section().atlas().contains(**point))
+            .count()
+    });
+    diagnostics.push(PrepareForSolvePrerequisiteDiagnostic {
+        name: "coordinates",
+        required: options.require_coordinates,
+        present: coords.is_some(),
+        complete: coords.is_some() && missing_coords == 0,
+        detail: if coords.is_some() {
+            format!(
+                "vertex_points={}, missing_vertex_coordinates={missing_coords}",
+                vertices.len()
+            )
+        } else {
+            "coordinate section is not attached".to_string()
+        },
+    });
+
+    let missing_cell_types = cell_types.map_or(cells.len(), |cell_types| {
+        cells
+            .iter()
+            .filter(|point| !cell_types.atlas().contains(**point))
+            .count()
+    });
+    diagnostics.push(PrepareForSolvePrerequisiteDiagnostic {
+        name: "cell_types",
+        required: options.require_cell_types,
+        present: cell_types.is_some(),
+        complete: cell_types.is_some() && missing_cell_types == 0,
+        detail: if cell_types.is_some() {
+            format!(
+                "cells={}, missing_cell_types={missing_cell_types}",
+                cells.len()
+            )
+        } else {
+            "cell-type section is not attached".to_string()
+        },
+    });
+
+    let missing_ownership = ownership.map_or(points.len(), |ownership| {
+        points
+            .iter()
+            .filter(|point| ownership.entry(**point).is_none())
+            .count()
+    });
+    diagnostics.push(PrepareForSolvePrerequisiteDiagnostic {
+        name: "ownership",
+        required: options.require_ownership,
+        present: ownership.is_some(),
+        complete: ownership.is_some() && missing_ownership == 0,
+        detail: if ownership.is_some() {
+            format!("topology_points={}, missing_ownership={missing_ownership}, ghost_points={ghost_count}", points.len())
+        } else {
+            "ownership map is not attached".to_string()
+        },
+    });
+
+    diagnostics.push(PrepareForSolvePrerequisiteDiagnostic {
+        name: "overlap",
+        required: overlap_required,
+        present: overlap.is_some(),
+        complete: !overlap_required || overlap.is_some(),
+        detail: if overlap.is_some() {
+            format!("ghost_points={ghost_count}, overlap_required={overlap_required}")
+        } else {
+            format!("overlap graph is not attached; ghost_points={ghost_count}, overlap_required={overlap_required}")
+        },
+    });
+
+    Ok(diagnostics)
+}
+
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct MetricSummary {
     pub max: f64,
@@ -318,14 +506,22 @@ where
         }
     }
     for (cell, diag) in &mut by_cell {
-        if let Some(cell_type) = cell_types.try_restrict(*cell).ok().and_then(|v| v.first().copied()) {
+        if let Some(cell_type) = cell_types
+            .try_restrict(*cell)
+            .ok()
+            .and_then(|v| v.first().copied())
+        {
             let mut verts: Vec<_> = sieve
                 .closure_iter([*cell])
                 .filter(|p| sieve.cone_points(*p).next().is_none())
                 .collect();
             verts.sort_unstable();
             verts.dedup();
-            let quality = crate::geometry::quality::cell_quality_from_section(cell_type, &verts, coordinates)?;
+            let quality = crate::geometry::quality::cell_quality_from_section(
+                cell_type,
+                &verts,
+                coordinates,
+            )?;
             let area_sum = *cell_area_sum.get(cell).unwrap_or(&0.0);
             if area_sum > 1e-12 {
                 diag.char_length = quality.jacobian_sign.abs() / area_sum;

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -33,8 +33,9 @@ use crate::data::section::Section;
 use crate::data::storage::{Storage, VecStorage};
 use crate::data::{ConstrainedSection, LabelConstraintSpec};
 use crate::diagnostics::{
-    FvmQualityDiagnostics, MeshCheckOptions, fvm_cell_diagnostics, fvm_quality_diagnostics,
-    run_mesh_checks,
+    FvmQualityDiagnostics, MeshCheckOptions, PrepareForSolveDiagnostics, PrepareForSolveOptions,
+    PrepareForSolvePreallocationDiagnostic, PrepareForSolveStepDiagnostic, fvm_cell_diagnostics,
+    fvm_quality_diagnostics, prepare_for_solve_prerequisites, run_mesh_checks,
 };
 use crate::geometry::fvm::build_fvm_face_metrics;
 use crate::io::MeshData;
@@ -1161,6 +1162,153 @@ where
             order: graph.order,
             row_nnz,
         }
+    }
+
+    /// Prepare this DM for solver assembly with a DMPLEX-like setup flow.
+    ///
+    /// The flow is intentionally deterministic: prerequisite diagnostics,
+    /// section/global numbering, matrix preallocation, ownership/overlap
+    /// validation, and optional ghost-section synchronization are all reported
+    /// in stable point/name order. Missing required prerequisites are returned
+    /// as structured diagnostics instead of panicking or partially preparing the
+    /// DM.
+    pub fn prepare_for_solve<C>(
+        &mut self,
+        comm: &C,
+        options: PrepareForSolveOptions,
+    ) -> Result<PrepareForSolveDiagnostics, MeshSieveError>
+    where
+        C: Communicator + Sync,
+        V: Send + PartialEq + bytemuck::Pod + 'static,
+    {
+        if options.create_serial_ownership && comm.size() == 1 {
+            self.ensure_serial_ownership(comm.rank())?;
+        }
+
+        let prerequisites = prepare_for_solve_prerequisites(
+            &self.mesh_data.sieve,
+            self.mesh_data.coordinates.as_ref(),
+            self.mesh_data.cell_types.as_ref(),
+            self.ownership.as_ref(),
+            self.overlap.as_ref(),
+            options,
+        )?;
+        let mut diagnostics = PrepareForSolveDiagnostics {
+            ready: false,
+            prerequisites,
+            ..PrepareForSolveDiagnostics::default()
+        };
+
+        if diagnostics.has_missing_required_prerequisites() {
+            diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                name: "section_global_numbering",
+                status: "skipped",
+                detail: "required prerequisites are missing".to_string(),
+            });
+            diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                name: "matrix_preallocation_graph",
+                status: "skipped",
+                detail: "required prerequisites are missing".to_string(),
+            });
+            diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                name: "ownership_overlap_checks",
+                status: "skipped",
+                detail: "required prerequisites are missing".to_string(),
+            });
+            diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                name: "section_synchronization",
+                status: "skipped",
+                detail: "required prerequisites are missing".to_string(),
+            });
+            return Ok(diagnostics);
+        }
+
+        self.build_global_sections(comm)?;
+        diagnostics.global_sections = self.global_sections.keys().cloned().collect();
+        diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+            name: "section_global_numbering",
+            status: "completed",
+            detail: format!("numbered_sections={}", diagnostics.global_sections.len()),
+        });
+
+        let cells = self.height_stratum(0)?;
+        let preallocation = self.matrix_preallocation_graph(cells, Default::default());
+        diagnostics.preallocation = Some(PrepareForSolvePreallocationDiagnostic {
+            rows: preallocation.order.len(),
+            edges: preallocation.adjncy.len(),
+            order: preallocation.order,
+            row_nnz: preallocation.row_nnz,
+        });
+        diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+            name: "matrix_preallocation_graph",
+            status: "completed",
+            detail: diagnostics
+                .preallocation
+                .as_ref()
+                .map(|p| format!("rows={}, edges={}", p.rows, p.edges))
+                .unwrap_or_else(|| "rows=0, edges=0".to_string()),
+        });
+
+        run_mesh_checks(
+            &mut self.mesh_data.sieve,
+            self.mesh_data.cell_types.as_ref(),
+            self.mesh_data.coordinates.as_ref(),
+            self.ownership.as_ref(),
+            self.overlap.as_ref(),
+            self.mesh_data.sections.values(),
+            MeshCheckOptions {
+                check_symmetry: true,
+                check_skeleton: true,
+                check_faces: true,
+                check_geometry: true,
+                check_overlap: true,
+                check_ownership: true,
+                check_sections: true,
+            },
+        )?;
+        diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+            name: "ownership_overlap_checks",
+            status: "completed",
+            detail: "ownership and overlap topology are consistent".to_string(),
+        });
+
+        if options.synchronize_ghost_sections {
+            let has_overlap = self.overlap.is_some();
+            let has_ownership = self.ownership.is_some();
+            if has_overlap && has_ownership {
+                let mut synchronized = Vec::new();
+                if self.mesh_data.coordinates.is_some() {
+                    synchronized.push("coordinates".to_string());
+                }
+                synchronized.extend(self.mesh_data.sections.keys().cloned());
+                self.distribute_fields(comm)?;
+                diagnostics.synchronized_sections = synchronized;
+                diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                    name: "section_synchronization",
+                    status: "completed",
+                    detail: format!(
+                        "synchronized_sections={}",
+                        diagnostics.synchronized_sections.len()
+                    ),
+                });
+            } else {
+                diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                    name: "section_synchronization",
+                    status: "skipped",
+                    detail: "no overlap/ownership state available for ghost synchronization"
+                        .to_string(),
+                });
+            }
+        } else {
+            diagnostics.steps.push(PrepareForSolveStepDiagnostic {
+                name: "section_synchronization",
+                status: "skipped",
+                detail: "ghost section synchronization disabled".to_string(),
+            });
+        }
+
+        diagnostics.ready = true;
+        Ok(diagnostics)
     }
 
     /// Create a zero-initialized local vector matching a named section.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,11 @@ pub mod prelude {
         mesh_dot_graph, mesh_json_debug_dump, mesh_text_summary, mesh_tikz_viewer, run_mesh_checks,
         run_mesh_checks_f64_with_report,
     };
+    pub use crate::diagnostics::{
+        PrepareForSolveDiagnostics, PrepareForSolveOptions, PrepareForSolvePreallocationDiagnostic,
+        PrepareForSolvePrerequisiteDiagnostic, PrepareForSolveStepDiagnostic,
+        prepare_for_solve_diagnostics_json,
+    };
     pub use crate::discretization::runtime::{
         Basis, BasisFamily, CellGeometry, ClosureDof, CsrPattern, DofMap, ElementRuntime,
         ElementTabulation, FaceGeometry, FiniteVolumeMetadata, FluxStencil, QuadratureRule,

--- a/tests/mesh_dm.rs
+++ b/tests/mesh_dm.rs
@@ -140,3 +140,110 @@ fn mesh_dm_label_helpers_filter_sections_and_build_subdm() {
     assert_eq!(sub.maps.sub_to_parent, vec![pid(1), pid(2), pid(3)]);
     assert!(sub.dm.section("u").is_some());
 }
+
+fn tiny_coordinates() -> mesh_sieve::data::coordinates::Coordinates<f64, VecStorage<f64>> {
+    let mut atlas = Atlas::default();
+    for point in [pid(1), pid(2), pid(5)] {
+        atlas.try_insert(point, 1).unwrap();
+    }
+    let mut section = Section::<f64, VecStorage<f64>>::new(atlas);
+    section.try_set(pid(1), &[0.0]).unwrap();
+    section.try_set(pid(2), &[1.0]).unwrap();
+    section.try_set(pid(5), &[2.0]).unwrap();
+    mesh_sieve::data::coordinates::Coordinates::from_section(1, 1, section).unwrap()
+}
+
+fn tiny_cell_types() -> Section<
+    mesh_sieve::topology::cell_type::CellType,
+    VecStorage<mesh_sieve::topology::cell_type::CellType>,
+> {
+    let mut atlas = Atlas::default();
+    atlas.try_insert(pid(3), 1).unwrap();
+    atlas.try_insert(pid(4), 1).unwrap();
+    let mut section = Section::<
+        mesh_sieve::topology::cell_type::CellType,
+        VecStorage<mesh_sieve::topology::cell_type::CellType>,
+    >::new(atlas);
+    section
+        .try_set(
+            pid(3),
+            &[mesh_sieve::topology::cell_type::CellType::Segment],
+        )
+        .unwrap();
+    section
+        .try_set(
+            pid(4),
+            &[mesh_sieve::topology::cell_type::CellType::Segment],
+        )
+        .unwrap();
+    section
+}
+
+fn solve_ready_dm() -> MeshDM<f64> {
+    MeshDM::<f64>::builder(tiny_mesh())
+        .coordinates(tiny_coordinates())
+        .cell_types(tiny_cell_types())
+        .section("u", scalar_section())
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn mesh_dm_prepare_for_solve_reports_missing_prerequisites() {
+    let mut dm = MeshDM::<f64>::builder(tiny_mesh())
+        .section("u", scalar_section())
+        .build()
+        .unwrap();
+
+    let report = dm
+        .prepare_for_solve(
+            &NoComm,
+            mesh_sieve::diagnostics::PrepareForSolveOptions {
+                create_serial_ownership: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert!(!report.ready);
+    assert!(
+        report
+            .prerequisites
+            .iter()
+            .any(|p| p.name == "coordinates" && p.required && !p.present)
+    );
+    assert!(
+        report
+            .prerequisites
+            .iter()
+            .any(|p| p.name == "cell_types" && p.required && !p.present)
+    );
+    assert!(
+        report
+            .prerequisites
+            .iter()
+            .any(|p| p.name == "ownership" && p.required && !p.present)
+    );
+    assert!(report.steps.iter().all(|s| s.status == "skipped"));
+}
+
+#[test]
+fn mesh_dm_prepare_for_solve_is_stable_for_identical_topology_and_partitioning() {
+    let mut left = solve_ready_dm();
+    let mut right = solve_ready_dm();
+
+    let left_report = left.prepare_for_solve(&NoComm, Default::default()).unwrap();
+    let right_report = right
+        .prepare_for_solve(&NoComm, Default::default())
+        .unwrap();
+
+    let left_json =
+        mesh_sieve::diagnostics::prepare_for_solve_diagnostics_json(&left_report).unwrap();
+    let right_json =
+        mesh_sieve::diagnostics::prepare_for_solve_diagnostics_json(&right_report).unwrap();
+    assert_eq!(left_json, right_json);
+    assert_eq!(
+        left_json,
+        "{\"ready\":true,\"prerequisites\":[{\"name\":\"coordinates\",\"required\":true,\"present\":true,\"complete\":true,\"detail\":\"vertex_points=3, missing_vertex_coordinates=0\"},{\"name\":\"cell_types\",\"required\":true,\"present\":true,\"complete\":true,\"detail\":\"cells=2, missing_cell_types=0\"},{\"name\":\"ownership\",\"required\":true,\"present\":true,\"complete\":true,\"detail\":\"topology_points=5, missing_ownership=0, ghost_points=0\"},{\"name\":\"overlap\",\"required\":false,\"present\":false,\"complete\":true,\"detail\":\"overlap graph is not attached; ghost_points=0, overlap_required=false\"}],\"steps\":[{\"name\":\"section_global_numbering\",\"status\":\"completed\",\"detail\":\"numbered_sections=1\"},{\"name\":\"matrix_preallocation_graph\",\"status\":\"completed\",\"detail\":\"rows=2, edges=2\"},{\"name\":\"ownership_overlap_checks\",\"status\":\"completed\",\"detail\":\"ownership and overlap topology are consistent\"},{\"name\":\"section_synchronization\",\"status\":\"skipped\",\"detail\":\"no overlap/ownership state available for ghost synchronization\"}],\"global_sections\":[\"u\"],\"preallocation\":{\"rows\":2,\"edges\":2,\"order\":[3,4],\"row_nnz\":[1,1]},\"synchronized_sections\":[]}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a DM-level deterministic `prepare_for_solve` pipeline that verifies prerequisites and performs the usual solver setup steps (section/global numbering, matrix preallocation, ownership/overlap checks, optional ghost-section synchronization) while emitting structured diagnostics instead of panicking. 
- Make readiness and preallocation output stable/serializable so calling code and tests can assert deterministic behavior for identical topology/partitioning.

### Description
- Added prepare-for-solve diagnostic types and helpers in `src/diagnostics.rs`: `PrepareForSolveOptions`, `PrepareForSolvePrerequisiteDiagnostic`, `PrepareForSolveStepDiagnostic`, `PrepareForSolvePreallocationDiagnostic`, `PrepareForSolveDiagnostics`, `prepare_for_solve_prerequisites`, and `prepare_for_solve_diagnostics_json` for stable JSON serialization. 
- Implemented `MeshDM::prepare_for_solve` in `src/dm.rs` which (optionally synthesizes serial ownership), runs prerequisite checks, invokes `build_global_sections`, generates a matrix preallocation graph via `matrix_preallocation_graph`, runs `run_mesh_checks` for ownership/overlap consistency, and optionally calls `distribute_fields` to synchronize ghost sections; the method returns the structured `PrepareForSolveDiagnostics`. 
- Re-exported the new prepare-for-solve types and serializer in the crate prelude via `src/lib.rs` for public API access. 
- Added integration tests in `tests/mesh_dm.rs` asserting that missing prerequisites are reported (skipping subsequent steps) and that the serialized diagnostics are stable/deterministic for identical input topology and partitioning.

### Testing
- Ran `cargo test --test mesh_dm`, which executed the new and existing `mesh_dm` tests and all passed (6 passed, 0 failed). 
- Ran `cargo check` and `cargo test` during development to validate compilation and test execution, both completed successfully (repository emits unrelated warnings but tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18c80c3458832986ae6a4f3fda893d)