### PR TITLE
Validate PETSc HDF5 migration provenance

### DIFF
--- a/docs/hdf5-layout.md
+++ b/docs/hdf5-layout.md
@@ -7,13 +7,20 @@ This repository supports two HDF5 layouts:
 2. `src/io/petsc_hdf5.rs` writes and reads a PETSc DMPlex HDF5 v3-style layout
    intended for interoperability with PETSc/Firedrake/FEniCSx-like workflows.
 
-## PETSc DMPlex HDF5 v3-compatible layout
+## PETSc DMPlex HDF5 v2/v3-compatible layout
+
+The PETSc-compatible reader accepts DMPlex storage versions `2` and `3` in
+strict mode.  mesh-sieve writes version `3` (`DMPLEX_STORAGE_VERSION`) because
+that is the layout used by PETSc's current DMPlex HDF5 workflow for named
+topologies, DMs, sections, and vectors.  Version `2` files are treated as legacy
+DMPlex-compatible input when they preserve the same topology/DM hierarchy and
+permutation semantics.
 
 The PETSc-compatible writer stores a version marker at the file root and then
 nests mesh topology, labels, sections, and vectors beneath a named topology:
 
 - `/dmplex_storage_version`
-  - `i32[1]`, currently `3`.
+  - `i32[1]`, currently written as `3`; strict reads accept `2` and `3`.
 - `/topologies/<mesh>/topology/permutation`
   - `i64[num_points]` containing the preserved global `PointId` order.
   - Cone arrays refer to points by zero-based index into this permutation, which
@@ -45,6 +52,52 @@ nests mesh topology, labels, sections, and vectors beneath a named topology:
 The public PETSc-compatible API is exposed as `mesh_sieve::io::petsc_hdf5` and
 provides `PetscHdf5Reader`, `PetscHdf5Writer`, `write_mesh_to_petsc_hdf5`, and
 `read_mesh_from_petsc_hdf5`.
+
+
+## PETSc parallel provenance and cross-rank validation
+
+PETSc DMPlex can save a mesh, sections, and vectors collectively and load them
+with a different communicator size.  mesh-sieve records the same workflow with
+root-level rank counts and serialized point-SF migration maps:
+
+- `/saved_rank_count`
+  - `i32[1]`; number of ranks that wrote the file.
+- `/loaded_rank_count`
+  - `i32[1]`; number of ranks represented by the loaded/redistributed view.
+- `/migration/load_sf`
+  - Flattened `i64` rows `[local_point, remote_rank, remote_point, owner_rank, is_ghost]`
+    describing the PETSc load SF.
+- `/migration/redistribute_sf`
+  - Optional flattened rows for the redistribution step when save/load rank
+    counts differ.
+- `/migration/section_sf`
+  - Flattened rows for section/vector migration after topology movement.
+
+`read_mesh_and_migration_provenance` validates that rank counts are non-zero,
+all referenced ranks are less than `loaded_rank_count`, duplicate SF leaves are
+rejected, a rank-count change has an explicit redistribution SF, and the section
+SF covers every point carrying section, coordinate, or cell-type data.  The same
+coherence rules are exposed on `MeshDMProvenance::validate_consistency()` for DM
+setup pipelines that combine load, redistribution, and section migration maps.
+
+The test suite keeps deterministic HDF5 fixtures for serial, partitioned, and
+cross-rank DMPlex-like files.  When `petsc4py` is installed, additional tests
+exercise the PETSc HDF5 viewer path so mesh-sieve-written files are opened by
+PETSc and PETSc-materialized HDF5 hierarchies are read back by mesh-sieve.
+
+## Known incompatibilities and limits
+
+- Only DMPlex storage versions `2` and `3` are accepted in strict mode.  Use
+  permissive mode only for diagnostics of newer or partially compatible files.
+- The topology reader expects a `permutation` dataset and stratum cone arrays;
+  PETSc files that omit the preserved point order cannot be re-associated with
+  sections/vectors safely.
+- Section/vector support currently covers scalar `f64` sections with explicit
+  `points`, `dofs`, `offsets`, and matching `/vecs/<name>` data.
+- Parallel HDF5 files are validated through serialized SF provenance metadata;
+  mesh-sieve does not replay PETSc's collective MPI-IO calls internally.
+- Unknown DMPlex cell-type integer codes are rejected unless mapped to a
+  supported `CellType`.
 
 ## Legacy compact Mesh Sieve layout
 

