### PR TITLE
Wire nonconforming constraints through solve path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-sieve"
-version = "3.2.0"
+version = "3.8.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/src/algs/assembly.rs
+++ b/src/algs/assembly.rs
@@ -8,6 +8,9 @@
 use crate::algs::communicator::{CommTag, Communicator, SectionCommTags};
 use crate::algs::completion::section_completion::complete_section_with_tags_and_ownership;
 use crate::data::constrained_section::{ConstraintSet, apply_constraints_to_section};
+use crate::data::hanging_node_constraints::{
+    HangingNodeConstraints, apply_hanging_constraints_to_section,
+};
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::mesh_error::MeshSieveError;
@@ -67,6 +70,59 @@ where
         tags.reduce,
     )?;
 
+    apply_constraints_to_section(section, constraints)?;
+
+    complete_section_with_tags_and_ownership::<V, S, CopyDelta, C>(
+        section,
+        overlap,
+        ownership,
+        comm,
+        my_rank,
+        tags.complete,
+    )?;
+
+    Ok(())
+}
+
+/// High-level assembly across overlap with ownership, hanging-node constraints,
+/// and fixed constraints. Hanging constraints are applied before fixed values so
+/// Dirichlet-like constraints can override interpolated values on the same DOF.
+pub fn assemble_section_with_hanging_constraints_and_ownership<V, S, D, C, Con>(
+    section: &mut Section<V, S>,
+    overlap: &Overlap,
+    ownership: &PointOwnership,
+    comm: &C,
+    my_rank: usize,
+    tags: AssemblyCommTags,
+    hanging_constraints: &HangingNodeConstraints<V>,
+    constraints: &Con,
+) -> Result<(), MeshSieveError>
+where
+    V: Clone
+        + Default
+        + Send
+        + PartialEq
+        + bytemuck::Pod
+        + Copy
+        + 'static
+        + core::ops::AddAssign
+        + core::ops::Mul<Output = V>,
+    S: Storage<V>,
+    D: ValueDelta<V> + Send + Sync + 'static,
+    D::Part: bytemuck::Pod + Default + Copy,
+    C: Communicator + Sync,
+    Con: ConstraintSet<V>,
+{
+    complete_section_with_tags_and_ownership::<V, S, D, C>(
+        section,
+        overlap,
+        ownership,
+        comm,
+        my_rank,
+        tags.reduce,
+    )?;
+
+    apply_hanging_constraints_to_section(section, hanging_constraints)?;
     apply_constraints_to_section(section, constraints)?;
 
     complete_section_with_tags_and_ownership::<V, S, CopyDelta, C>(

--- a/src/data/hanging_node_constraints.rs
+++ b/src/data/hanging_node_constraints.rs
@@ -1,5 +1,6 @@
 //! Hanging node constraints: linear relationships between DOFs.
 
+use crate::data::constrained_section::DofConstraint;
 use crate::data::section::Section;
 use crate::data::storage::Storage;
 use crate::mesh_error::MeshSieveError;
@@ -69,6 +70,48 @@ impl<V> HangingNodeConstraints<V> {
     /// Mutable access to the constraint map.
     pub fn constraints_mut(&mut self) -> &mut BTreeMap<PointId, Vec<HangingDofConstraint<V>>> {
         &mut self.constraints
+    }
+
+    /// Return constraints for one point.
+    pub fn constraints_for(&self, point: PointId) -> Option<&[HangingDofConstraint<V>]> {
+        self.constraints
+            .get(&point)
+            .map(|constraints| constraints.as_slice())
+    }
+
+    /// Return true when `point`/`index` is governed by a hanging-node equation.
+    pub fn is_constrained_dof(&self, point: PointId, index: usize) -> bool {
+        self.constraints.get(&point).is_some_and(|constraints| {
+            constraints
+                .iter()
+                .any(|constraint| constraint.index == index)
+        })
+    }
+
+    /// Convert hanging equations to a fixed-constraint mask for layout/numbering.
+    ///
+    /// The values are placeholders; only the constrained local DOF indices are
+    /// used by [`ConstraintSet`](crate::data::constrained_section::ConstraintSet)
+    /// layout helpers.
+    pub fn to_dof_constraint_mask(&self, value: V) -> BTreeMap<PointId, Vec<DofConstraint<V>>>
+    where
+        V: Clone,
+    {
+        self.constraints
+            .iter()
+            .map(|(point, constraints)| {
+                (
+                    *point,
+                    constraints
+                        .iter()
+                        .map(|constraint| DofConstraint {
+                            index: constraint.index,
+                            value: value.clone(),
+                        })
+                        .collect(),
+                )
+            })
+            .collect()
     }
 
     /// Insert or update a linear constraint for a point DOF.

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -30,6 +30,9 @@ use crate::data::closure::{ClosureIndex, ClosureOrder, IdentitySectionSym, build
 use crate::data::coordinates::Coordinates;
 use crate::data::discretization::Discretization;
 use crate::data::global_map::{LocalToGlobalMap, global_vector_for_map};
+use crate::data::hanging_node_constraints::{
+    HangingNodeConstraints, apply_hanging_constraints_to_section,
+};
 use crate::data::multi_section::constrained_section_from_label_specs;
 use crate::data::section::Section;
 use crate::data::storage::{Storage, VecStorage};
@@ -45,6 +48,7 @@ use crate::mesh_error::MeshSieveError;
 use crate::mesh_graph::{AdjacencyWeighting, MeshGraph, cell_adjacency_graph_with_cells};
 use crate::overlap::overlap::Overlap;
 use crate::physics::fe::{ElementClosureData, extract_oriented_element_closure};
+use crate::topology::anchors::TopologicalAnchors;
 use crate::topology::cache::InvalidateCache;
 use crate::topology::cell_type::CellType;
 use crate::topology::labels::LabelSet;
@@ -925,6 +929,8 @@ where
     ownership: Option<PointOwnership>,
     overlap: Option<Overlap>,
     global_sections: BTreeMap<String, LocalToGlobalMap>,
+    anchors: TopologicalAnchors,
+    hanging_constraints: BTreeMap<String, HangingNodeConstraints<V>>,
     distribution: Option<MeshDMDistribution>,
     provenance_maps: MeshDMProvenance<crate::algs::communicator::NoComm>,
 }
@@ -956,6 +962,8 @@ where
             ownership: None,
             overlap: None,
             global_sections: BTreeMap::new(),
+            anchors: TopologicalAnchors::default(),
+            hanging_constraints: BTreeMap::new(),
             distribution: None,
             provenance_maps: MeshDMProvenance::default(),
         }
@@ -1042,6 +1050,50 @@ where
     /// Borrow DM setup options.
     pub fn options(&self) -> &MeshDMOptions {
         &self.options
+    }
+
+    /// Replace topological anchor metadata used by nonconforming setup flows.
+    pub fn set_topological_anchors(&mut self, anchors: TopologicalAnchors) {
+        self.anchors = anchors;
+    }
+
+    /// Borrow topological anchor metadata for nonconforming/adapted points.
+    pub fn topological_anchors(&self) -> &TopologicalAnchors {
+        &self.anchors
+    }
+
+    /// Attach hanging-node constraints to a named section.
+    pub fn set_hanging_constraints_for_section(
+        &mut self,
+        section_name: impl Into<String>,
+        constraints: HangingNodeConstraints<V>,
+    ) {
+        self.hanging_constraints
+            .insert(section_name.into(), constraints);
+    }
+
+    /// Borrow hanging-node constraints attached to a named section.
+    pub fn hanging_constraints_for_section(
+        &self,
+        section_name: &str,
+    ) -> Option<&HangingNodeConstraints<V>> {
+        self.hanging_constraints.get(section_name)
+    }
+
+    fn apply_hanging_constraints_to_sections(&mut self) -> Result<(), MeshSieveError>
+    where
+        V: core::ops::AddAssign + core::ops::Mul<Output = V>,
+    {
+        let constraints = self.hanging_constraints.clone();
+        for (name, hanging) in constraints {
+            let section = self
+                .mesh_data
+                .sections
+                .get_mut(&name)
+                .ok_or_else(|| MeshSieveError::MissingSectionName { name: name.clone() })?;
+            apply_hanging_constraints_to_section(section, &hanging)?;
+        }
+        Ok(())
     }
 
     /// Run local setup actions that do not require a partitioner/communicator.
@@ -1378,6 +1430,8 @@ where
         let mut dm = MeshDM::from_mesh_data_with_options(mesh_data, self.options.clone());
         dm.ownership = remap_ownership_to_submesh(self.ownership.as_ref(), &maps)?;
         dm.global_sections = remap_global_sections_to_submesh(&self.global_sections, &maps)?;
+        dm.anchors = self.anchors.clone();
+        dm.hanging_constraints = self.hanging_constraints.clone();
         dm.provenance_maps = MeshDMProvenance {
             load_map: None,
             redistribute_map: None,
@@ -1439,8 +1493,15 @@ where
     ) -> Result<PrepareForSolveDiagnostics, MeshSieveError>
     where
         C: Communicator + Sync,
-        V: Send + PartialEq + bytemuck::Pod + 'static,
+        V: Send
+            + PartialEq
+            + bytemuck::Pod
+            + 'static
+            + core::ops::AddAssign
+            + core::ops::Mul<Output = V>,
     {
+        self.apply_hanging_constraints_to_sections()?;
+
         if options.create_serial_ownership && comm.size() == 1 {
             self.ensure_serial_ownership(comm.rank())?;
         }
@@ -1595,16 +1656,29 @@ where
         let overlap = self.overlap.as_ref().unwrap_or(&empty_overlap);
         let mut maps = BTreeMap::new();
         for (name, section) in &self.mesh_data.sections {
-            maps.insert(
-                name.clone(),
+            let map = if let Some(hanging) = self.hanging_constraints.get(name) {
+                let mask = hanging.to_dof_constraint_mask(V::default());
+                LocalToGlobalMap::from_section_with_constraints_and_ownership(
+                    section,
+                    &mask,
+                    overlap,
+                    ownership,
+                    comm,
+                    comm.rank(),
+                    crate::algs::communicator::SectionCommTags::from_base(
+                        crate::algs::communicator::CommTag::new(0xBEEF),
+                    ),
+                )?
+            } else {
                 LocalToGlobalMap::from_section_with_ownership(
                     section,
                     overlap,
                     ownership,
                     comm,
                     comm.rank(),
-                )?,
-            );
+                )?
+            };
+            maps.insert(name.clone(), map);
         }
         self.global_sections = maps;
         Ok(())
@@ -1738,6 +1812,8 @@ where
             ownership: Some(data.ownership),
             overlap: Some(data.overlap),
             global_sections: BTreeMap::new(),
+            anchors: TopologicalAnchors::default(),
+            hanging_constraints: BTreeMap::new(),
             distribution: Some(MeshDMDistribution {
                 point_owners: data.point_owners,
                 cell_parts: data.cell_parts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,8 @@ pub use debug_invariants::DebugInvariants;
 /// A convenient prelude to import the most-used traits & types:
 pub mod prelude {
     pub use crate::algs::assembly::{
-        AssemblyCommTags, assemble_section_with_ownership, assemble_section_with_tags_and_ownership,
+        AssemblyCommTags, assemble_section_with_hanging_constraints_and_ownership,
+        assemble_section_with_ownership, assemble_section_with_tags_and_ownership,
     };
     pub use crate::algs::assembly::{
         GlobalCsrPattern, cell_closure_dof_map, global_preallocation_csr_from_closure,
@@ -165,8 +166,9 @@ pub mod prelude {
     pub use crate::overlap::delta::{AddDelta, CopyDelta, ValueDelta};
     pub use crate::overlap::overlap::Overlap;
     pub use crate::physics::fe::{
-        ElementClosureData, ElementMatrices, ReferenceElementEvaluation, assemble_element_matrices,
-        evaluate_reference_element, extract_element_closure, extract_oriented_element_closure,
+        ElementClosureData, ElementClosurePoint, ElementMatrices, ReferenceElementEvaluation,
+        assemble_element_matrices, evaluate_reference_element, extract_element_closure,
+        extract_oriented_element_closure, insert_element_residual_with_hanging_constraints,
         integrate_reference_scalar,
     };
     pub use crate::physics::fvm::{

--- a/src/physics/fe.rs
+++ b/src/physics/fe.rs
@@ -200,7 +200,22 @@ pub struct ElementClosureData<V> {
     /// Flattened closure values after applying point orientation symmetries.
     pub values: Vec<V>,
     /// Local point/slot to global-index map for each closure scalar DOF, when provided.
+    ///
+    /// Constrained/eliminated DOFs that have no owned global slot are recorded
+    /// as `u64::MAX`; constraint-aware insertion helpers distribute those
+    /// entries through their parent equations instead of using the sentinel.
     pub global_indices: Option<Vec<u64>>,
+    /// Closure point and local-DOF order corresponding to `values`.
+    pub points: Vec<ElementClosurePoint>,
+}
+
+/// One point contribution in an element closure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElementClosurePoint {
+    /// Point in the closure.
+    pub point: PointId,
+    /// Local DOF indices in oriented closure order.
+    pub local_dofs: Vec<usize>,
 }
 
 /// Extract closure values for a FE cell using DMPLEX-like ordering.
@@ -225,10 +240,19 @@ where
         &IdentitySectionSym,
     )?;
     let values = get_closure(section, &index)?;
+    let points = index
+        .points
+        .iter()
+        .map(|entry| ElementClosurePoint {
+            point: entry.point,
+            local_dofs: entry.permutation.clone(),
+        })
+        .collect();
     Ok(ElementClosureData {
         cell,
         values,
         global_indices: None,
+        points,
     })
 }
 
@@ -255,16 +279,102 @@ where
         let mut indices = Vec::with_capacity(index.len);
         for entry in &index.points {
             for &local_dof in &entry.permutation {
-                indices.push(map.global_index(entry.point, local_dof)?);
+                match map.global_index(entry.point, local_dof) {
+                    Ok(global) => indices.push(global),
+                    Err(MeshSieveError::ConstraintIndexOutOfBounds { .. }) => {
+                        indices.push(u64::MAX)
+                    }
+                    Err(err) => return Err(err),
+                }
             }
         }
         Some(indices)
     } else {
         None
     };
+    let points = index
+        .points
+        .iter()
+        .map(|entry| ElementClosurePoint {
+            point: entry.point,
+            local_dofs: entry.permutation.clone(),
+        })
+        .collect();
     Ok(ElementClosureData {
         cell,
         values,
         global_indices,
+        points,
     })
+}
+
+/// Scatter an element residual into a global vector while honoring hanging-node constraints.
+///
+/// Free closure DOFs are inserted at their own global index. Contributions for a
+/// hanging DOF are distributed to its parent DOFs using the constraint weights,
+/// matching the transpose action of linear constraint elimination.
+pub fn insert_element_residual_with_hanging_constraints<V>(
+    closure: &ElementClosureData<V>,
+    element_residual: &[V],
+    global_map: &LocalToGlobalMap,
+    constraints: &crate::data::hanging_node_constraints::HangingNodeConstraints<V>,
+    global_residual: &mut [V],
+) -> Result<(), MeshSieveError>
+where
+    V: Clone + Default + core::ops::AddAssign + core::ops::Mul<Output = V>,
+{
+    if closure.values.len() != element_residual.len() {
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "element residual length {} does not match closure length {} for {:?}",
+            element_residual.len(),
+            closure.values.len(),
+            closure.cell
+        )));
+    }
+
+    let Some(global_indices) = &closure.global_indices else {
+        return Err(MeshSieveError::InvalidGeometry(
+            "global indices are required for constrained residual insertion".to_string(),
+        ));
+    };
+    if global_indices.len() != element_residual.len() {
+        return Err(MeshSieveError::InvalidGeometry(format!(
+            "global-index length {} does not match residual length {} for {:?}",
+            global_indices.len(),
+            element_residual.len(),
+            closure.cell
+        )));
+    }
+
+    let mut cursor = 0usize;
+    for entry in &closure.points {
+        for &local_dof in &entry.local_dofs {
+            let value = element_residual[cursor].clone();
+            if let Some(point_constraints) = constraints.constraints_for(entry.point)
+                && let Some(constraint) = point_constraints.iter().find(|c| c.index == local_dof)
+            {
+                for term in &constraint.terms {
+                    let global = global_map.global_index(term.point, term.index)? as usize;
+                    let len = global_residual.len();
+                    let slot = global_residual.get_mut(global).ok_or_else(|| {
+                        MeshSieveError::InvalidGeometry(format!(
+                            "global residual index {global} out of bounds (len={len})"
+                        ))
+                    })?;
+                    *slot += value.clone() * term.weight.clone();
+                }
+            } else {
+                let global = global_indices[cursor] as usize;
+                let len = global_residual.len();
+                let slot = global_residual.get_mut(global).ok_or_else(|| {
+                    MeshSieveError::InvalidGeometry(format!(
+                        "global residual index {global} out of bounds (len={len})"
+                    ))
+                })?;
+                *slot += value;
+            }
+            cursor += 1;
+        }
+    }
+    Ok(())
 }

