### PR TITLE
Expand FE/FV discretization capability matrix

### DIFF
--- a/src/discretization/mod.rs
+++ b/src/discretization/mod.rs
@@ -3,7 +3,9 @@
 pub mod runtime;
 
 pub use runtime::{
-    Basis, BasisTabulation, ClosureDof, DofMap, ElementRuntime, ElementTabulation, QuadratureRule,
-    assemble_local_matrix, assemble_local_vector, cell_vertices, local_load_vector,
-    local_stiffness_matrix, runtime_from_metadata, tabulate_element,
+    Basis, BasisFamily, BasisTabulation, ClosureDof, DiscretizationCapability, DofMap,
+    ElementRuntime, ElementTabulation, QuadratureFamily, QuadratureRule, assemble_local_matrix,
+    assemble_local_vector, cell_vertices, discretization_capability,
+    ensure_geometry_order_supported, local_load_vector, local_stiffness_matrix,
+    runtime_from_metadata, supported_discretizations, tabulate_element,
 };

--- a/src/discretization/runtime.rs
+++ b/src/discretization/runtime.rs
@@ -44,6 +44,81 @@ pub enum BasisFamily {
     Pyramid,
 }
 
+/// Quadrature families accepted by the runtime capability matrix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuadratureFamily {
+    /// Single point/centroid rules.
+    Point,
+    /// Gauss-Legendre rules on tensor-product reference cells.
+    GaussLegendre,
+    /// Simplex rules on triangle/tetrahedron/simplex reference cells.
+    Simplex,
+    /// Tensor product of a simplex rule and a segment rule.
+    PrismProduct,
+    /// Pyramid reference rule.
+    Pyramid,
+    /// Polygon centroid/fan rule.
+    PolygonCentroid,
+    /// Generic polyhedron centroid rule.
+    PolyhedronCentroid,
+    /// Caller-provided points and weights.
+    Explicit,
+}
+
+/// One row in the supported PetscFE/PetscFV-equivalent discretization matrix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiscretizationCapability {
+    /// Canonical cell topology.
+    pub cell_type: CellType,
+    /// Topological dimension.
+    pub dimension: usize,
+    /// Lagrange node/basis families supported for this topology.
+    pub basis_families: &'static [BasisFamily],
+    /// Inclusive polynomial degree range supported by the runtime tabulator.
+    pub degree_range: (usize, usize),
+    /// Quadrature families supported for this topology.
+    pub quadrature_families: &'static [QuadratureFamily],
+    /// Inclusive coordinate geometry order range supported by element assembly.
+    pub geometry_order_range: (usize, usize),
+    /// Whether cell-centered FV stencils/geometry are supported.
+    pub finite_volume: bool,
+}
+
+impl DiscretizationCapability {
+    const fn new(
+        cell_type: CellType,
+        dimension: usize,
+        basis_families: &'static [BasisFamily],
+        degree_range: (usize, usize),
+        quadrature_families: &'static [QuadratureFamily],
+        geometry_order_range: (usize, usize),
+        finite_volume: bool,
+    ) -> Self {
+        Self {
+            cell_type,
+            dimension,
+            basis_families,
+            degree_range,
+            quadrature_families,
+            geometry_order_range,
+            finite_volume,
+        }
+    }
+
+    fn supports_basis(self, family: BasisFamily, degree: usize) -> bool {
+        self.basis_families.contains(&family)
+            && (self.degree_range.0..=self.degree_range.1).contains(&degree)
+    }
+
+    fn supports_quadrature(self, family: QuadratureFamily) -> bool {
+        self.quadrature_families.contains(&family)
+    }
+
+    fn supports_geometry_order(self, order: usize) -> bool {
+        (self.geometry_order_range.0..=self.geometry_order_range.1).contains(&order)
+    }
+}
+
 impl Basis {
     /// Resolve a basis implementation from a metadata label and cell type.
     pub fn from_metadata(name: &str, cell_type: CellType) -> Result<Self, MeshSieveError> {
@@ -183,11 +258,18 @@ impl QuadratureRule {
     /// Construct a quadrature rule from a metadata label and cell type.
     pub fn from_metadata(name: &str, cell_type: CellType) -> Result<Self, MeshSieveError> {
         let normalized = normalize_name(name);
+        let family = quadrature_family_from_name(&normalized, cell_type)?;
+        ensure_quadrature_supported(cell_type, family)?;
         let order =
             parse_trailing_degree(&normalized).unwrap_or_else(|| match normalized.as_str() {
                 "midpoint" | "centroid" => 1,
                 _ => 2,
             });
+        if order > MAX_RUNTIME_ORDER {
+            return Err(MeshSieveError::InvalidGeometry(format!(
+                "unsupported quadrature order {order} for {cell_type:?}; maximum supported order is {MAX_RUNTIME_ORDER}"
+            )));
+        }
         match canonical_cell_type(cell_type) {
             CellType::Vertex => Ok(point_quadrature(name)),
             CellType::Segment => Ok(gauss_legendre_1d(order.min(3), name)),
@@ -245,6 +327,7 @@ pub fn runtime_from_metadata(
 ) -> Result<ElementRuntime, MeshSieveError> {
     let basis = Basis::from_metadata_with_order(metadata, cell_type)?;
     let quadrature = if metadata.has_quadrature_data() {
+        ensure_quadrature_supported(cell_type, QuadratureFamily::Explicit)?;
         QuadratureRule::from_explicit(
             metadata.quadrature.clone(),
             metadata.quadrature_points.clone(),
@@ -253,6 +336,13 @@ pub fn runtime_from_metadata(
     } else {
         QuadratureRule::from_metadata(&metadata.quadrature, cell_type)?
     };
+    if quadrature.dimension() != basis.dimension() {
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "quadrature dimension {} does not match basis dimension {} for {cell_type:?}",
+            quadrature.dimension(),
+            basis.dimension()
+        )));
+    }
     Ok(ElementRuntime { basis, quadrature })
 }
 
@@ -829,55 +919,117 @@ fn parse_trailing_degree(name: &str) -> Option<usize> {
     (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
 }
 
-/// Runtime finite-element support policy.
+/// Runtime finite-element/FV support policy.
 ///
-/// The table below is the single source of truth for combinations implemented by
-/// this module. Unsupported entries are intentionally rejected before node,
-/// quadrature, or Jacobian code is reached.
-///
-/// | Cell topology | Lagrange families | Quadrature | Jacobian |
-/// | --- | --- | --- | --- |
-/// | `Vertex`, `Simplex(0)` | `Simplex`, `TensorProduct` | point rule | 0D |
-/// | `Segment`, `Simplex(1)` | `Simplex`, `TensorProduct` | Gauss-Legendre | 1D |
-/// | `Triangle`, `Simplex(2)` | `Simplex` | simplex triangle | 2D |
-/// | `Quadrilateral` | `TensorProduct` | tensor-product Gauss | 2D |
-/// | `Tetrahedron`, `Simplex(3)` | `Simplex` | simplex tetrahedron | 3D |
-/// | `Simplex(d)` | `Simplex` | centroid/simplex rule | dD |
-/// | `Polygon(n)` | `TensorProduct` | centroid fan rule | 2D |
-/// | `Polyhedron` | `TensorProduct` | centroid rule | 3D |
-/// | `Hexahedron` | `TensorProduct` | tensor-product Gauss | 3D |
-/// | `Prism` | `Prism` | triangle × segment product | 3D |
-/// | `Pyramid` | `Pyramid` | one-point pyramid rule | 3D |
-const RUNTIME_CAPABILITIES: &[RuntimeCapability] = &[
-    RuntimeCapability::new(
+/// This table is the single source of truth for combinations implemented by
+/// this module. Unsupported entries are rejected as policy errors before node,
+/// quadrature, Jacobian, or stencil code is reached. The degree and geometry
+/// order limits are intentionally finite because the current runtime tabulator
+/// builds dense interpolation matrices and the built-in quadrature rules are
+/// only intended for common low-order PetscFE/PetscFV setup paths.
+const MAX_RUNTIME_ORDER: usize = 4;
+
+const SIMPLEX_FAMILIES: &[BasisFamily] = &[BasisFamily::Simplex];
+const SEGMENT_FAMILIES: &[BasisFamily] = &[BasisFamily::Simplex, BasisFamily::TensorProduct];
+const TENSOR_FAMILIES: &[BasisFamily] = &[BasisFamily::TensorProduct];
+const PRISM_FAMILIES: &[BasisFamily] = &[BasisFamily::Prism];
+const PYRAMID_FAMILIES: &[BasisFamily] = &[BasisFamily::Pyramid];
+const POINT_FAMILIES: &[BasisFamily] = &[BasisFamily::Simplex, BasisFamily::TensorProduct];
+
+const POINT_QUADRATURE: &[QuadratureFamily] =
+    &[QuadratureFamily::Point, QuadratureFamily::Explicit];
+const GAUSS_QUADRATURE: &[QuadratureFamily] =
+    &[QuadratureFamily::GaussLegendre, QuadratureFamily::Explicit];
+const SIMPLEX_QUADRATURE: &[QuadratureFamily] =
+    &[QuadratureFamily::Simplex, QuadratureFamily::Explicit];
+const PRISM_QUADRATURE: &[QuadratureFamily] =
+    &[QuadratureFamily::PrismProduct, QuadratureFamily::Explicit];
+const PYRAMID_QUADRATURE: &[QuadratureFamily] =
+    &[QuadratureFamily::Pyramid, QuadratureFamily::Explicit];
+
+const RUNTIME_CAPABILITIES: &[DiscretizationCapability] = &[
+    DiscretizationCapability::new(
         CellType::Vertex,
-        &[BasisFamily::Simplex, BasisFamily::TensorProduct],
+        0,
+        POINT_FAMILIES,
+        (0, MAX_RUNTIME_ORDER),
+        POINT_QUADRATURE,
+        (1, 1),
+        false,
     ),
-    RuntimeCapability::new(
+    DiscretizationCapability::new(
         CellType::Segment,
-        &[BasisFamily::Simplex, BasisFamily::TensorProduct],
+        1,
+        SEGMENT_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        GAUSS_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
     ),
-    RuntimeCapability::new(CellType::Triangle, &[BasisFamily::Simplex]),
-    RuntimeCapability::new(CellType::Quadrilateral, &[BasisFamily::TensorProduct]),
-    RuntimeCapability::new(CellType::Tetrahedron, &[BasisFamily::Simplex]),
-    RuntimeCapability::new(CellType::Hexahedron, &[BasisFamily::TensorProduct]),
-    RuntimeCapability::new(CellType::Prism, &[BasisFamily::Prism]),
-    RuntimeCapability::new(CellType::Pyramid, &[BasisFamily::Pyramid]),
+    DiscretizationCapability::new(
+        CellType::Triangle,
+        2,
+        SIMPLEX_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        SIMPLEX_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
+    ),
+    DiscretizationCapability::new(
+        CellType::Quadrilateral,
+        2,
+        TENSOR_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        GAUSS_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
+    ),
+    DiscretizationCapability::new(
+        CellType::Tetrahedron,
+        3,
+        SIMPLEX_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        SIMPLEX_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
+    ),
+    DiscretizationCapability::new(
+        CellType::Hexahedron,
+        3,
+        TENSOR_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        GAUSS_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
+    ),
+    DiscretizationCapability::new(
+        CellType::Prism,
+        3,
+        PRISM_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        PRISM_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
+    ),
+    DiscretizationCapability::new(
+        CellType::Pyramid,
+        3,
+        PYRAMID_FAMILIES,
+        (1, MAX_RUNTIME_ORDER),
+        PYRAMID_QUADRATURE,
+        (1, MAX_RUNTIME_ORDER),
+        true,
+    ),
 ];
 
-#[derive(Clone, Copy, Debug)]
-struct RuntimeCapability {
-    cell_type: CellType,
-    families: &'static [BasisFamily],
+/// Return the explicit runtime capability row for a cell type, when one exists.
+pub fn discretization_capability(cell_type: CellType) -> Option<DiscretizationCapability> {
+    capability_for(cell_type).copied()
 }
 
-impl RuntimeCapability {
-    const fn new(cell_type: CellType, families: &'static [BasisFamily]) -> Self {
-        Self {
-            cell_type,
-            families,
-        }
-    }
+/// Iterate over the static supported-discretization matrix.
+pub fn supported_discretizations() -> &'static [DiscretizationCapability] {
+    RUNTIME_CAPABILITIES
 }
 
 fn canonical_cell_type(cell_type: CellType) -> CellType {
@@ -899,11 +1051,124 @@ fn is_dynamic_lagrange_supported(cell_type: CellType, family: BasisFamily) -> bo
     )
 }
 
-fn capability_for(cell_type: CellType) -> Option<&'static RuntimeCapability> {
+fn capability_for(cell_type: CellType) -> Option<&'static DiscretizationCapability> {
     let canonical = canonical_cell_type(cell_type);
     RUNTIME_CAPABILITIES
         .iter()
         .find(|capability| capability.cell_type == canonical)
+}
+
+fn quadrature_family_from_name(
+    normalized: &str,
+    cell_type: CellType,
+) -> Result<QuadratureFamily, MeshSieveError> {
+    if normalized.contains("explicit") || normalized.contains("custom") {
+        return Ok(QuadratureFamily::Explicit);
+    }
+    let canonical = canonical_cell_type(cell_type);
+    match canonical {
+        CellType::Vertex => Ok(QuadratureFamily::Point),
+        CellType::Segment | CellType::Quadrilateral | CellType::Hexahedron => {
+            if normalized.contains("gauss")
+                || normalized.contains("legendre")
+                || normalized.contains("gll")
+                || normalized.contains("lobatto")
+                || normalized.contains("tensor")
+            {
+                Ok(QuadratureFamily::GaussLegendre)
+            } else {
+                Err(MeshSieveError::InvalidGeometry(format!(
+                    "unsupported quadrature '{normalized}' for {cell_type:?}; expected a Gauss/tensor-product rule"
+                )))
+            }
+        }
+        CellType::Triangle | CellType::Tetrahedron | CellType::Simplex(_) => {
+            if normalized.contains("gauss")
+                || normalized.contains("simplex")
+                || normalized.contains("centroid")
+                || normalized.contains("midpoint")
+            {
+                Ok(QuadratureFamily::Simplex)
+            } else {
+                Err(MeshSieveError::InvalidGeometry(format!(
+                    "unsupported quadrature '{normalized}' for {cell_type:?}; expected a simplex rule"
+                )))
+            }
+        }
+        CellType::Prism => Ok(QuadratureFamily::PrismProduct),
+        CellType::Pyramid => Ok(QuadratureFamily::Pyramid),
+        CellType::Polygon(_) => Ok(QuadratureFamily::PolygonCentroid),
+        CellType::Polyhedron => Ok(QuadratureFamily::PolyhedronCentroid),
+    }
+}
+
+fn ensure_quadrature_supported(
+    cell_type: CellType,
+    family: QuadratureFamily,
+) -> Result<(), MeshSieveError> {
+    if matches!(cell_type, CellType::Simplex(_))
+        && matches!(
+            family,
+            QuadratureFamily::Simplex | QuadratureFamily::Explicit
+        )
+    {
+        return Ok(());
+    }
+    if matches!(cell_type, CellType::Polygon(_))
+        && matches!(
+            family,
+            QuadratureFamily::PolygonCentroid | QuadratureFamily::Explicit
+        )
+    {
+        return Ok(());
+    }
+    if matches!(cell_type, CellType::Polyhedron)
+        && matches!(
+            family,
+            QuadratureFamily::PolyhedronCentroid | QuadratureFamily::Explicit
+        )
+    {
+        return Ok(());
+    }
+    let capability = capability_for(cell_type).ok_or_else(|| {
+        MeshSieveError::InvalidGeometry(format!(
+            "unsupported cell type {cell_type:?} for quadrature"
+        ))
+    })?;
+    if !capability.supports_quadrature(family) {
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "unsupported quadrature family {family:?} for {cell_type:?}; supported families: {:?}",
+            capability.quadrature_families
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a coordinate geometry order against the explicit support matrix.
+pub fn ensure_geometry_order_supported(
+    cell_type: CellType,
+    geometry_order: usize,
+) -> Result<(), MeshSieveError> {
+    if matches!(
+        cell_type,
+        CellType::Simplex(_) | CellType::Polygon(_) | CellType::Polyhedron
+    ) {
+        if (1..=MAX_RUNTIME_ORDER).contains(&geometry_order) {
+            return Ok(());
+        }
+    }
+    let capability = capability_for(cell_type).ok_or_else(|| {
+        MeshSieveError::InvalidGeometry(format!(
+            "unsupported cell type {cell_type:?} for geometry order {geometry_order}"
+        ))
+    })?;
+    if !capability.supports_geometry_order(geometry_order) {
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "unsupported geometry order {geometry_order} for {cell_type:?}; supported range: {:?}",
+            capability.geometry_order_range
+        )));
+    }
+    Ok(())
 }
 
 fn default_lagrange_family(cell_type: CellType) -> Result<BasisFamily, MeshSieveError> {
@@ -914,7 +1179,7 @@ fn default_lagrange_family(cell_type: CellType) -> Result<BasisFamily, MeshSieve
         return Ok(BasisFamily::TensorProduct);
     }
     capability_for(cell_type)
-        .and_then(|capability| capability.families.first().copied())
+        .and_then(|capability| capability.basis_families.first().copied())
         .ok_or_else(|| {
             MeshSieveError::InvalidGeometry(format!(
                 "unsupported cell type {cell_type:?} for Lagrange basis"
@@ -933,17 +1198,22 @@ fn ensure_lagrange_supported(
         ));
     }
     if is_dynamic_lagrange_supported(cell_type, family) {
-        return Ok(());
+        if degree <= MAX_RUNTIME_ORDER {
+            return Ok(());
+        }
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "unsupported Lagrange degree {degree} for {cell_type:?}; maximum supported degree is {MAX_RUNTIME_ORDER}"
+        )));
     }
     let capability = capability_for(cell_type).ok_or_else(|| {
         MeshSieveError::InvalidGeometry(format!(
             "unsupported cell type {cell_type:?} for Lagrange basis"
         ))
     })?;
-    if !capability.families.contains(&family) {
+    if !capability.supports_basis(family, degree) {
         return Err(MeshSieveError::InvalidGeometry(format!(
-            "unsupported Lagrange family {family:?} for {cell_type:?}; supported families: {:?}",
-            capability.families
+            "unsupported Lagrange family/degree {family:?}/P{degree} for {cell_type:?}; supported families: {:?}, degree range: {:?}",
+            capability.basis_families, capability.degree_range
         )));
     }
     Ok(())
@@ -1700,7 +1970,7 @@ mod tests {
     fn capability_supports(cell_type: CellType, family: BasisFamily) -> bool {
         is_dynamic_lagrange_supported(cell_type, family)
             || capability_for(cell_type)
-                .map(|capability| capability.families.contains(&family))
+                .map(|capability| capability.basis_families.contains(&family))
                 .unwrap_or(false)
     }
 
@@ -1721,7 +1991,7 @@ mod tests {
     #[test]
     fn supported_basis_quadrature_and_node_layouts_tabulate() {
         for capability in RUNTIME_CAPABILITIES {
-            for &family in capability.families {
+            for &family in capability.basis_families {
                 for degree in 1..=2 {
                     let basis =
                         Basis::lagrange_with_family(capability.cell_type, degree, family).unwrap();

--- a/src/physics/fe.rs
+++ b/src/physics/fe.rs
@@ -10,8 +10,8 @@ use crate::data::global_map::LocalToGlobalMap;
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::discretization::runtime::{
-    Basis, BasisTabulation, QuadratureRule, local_load_vector, local_stiffness_matrix,
-    runtime_from_metadata, tabulate_element,
+    Basis, BasisTabulation, QuadratureRule, ensure_geometry_order_supported, local_load_vector,
+    local_stiffness_matrix, runtime_from_metadata, tabulate_element,
 };
 use crate::mesh_error::MeshSieveError;
 use crate::topology::cell_type::CellType;
@@ -110,6 +110,34 @@ fn gather_node_coordinates<S: Storage<f64>>(
     Ok(node_coords)
 }
 
+fn closure_vertex_coordinates<T, S>(
+    topology: &T,
+    coordinates: &Coordinates<f64, S>,
+    cell: PointId,
+    topology_version: u64,
+    order: &ClosureOrder,
+) -> Result<Vec<Vec<f64>>, MeshSieveError>
+where
+    T: Sieve<Point = PointId>,
+    S: Storage<f64>,
+{
+    let index = build_closure_index_unoriented(
+        topology,
+        coordinates.section(),
+        cell,
+        topology_version,
+        order,
+        &IdentitySectionSym,
+    )?;
+    let mut cell_nodes = Vec::new();
+    for point in index.point_order() {
+        if topology.cone_points(point).next().is_none() {
+            cell_nodes.push(point);
+        }
+    }
+    gather_node_coordinates(coordinates, &cell_nodes)
+}
+
 /// Assemble element matrices using vertices selected from a DMPlex-style closure.
 ///
 /// This is the closure-aware counterpart to [`assemble_element_matrices`].  The
@@ -130,21 +158,38 @@ where
     S: Storage<f64>,
     F: Fn(&[f64]) -> f64,
 {
-    let index = build_closure_index_unoriented(
-        topology,
-        coordinates.section(),
-        cell,
-        topology_version,
-        order,
-        &IdentitySectionSym,
-    )?;
-    let mut cell_nodes = Vec::new();
-    for point in index.point_order() {
-        if topology.cone_points(point).next().is_none() {
-            cell_nodes.push(point);
+    let runtime = runtime_from_metadata(metadata, cell_type)?;
+    let node_coords = if let Some(high_order) = coordinates.high_order() {
+        if high_order.section().atlas().contains(cell) {
+            let values = high_order.section().try_restrict(cell)?;
+            let dim = high_order.dimension();
+            let geometry_nodes = values.len() / dim;
+            let geometry_order = metadata
+                .basis_order
+                .unwrap_or(runtime.basis.degree())
+                .max(1);
+            ensure_geometry_order_supported(cell_type, geometry_order)?;
+            if geometry_nodes == runtime.basis.num_nodes() {
+                values.chunks(dim).map(|tuple| tuple.to_vec()).collect()
+            } else {
+                return Err(MeshSieveError::InvalidGeometry(format!(
+                    "high-order coordinates for {cell:?} provide {geometry_nodes} nodes, but {:?} P{} requires {}",
+                    cell_type,
+                    runtime.basis.degree(),
+                    runtime.basis.num_nodes()
+                )));
+            }
+        } else {
+            closure_vertex_coordinates(topology, coordinates, cell, topology_version, order)?
         }
-    }
-    assemble_element_matrices(coordinates, cell_type, &cell_nodes, metadata, rhs)
+    } else {
+        closure_vertex_coordinates(topology, coordinates, cell, topology_version, order)?
+    };
+    let tabulation = tabulate_element(&runtime, &node_coords)?;
+    Ok(ElementMatrices {
+        stiffness: local_stiffness_matrix(&tabulation),
+        load: local_load_vector(&tabulation, rhs),
+    })
 }
 
 /// Orientation-aware FE closure data for element kernels.

--- a/src/physics/fvm.rs
+++ b/src/physics/fvm.rs
@@ -15,8 +15,11 @@
 
 use crate::data::section::Section;
 use crate::data::storage::Storage;
-use crate::discretization::runtime::{CellGeometry, FaceGeometry, FluxStencil};
+use crate::discretization::runtime::{
+    CellGeometry, FaceGeometry, FluxStencil, discretization_capability,
+};
 use crate::mesh_error::MeshSieveError;
+use crate::topology::cell_type::CellType;
 use crate::topology::coastal::{
     BOUNDARY_CLASS_LABEL, BOUNDARY_ROLE_LABEL, BoundaryClass, OpenBoundaryRole, WET_DRY_MASK_LABEL,
     WetDryMask,
@@ -25,6 +28,24 @@ use crate::topology::labels::LabelSet;
 use crate::topology::point::PointId;
 use crate::topology::sieve::Sieve;
 use std::collections::{HashMap, HashSet};
+
+/// Validate that a cell topology is part of the explicit PetscFV-style runtime matrix.
+pub fn validate_fv_cell_type(cell_type: CellType) -> Result<(), MeshSieveError> {
+    let supported = match cell_type {
+        CellType::Simplex(dim) => (1..=3).contains(&dim),
+        CellType::Polygon(_) | CellType::Polyhedron => true,
+        other => discretization_capability(other)
+            .map(|capability| capability.finite_volume)
+            .unwrap_or(false),
+    };
+    if supported {
+        Ok(())
+    } else {
+        Err(MeshSieveError::InvalidGeometry(format!(
+            "unsupported finite-volume cell topology {cell_type:?}"
+        )))
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FaceKind {

--- a/tests/discretization_petsc_workflows.rs
+++ b/tests/discretization_petsc_workflows.rs
@@ -102,3 +102,148 @@ fn closure_preallocation_builds_csr_from_section_dofs() {
     assert_eq!(csr.xadj.len(), 5);
     assert!(csr.adjncy.len() >= 8);
 }
+
+#[test]
+fn explicit_discretization_matrix_covers_common_fe_fv_cells() {
+    use mesh_sieve::discretization::runtime::{
+        BasisFamily, QuadratureFamily, supported_discretizations,
+    };
+    use mesh_sieve::physics::fvm::validate_fv_cell_type;
+
+    let rows = supported_discretizations();
+    for cell in [
+        CellType::Segment,
+        CellType::Triangle,
+        CellType::Quadrilateral,
+        CellType::Tetrahedron,
+        CellType::Hexahedron,
+        CellType::Prism,
+        CellType::Pyramid,
+    ] {
+        let row = rows
+            .iter()
+            .find(|row| row.cell_type == cell)
+            .expect("capability row");
+        assert_eq!(row.dimension, cell.dimension() as usize);
+        assert!(row.finite_volume);
+        validate_fv_cell_type(cell).unwrap();
+    }
+
+    let triangle = rows
+        .iter()
+        .find(|row| row.cell_type == CellType::Triangle)
+        .unwrap();
+    assert!(triangle.basis_families.contains(&BasisFamily::Simplex));
+    assert!(
+        triangle
+            .quadrature_families
+            .contains(&QuadratureFamily::Simplex)
+    );
+
+    let hex = rows
+        .iter()
+        .find(|row| row.cell_type == CellType::Hexahedron)
+        .unwrap();
+    assert!(hex.basis_families.contains(&BasisFamily::TensorProduct));
+    assert!(
+        hex.quadrature_families
+            .contains(&QuadratureFamily::GaussLegendre)
+    );
+}
+
+#[test]
+fn unsupported_discretizations_are_policy_errors() {
+    use mesh_sieve::discretization::runtime::{BasisFamily, QuadratureRule};
+    use mesh_sieve::physics::fvm::validate_fv_cell_type;
+
+    let bad_basis =
+        Basis::lagrange_with_family(CellType::Quadrilateral, 2, BasisFamily::Simplex).unwrap_err();
+    assert!(format!("{bad_basis}").contains("unsupported Lagrange"));
+
+    let bad_quadrature =
+        QuadratureRule::from_metadata("newton_cotes2", CellType::Triangle).unwrap_err();
+    assert!(format!("{bad_quadrature}").contains("unsupported quadrature"));
+
+    let bad_fv = validate_fv_cell_type(CellType::Simplex(4)).unwrap_err();
+    assert!(format!("{bad_fv}").contains("unsupported finite-volume"));
+}
+
+#[test]
+fn high_order_coordinates_drive_quadratic_closure_assembly() {
+    use mesh_sieve::data::coordinates::{Coordinates, HighOrderCoordinates};
+    use mesh_sieve::physics::fe::assemble_element_matrices_from_closure;
+
+    let cell = p(10);
+    let vertices = [p(1), p(2), p(3)];
+    let mut sieve = InMemorySieve::<PointId, ()>::default();
+    for vertex in vertices {
+        sieve.add_arrow(cell, vertex, ());
+    }
+
+    let mut coord_atlas = Atlas::default();
+    for vertex in vertices {
+        coord_atlas.try_insert(vertex, 2).unwrap();
+    }
+    let mut coords = Coordinates::<f64, VecStorage<f64>>::try_new(2, 2, coord_atlas).unwrap();
+    coords.section_mut().try_set(p(1), &[0.0, 0.0]).unwrap();
+    coords.section_mut().try_set(p(2), &[1.0, 0.0]).unwrap();
+    coords.section_mut().try_set(p(3), &[0.0, 1.0]).unwrap();
+
+    let mut ho_atlas = Atlas::default();
+    ho_atlas.try_insert(cell, 12).unwrap();
+    let mut ho = HighOrderCoordinates::<f64, VecStorage<f64>>::try_new(2, ho_atlas).unwrap();
+    ho.section_mut()
+        .try_set(
+            cell,
+            &[
+                0.0, 0.0, // (0,0)
+                0.0, 0.5, // (0,1/2)
+                0.0, 1.0, // (0,1)
+                0.5, 0.0, // (1/2,0)
+                0.5, 0.5, // (1/2,1/2)
+                1.0, 0.0, // (1,0)
+            ],
+        )
+        .unwrap();
+    coords.set_high_order(ho).unwrap();
+
+    let metadata =
+        DiscretizationMetadata::new("lagrange", "gauss2").with_basis_metadata(2, [] as [&str; 0]);
+    let matrices = assemble_element_matrices_from_closure(
+        &sieve,
+        &coords,
+        CellType::Triangle,
+        cell,
+        0,
+        &ClosureOrder::BreadthFirstDmpLex,
+        &metadata,
+        |_| 1.0,
+    )
+    .unwrap();
+    assert_eq!(matrices.load.len(), 6);
+    assert_eq!(matrices.stiffness.len(), 36);
+}
+
+#[test]
+fn fv_stencils_are_deterministic_for_supported_cell_families() {
+    use mesh_sieve::discretization::runtime::supported_discretizations;
+    use mesh_sieve::physics::fvm::validate_fv_cell_type;
+
+    for (idx, row) in supported_discretizations()
+        .iter()
+        .filter(|row| row.finite_volume)
+        .enumerate()
+    {
+        validate_fv_cell_type(row.cell_type).unwrap();
+        let face = p(1000 + idx as u64);
+        let left = p(2000 + idx as u64 * 2);
+        let right = p(2001 + idx as u64 * 2);
+        let mut sieve = InMemorySieve::<PointId, ()>::default();
+        sieve.add_arrow(right, face, ());
+        sieve.add_arrow(left, face, ());
+        let stencils = flux_stencils(&sieve, [face]);
+        assert_eq!(stencils.len(), 1, "{:?}", row.cell_type);
+        assert_eq!(stencils[0].left, left, "{:?}", row.cell_type);
+        assert_eq!(stencils[0].right, Some(right), "{:?}", row.cell_type);
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace ad-hoc runtime paths with an explicit PetscFE/PetscFV-like capability matrix so FE/FV support is a clear policy, not incidental coverage gaps. 
- Add first-class handling for quadrature families, basis families, polynomial degree ranges, and geometry order so DMPLEX-style workflows can be mapped reliably. 
- Allow element assembly to consume higher-order coordinate DOFs when available instead of failing silently. 
- Surface FV workflows need explicit topology validation to keep unsupported cell types a policy error rather than a runtime surprise. 

### Description
- Added public capability types and families: `QuadratureFamily` and `DiscretizationCapability`, a static `RUNTIME_CAPABILITIES` table, and accessors `discretization_capability` / `supported_discretizations` in `src/discretization/runtime.rs`. 
- Implemented quadrature/basis/geometry validation helpers (`quadrature_family_from_name`, `ensure_quadrature_supported`, `ensure_geometry_order_supported`) and tightened `runtime_from_metadata` to validate dimension/order compatibility and explicit `Explicit` quadrature support. 
- Extended Lagrange support checks to enforce family+degree bounds via `ensure_lagrange_supported` and added a `MAX_RUNTIME_ORDER` cap used by policy. 
- Updated FE closure assembly in `src/physics/fe.rs` to prefer `Coordinates::high_order()` when present and validated node counts / geometry order before tabulation; factored closure vertex coordinate gathering into `closure_vertex_coordinates`. 
- Added FV topology validation `validate_fv_cell_type` in `src/physics/fvm.rs` and exported capability-related symbols via `src/discretization/mod.rs`. 
- Added tests in `tests/discretization_petsc_workflows.rs` that enumerate supported capability rows, assert explicit policy errors for unsupported combos, exercise high-order closure assembly, and verify deterministic FV face stencils. 

### Testing
- Ran `cargo test -q --test discretization_petsc_workflows` and the new/updated tests completed successfully (all tests passed). 
- Ran `cargo test -q discretization::runtime` to exercise the runtime tabulator and capability table, and those tests passed. 
- Ran `cargo test -q --test dmplex_closure` to ensure closure-order/orientation helpers remained correct, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19be4b6d58832988d354ea9141b2ab)