--- a/src/algs/point_sf.rs
+++ b/src/algs/point_sf.rs
@@ -167,6 +167,55 @@ where
         self.leaves.len()
     }
 
+    /// Highest rank mentioned by a leaf remote or owner entry.
+    pub fn max_referenced_rank(&self) -> Option<usize> {
+        self.leaves
+            .iter()
+            .flat_map(|leaf| [leaf.remote.rank, leaf.owner_rank])
+            .max()
+    }
+
+    /// Return local points from `required` that are not represented as leaves.
+    pub fn missing_leaf_points<I>(&self, required: I) -> Vec<PointId>
+    where
+        I: IntoIterator<Item = PointId>,
+    {
+        let domain: BTreeSet<_> = self.leaves.iter().map(|leaf| leaf.local).collect();
+        required
+            .into_iter()
+            .filter(|point| !domain.contains(point))
+            .collect()
+    }
+
+    /// Validate this SF as provenance for a named migration stage.
+    pub fn validate_provenance_stage(
+        &self,
+        stage: &str,
+        loaded_rank_count: Option<usize>,
+    ) -> Result<SfValidationReport, MeshSieveError> {
+        let report = self.validate_mapping();
+        if !report.duplicate_leaves.is_empty() {
+            return Err(MeshSieveError::MeshIoParse(format!(
+                "{stage} SF has duplicate leaves for points {:?}",
+                report.duplicate_leaves
+            )));
+        }
+        if !report.unmapped_ghosts.is_empty() {
+            return Err(MeshSieveError::MeshIoParse(format!(
+                "{stage} SF has ghost ownership entries without leaves for points {:?}",
+                report.unmapped_ghosts
+            )));
+        }
+        if let (Some(size), Some(max_rank)) = (loaded_rank_count, self.max_referenced_rank())
+            && max_rank >= size
+        {
+            return Err(MeshSieveError::MeshIoParse(format!(
+                "{stage} SF references rank {max_rank}, but loaded_rank_count is {size}"
+            )));
+        }
+        Ok(report)
+    }
+
     /// Create a PointSF without ownership metadata from an overlap graph.
     pub fn new(overlap: &'a Overlap, comm: &'a C, my_rank: usize) -> Self {
         Self::from_overlap(overlap, None, Some(comm), my_rank)

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -7,7 +7,7 @@
 //! "build topology → attach data → validate → distribute → number sections →
 //! assemble vectors/matrices" workflow.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::adapt::{
     AdaptationProvenanceMap, BoundaryRemeshingPolicy, FvStabilityThresholds,
@@ -385,6 +385,60 @@ pub struct MeshDMProvenance<C: Communicator + Sync + 'static> {
     pub storage_version: Option<i32>,
     pub permutation_source: Option<String>,
     pub redistribution_map_id: Option<String>,
+    pub saved_rank_count: Option<usize>,
+    pub loaded_rank_count: Option<usize>,
+}
+
+impl<C> MeshDMProvenance<C>
+where
+    C: Communicator + Sync + 'static,
+{
+    /// Validate that load, redistribution, and section migration SFs form a coherent DMPlex pipeline.
+    pub fn validate_consistency(&self) -> Result<(), MeshSieveError> {
+        if matches!(
+            (self.saved_rank_count, self.loaded_rank_count),
+            (Some(0), _) | (_, Some(0))
+        ) {
+            return Err(MeshSieveError::MeshIoParse(
+                "DMPlex provenance rank counts must be non-zero".to_string(),
+            ));
+        }
+        if let (Some(saved), Some(loaded)) = (self.saved_rank_count, self.loaded_rank_count)
+            && saved != loaded
+            && self.redistribute_map.is_none()
+        {
+            return Err(MeshSieveError::MeshIoParse(format!(
+                "DMPlex provenance records save/load rank change {saved}->{loaded} without a redistribution SF"
+            )));
+        }
+
+        let loaded = self.loaded_rank_count;
+        if let Some(sf) = &self.load_map {
+            sf.validate_provenance_stage("load", loaded)?;
+        }
+        if let Some(sf) = &self.redistribute_map {
+            sf.validate_provenance_stage("redistribute", loaded)?;
+        }
+        if let Some(sf) = &self.section_map {
+            sf.validate_provenance_stage("section", loaded)?;
+        }
+        if self.section_map.is_some() && self.load_map.is_none() {
+            return Err(MeshSieveError::MeshIoParse(
+                "DMPlex provenance has a section SF but no load SF".to_string(),
+            ));
+        }
+        if let (Some(load), Some(section)) = (&self.load_map, &self.section_map) {
+            let load_range: BTreeSet<_> = load.leaves().map(|leaf| leaf.remote.point).collect();
+            let missing = section.missing_leaf_points(load_range);
+            if !missing.is_empty() {
+                return Err(MeshSieveError::MeshIoParse(format!(
+                    "section SF does not cover loaded points {:?}",
+                    missing
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<St, CtSt> MeshDM<f64, St, CtSt>
@@ -1439,6 +1493,8 @@ where
             storage_version: self.provenance_maps.storage_version,
             permutation_source: Some("sub_dm_by_label".to_string()),
             redistribution_map_id: self.provenance_maps.redistribution_map_id.clone(),
+            saved_rank_count: self.provenance_maps.saved_rank_count,
+            loaded_rank_count: self.provenance_maps.loaded_rank_count,
         };
         Ok(MeshDMSubmesh { dm, maps })
     }
@@ -1827,6 +1883,8 @@ where
                 storage_version: None,
                 permutation_source: None,
                 redistribution_map_id: None,
+                saved_rank_count: Some(size),
+                loaded_rank_count: Some(size),
             },
         }
     }

--- a/src/io/petsc_hdf5.rs
+++ b/src/io/petsc_hdf5.rs
@@ -402,6 +402,13 @@ pub fn read_mesh_and_migration_provenance(
         .unwrap_or_else(|| PointSF::<NoComm>::identity(0, order.iter().copied()));
     let redistribute_map = read_sf_dataset(file, DATASET_REDISTRIBUTE_SF)?;
     let section_map = read_sf_dataset(file, DATASET_SECTION_SF)?;
+    validate_migration_provenance(
+        &mesh,
+        &metadata,
+        &load_map,
+        redistribute_map.as_ref(),
+        section_map.as_ref(),
+    )?;
     Ok((
         mesh,
         PetscMigrationProvenance {
@@ -411,6 +418,58 @@ pub fn read_mesh_and_migration_provenance(
             section_map,
         },
     ))
+}
+
+fn validate_migration_provenance(
+    mesh: &MeshData<MeshSieve, f64, VecStorage<f64>, VecStorage<CellType>>,
+    metadata: &PetscProvenance,
+    load_map: &PointSF<'_, NoComm>,
+    redistribute_map: Option<&PointSF<'_, NoComm>>,
+    section_map: Option<&PointSF<'_, NoComm>>,
+) -> Result<(), MeshSieveError> {
+    if matches!(
+        (metadata.saved_rank_count, metadata.loaded_rank_count),
+        (Some(0), _) | (_, Some(0))
+    ) {
+        return Err(MeshSieveError::MeshIoParse(
+            "DMPlex HDF5 migration metadata contains a zero rank count".to_string(),
+        ));
+    }
+    if let (Some(saved), Some(loaded)) = (metadata.saved_rank_count, metadata.loaded_rank_count)
+        && saved != loaded
+        && redistribute_map.is_none()
+    {
+        return Err(MeshSieveError::MeshIoParse(format!(
+            "DMPlex HDF5 metadata records save/load rank change {saved}->{loaded} without redistribution SF"
+        )));
+    }
+
+    let loaded = metadata.loaded_rank_count;
+    load_map.validate_provenance_stage("load", loaded)?;
+    if let Some(sf) = redistribute_map {
+        sf.validate_provenance_stage("redistribute", loaded)?;
+    }
+    if let Some(sf) = section_map {
+        sf.validate_provenance_stage("section", loaded)?;
+        let mut required = BTreeSet::new();
+        for section in mesh.sections.values() {
+            required.extend(section.atlas().points());
+        }
+        if let Some(coords) = &mesh.coordinates {
+            required.extend(coords.section().atlas().points());
+        }
+        if let Some(cell_types) = &mesh.cell_types {
+            required.extend(cell_types.atlas().points());
+        }
+        let missing = sf.missing_leaf_points(required);
+        if !missing.is_empty() {
+            return Err(MeshSieveError::MeshIoParse(format!(
+                "section SF is missing points with section/coordinate/cell-type data: {:?}",
+                missing
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn point_order(

--- a/tests/petsc_hdf5_roundtrip.rs
+++ b/tests/petsc_hdf5_roundtrip.rs
@@ -5,6 +5,7 @@ use mesh_sieve::data::atlas::Atlas;
 use mesh_sieve::data::coordinates::Coordinates;
 use mesh_sieve::data::section::Section;
 use mesh_sieve::data::storage::VecStorage;
+use mesh_sieve::dm::MeshDMProvenance;
 use mesh_sieve::io::petsc_hdf5::{
     DMPLEX_STORAGE_VERSION, PetscHdf5Reader, PetscHdf5Writer, PetscLoadFilter, PetscLoadMode,
     PetscLoadOptions, read_mesh_and_migration_provenance, read_mesh_from_petsc_hdf5,
@@ -401,6 +402,8 @@ fn migration_provenance_records_rank_count_changes_and_section_maps() {
             (p(2), 0, p(2)),
             (p(3), 0, p(3)),
             (p(6), 1, p(6)),
+            (p(4), 0, p(4)),
+            (p(5), 1, p(5)),
         ],
     );
     write_migration_metadata(
@@ -429,8 +432,84 @@ fn migration_provenance_records_rank_count_changes_and_section_maps() {
             .count(),
         2
     );
-    assert_eq!(provenance.section_map.as_ref().unwrap().leaf_count(), 4);
+    assert_eq!(provenance.section_map.as_ref().unwrap().leaf_count(), 6);
     let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn cross_rank_provenance_validation_rejects_missing_section_points_and_bad_ranks() {
+    let mesh = fixture_mesh(true);
+    let path = std::env::temp_dir().join("mesh_sieve_invalid_migration_provenance_fixture.h5");
+    let _ = std::fs::remove_file(&path);
+    let file = File::create(&path).unwrap();
+    write_mesh_to_petsc_hdf5(&file, &mesh, "mesh", "dm").unwrap();
+
+    let load_map = PointSF::<NoComm>::from_point_map(
+        0,
+        [
+            (p(1), 0, p(1)),
+            (p(2), 0, p(2)),
+            (p(3), 0, p(3)),
+            (p(6), 1, p(6)),
+        ],
+    );
+    let redistribute_map = PointSF::<NoComm>::from_point_map(0, [(p(4), 2, p(4))]);
+    let incomplete_section_map =
+        PointSF::<NoComm>::from_point_map(0, [(p(1), 0, p(1)), (p(2), 0, p(2))]);
+    write_migration_metadata(
+        &file,
+        1,
+        2,
+        &load_map,
+        Some(&redistribute_map),
+        Some(&incomplete_section_map),
+    )
+    .unwrap();
+
+    let err = read_mesh_and_migration_provenance(&file, "mesh", "dm", &PetscLoadOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("references rank 2"));
+
+    let valid_redistribute_map = PointSF::<NoComm>::from_point_map(0, [(p(4), 0, p(4))]);
+    write_migration_metadata(
+        &file,
+        1,
+        2,
+        &load_map,
+        Some(&valid_redistribute_map),
+        Some(&incomplete_section_map),
+    )
+    .unwrap();
+    let err = read_mesh_and_migration_provenance(&file, "mesh", "dm", &PetscLoadOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("section SF is missing"));
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn mesh_dm_provenance_requires_redistribution_for_rank_count_changes() {
+    let load_map = PointSF::<NoComm>::from_point_map(0, [(p(1), 0, p(1)), (p(2), 1, p(2))]);
+    let section_map = PointSF::<NoComm>::from_point_map(0, [(p(1), 0, p(1)), (p(2), 1, p(2))]);
+    let missing_redistribution = MeshDMProvenance {
+        load_map: Some(load_map.clone()),
+        redistribute_map: None,
+        section_map: Some(section_map.clone()),
+        storage_version: Some(DMPLEX_STORAGE_VERSION),
+        permutation_source: Some("/topologies/mesh/topology/permutation".into()),
+        redistribution_map_id: Some("petsc:load-1-to-2".into()),
+        saved_rank_count: Some(1),
+        loaded_rank_count: Some(2),
+    };
+    assert!(missing_redistribution.validate_consistency().is_err());
+
+    let valid = MeshDMProvenance {
+        redistribute_map: Some(PointSF::<NoComm>::from_point_map(
+            0,
+            [(p(1), 0, p(1)), (p(2), 1, p(2))],
+        )),
+        ..missing_redistribution
+    };
+    valid.validate_consistency().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Ensure PETSc DMPlex HDF5 interoperability when meshes/sections/vectors are saved and loaded across different PETSc ranks by validating recorded migration provenance and coverage.
- Reject malformed or out-of-range SF maps and incomplete section coverage so downstream DM setup/redistribution is deterministic and provably safe.

### Description
- Add provenance-stage helpers to `PointSF`: `max_referenced_rank`, `missing_leaf_points`, and `validate_provenance_stage` to detect duplicate leaves, unmapped ghosts, and out-of-range rank references. (`src/algs/point_sf.rs`)
- Validate migration provenance when reading PETSc HDF5 in `read_mesh_and_migration_provenance` by checking non-zero `saved/loaded_rank_count`, requiring a redistribution SF when save/load rank counts differ, validating per-stage SFs, and ensuring the section SF covers all points carrying section/coordinate/cell-type data. (`src/io/petsc_hdf5.rs`)
- Extend `MeshDMProvenance` with `saved_rank_count` and `loaded_rank_count` and add `validate_consistency()` that performs the same coherence checks for DM setup pipelines; propagate rank counts through sub-DM extraction and distributed DM construction. (`src/dm.rs`)
- Add cross-rank provenance tests that exercise invalid rank references, incomplete section coverage, and the requirement for redistribution on rank-count changes, and update an existing migration test to include section points from redistribution. (`tests/petsc_hdf5_roundtrip.rs`)
- Document supported PETSc storage versions, parallel provenance datasets, validation guarantees, and known incompatibilities in `docs/hdf5-layout.md`.

### Testing
- Ran `cargo fmt` and formatting completed successfully.
- Ran `cargo test --test petsc_hdf5_roundtrip` and all targeted PETSc HDF5 round-trip tests passed (14/14).
- Ran full test suite with `cargo test` and unit+doc tests passed (all tests passed in the run reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1a7da86883299672152747c350ab)