--- a/tests/nonconforming_dm_solve.rs
+++ b/tests/nonconforming_dm_solve.rs
@@ -1,0 +1,110 @@
+use mesh_sieve::algs::communicator::NoComm;
+use mesh_sieve::data::atlas::Atlas;
+use mesh_sieve::data::closure::ClosureOrder;
+use mesh_sieve::data::hanging_node_constraints::{HangingNodeConstraints, LinearConstraintTerm};
+use mesh_sieve::data::section::Section;
+use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::diagnostics::PrepareForSolveOptions;
+use mesh_sieve::dm::MeshDM;
+use mesh_sieve::physics::fe::insert_element_residual_with_hanging_constraints;
+use mesh_sieve::topology::anchors::{AnchorKind, TopologicalAnchors};
+use mesh_sieve::topology::point::PointId;
+use mesh_sieve::topology::sieve::{MeshSieve, Sieve};
+
+fn p(id: u64) -> PointId {
+    PointId::new(id).unwrap()
+}
+
+fn nonconforming_mesh() -> MeshSieve {
+    let mut mesh = MeshSieve::default();
+    // One fine/nonconforming cell whose third vertex is a hanging midpoint on
+    // the coarse edge between points 1 and 2.
+    for point in [p(1), p(2), p(4)] {
+        mesh.add_arrow(p(10), point, ());
+    }
+    mesh
+}
+
+fn scalar_section() -> Section<f64, VecStorage<f64>> {
+    let mut atlas = Atlas::default();
+    for point in [p(1), p(2), p(4), p(10)] {
+        atlas.try_insert(point, 1).unwrap();
+    }
+    let mut section = Section::<f64, VecStorage<f64>>::new(atlas);
+    section.try_set(p(1), &[2.0]).unwrap();
+    section.try_set(p(2), &[6.0]).unwrap();
+    section.try_set(p(4), &[0.0]).unwrap();
+    section.try_set(p(10), &[0.0]).unwrap();
+    section
+}
+
+fn hanging_constraints() -> HangingNodeConstraints<f64> {
+    let mut constraints = HangingNodeConstraints::default();
+    constraints.insert_constraint(
+        p(4),
+        0,
+        vec![
+            LinearConstraintTerm::new(p(1), 0, 0.5),
+            LinearConstraintTerm::new(p(2), 0, 0.5),
+        ],
+    );
+    constraints
+}
+
+#[test]
+fn nonconforming_constraints_flow_through_dm_numbering_closure_and_residual() {
+    let mut anchors = TopologicalAnchors::default();
+    anchors.insert(p(4), [p(1), p(2)], AnchorKind::Hanging);
+    let constraints = hanging_constraints();
+
+    let mut dm = MeshDM::<f64>::builder(nonconforming_mesh())
+        .section("u", scalar_section())
+        .build()
+        .unwrap();
+    dm.set_topological_anchors(anchors);
+    dm.set_hanging_constraints_for_section("u", constraints.clone());
+
+    let diagnostics = dm
+        .prepare_for_solve(
+            &NoComm,
+            PrepareForSolveOptions {
+                require_coordinates: false,
+                require_cell_types: false,
+                synchronize_ghost_sections: false,
+                ..PrepareForSolveOptions::default()
+            },
+        )
+        .unwrap();
+    assert!(diagnostics.ready);
+
+    let global = dm.global_section("u").unwrap();
+    assert_eq!(global.total_dofs(), 3, "hanging point is eliminated");
+    assert_eq!(global.global_index(p(1), 0).unwrap(), 0);
+    assert_eq!(global.global_index(p(2), 0).unwrap(), 1);
+    assert_eq!(global.global_index(p(10), 0).unwrap(), 2);
+    assert!(global.global_index(p(4), 0).is_err());
+
+    let closure = dm
+        .get_closure_values("u", p(10), &ClosureOrder::BreadthFirstDmpLex)
+        .unwrap();
+    assert_eq!(closure.values, vec![0.0, 2.0, 6.0, 4.0]);
+    assert_eq!(
+        closure
+            .points
+            .iter()
+            .map(|entry| entry.point)
+            .collect::<Vec<_>>(),
+        vec![p(10), p(1), p(2), p(4)]
+    );
+
+    let mut residual = dm.create_global_vector("u").unwrap().values;
+    insert_element_residual_with_hanging_constraints(
+        &closure,
+        &[0.0, 10.0, 20.0, 8.0],
+        global,
+        &constraints,
+        &mut residual,
+    )
+    .unwrap();
+    assert_eq!(residual, vec![14.0, 24.0, 0.0]);
+}


### PR DESCRIPTION
### Motivation

- Ensure nonconforming/hanging-node metadata (anchors + linear constraints) participates in the full DM solve pipeline so numbering, closure extraction, assembly and residual insertion are consistent with DMPLEX expectations.

### Description

- Add DM-level storage and APIs for topology anchors and per-section hanging-node constraints: `MeshDM` now holds `TopologicalAnchors` and a `BTreeMap<String, HangingNodeConstraints<V>>`, and exposes `set_topological_anchors`, `topological_anchors`, `set_hanging_constraints_for_section`, and `hanging_constraints_for_section`.
- Apply hanging-node constraints early in `prepare_for_solve` via `apply_hanging_constraints_to_sections`, and use a constraint-derived DOF mask (`to_dof_constraint_mask`) when building global numbering maps with `LocalToGlobalMap::from_section_with_constraints_and_ownership` so eliminated DOFs are removed from global numbering.
- Extend hanging-constraint helpers (`HangingNodeConstraints`) with `constraints_for`, `is_constrained_dof`, and `to_dof_constraint_mask` to support numbering/layout code.
- Extend FE closure helpers: `ElementClosureData` now carries closure point/local-DOF layout (`ElementClosurePoint`) and `global_indices` uses `u64::MAX` as a sentinel for eliminated DOFs; add `insert_element_residual_with_hanging_constraints` to scatter element residuals honoring hanging-node equations (distributes contributions to parent DOFs using constraint weights).
- Provide a convenience assembly variant `assemble_section_with_hanging_constraints_and_ownership` which applies hanging constraints before fixed constraints in the two-phase overlap assembly flow.
- Export new FE and assembly APIs via the `prelude` and add an end-to-end regression test `tests/nonconforming_dm_solve.rs` that registers anchors/constraints, runs `prepare_for_solve`, verifies global numbering, checks closure extraction, and validates constrained residual insertion.

### Testing

- Ran `cargo test --test nonconforming_dm_solve --test hanging_node_constraints` and the new focused tests passed.
- Ran the single regression test `cargo test nonconforming_constraints_flow_through_dm_numbering_closure_and_residual` and it passed.
- Existing test-suite smoke runs used during development completed; the change is covered by the added unit test that verifies global numbering elimination, closure contents, and constrained residual scattering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a1709972c832981d303419d086db2)