### PR TITLE
Harden external mesh generator backends: preserve markers/regions and add diagnostics

### DIFF
--- a/examples/external_mesh_workflows.rs
+++ b/examples/external_mesh_workflows.rs
@@ -66,6 +66,7 @@ fn main() {
             [7, 4],
         ],
         holes: vec![[0.5, 0.5]],
+        ..TriangleInput::default()
     };
     let triangle_options = TriangleOptions {
         max_area: Some(0.02),
@@ -116,7 +117,7 @@ fn main() {
             [0.0, 0.0, 1.0],
         ],
         facets: vec![vec![0, 2, 1], vec![0, 1, 3], vec![1, 2, 3], vec![2, 0, 3]],
-        holes: Vec::new(),
+        ..TetGenInput::default()
     };
     report(
         "tetgen create",

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -215,6 +215,28 @@ pub enum ExternalRemeshingBackend {
     Mmg,
 }
 
+impl ExternalRemeshingBackend {
+    /// Returns true when this backend's mesh-generation feature is enabled in this build.
+    pub fn is_feature_enabled(self) -> bool {
+        match self {
+            ExternalRemeshingBackend::Triangle => cfg!(feature = "triangle-support"),
+            ExternalRemeshingBackend::TetGen => cfg!(feature = "tetgen-support"),
+            ExternalRemeshingBackend::Gmsh => cfg!(feature = "gmsh-support"),
+            ExternalRemeshingBackend::Mmg => false,
+        }
+    }
+
+    /// Returns the Cargo feature that wires this backend into mesh-generation/remeshing helpers.
+    pub fn cargo_feature(self) -> Option<&'static str> {
+        match self {
+            ExternalRemeshingBackend::Triangle => Some("triangle-support"),
+            ExternalRemeshingBackend::TetGen => Some("tetgen-support"),
+            ExternalRemeshingBackend::Gmsh => Some("gmsh-support"),
+            ExternalRemeshingBackend::Mmg => None,
+        }
+    }
+}
+
 /// Backend policy for metric adaptation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MetricRemeshingBackend {
@@ -1397,8 +1419,16 @@ where
     C: Fn(&[MetricSplitHint]) -> Vec<CoarsenEntity>,
 {
     if let MetricRemeshingBackend::External(backend) = options.backend {
+        let feature = backend
+            .cargo_feature()
+            .unwrap_or("no cargo feature is currently available");
+        let availability = if backend.is_feature_enabled() {
+            "the mesh-generation feature is enabled; invoke the corresponding meshgen remesher to obtain a MeshData round trip"
+        } else {
+            "enable the backend feature before invoking the corresponding meshgen remesher"
+        };
         return Err(MeshSieveError::InvalidGeometry(format!(
-            "external metric remeshing backend {backend:?} is not linked yet"
+            "external metric remeshing backend {backend:?} is selected through MetricRemeshingBackend; {availability}. Required feature: {feature}."
         )));
     }
     let normalized_metric = normalized_metric_section(metric, options.normalization)?;

--- a/src/algs/meshgen.rs
+++ b/src/algs/meshgen.rs
@@ -138,6 +138,34 @@ fn build_mesh(
     })
 }
 
+#[cfg(any(feature = "triangle-support", feature = "tetgen-support"))]
+fn generated_vertex_point(vertex_index: usize) -> Result<PointId, MeshSieveError> {
+    PointId::new(vertex_index as u64 + 1)
+}
+
+#[cfg(any(feature = "triangle-support", feature = "tetgen-support"))]
+fn generated_cell_point(vertex_count: usize, cell_index: usize) -> Result<PointId, MeshSieveError> {
+    PointId::new((vertex_count + cell_index) as u64 + 1)
+}
+
+#[cfg(any(feature = "triangle-support", feature = "tetgen-support"))]
+fn merge_labels(
+    mesh: &mut MeshData<InMemorySieve<PointId, ()>, f64, VecStorage<f64>, VecStorage<CellType>>,
+    labels: LabelSet,
+) {
+    if labels.is_empty() {
+        return;
+    }
+    match mesh.labels.as_mut() {
+        Some(existing) => {
+            for (name, point, value) in labels.iter() {
+                existing.set_label(point, &name, value);
+            }
+        }
+        None => mesh.labels = Some(labels),
+    }
+}
+
 pub fn structured_box_1d(nx: usize, min: f64, max: f64, options: MeshGenOptions) -> MeshGenResult {
     let mut out = interval_mesh(
         nx,
@@ -367,12 +395,30 @@ pub fn cylinder_shell(
 /// Polygonal input for Triangle constrained Delaunay triangulation.
 #[derive(Clone, Debug, Default)]
 pub struct TriangleInput {
-    /// Planar vertex coordinates. Indices used by segments and holes are zero-based.
+    /// Planar vertex coordinates. Indices used by segments, holes, and regions are zero-based.
     pub vertices: Vec<[f64; 2]>,
+    /// Optional per-vertex boundary markers written to Triangle `.poly` input and restored as
+    /// `triangle:vertex_marker` labels when present in `.node` output. Missing entries default to 0.
+    pub vertex_markers: Vec<i32>,
     /// Constrained segments as zero-based vertex index pairs.
     pub segments: Vec<[usize; 2]>,
+    /// Optional per-segment boundary markers written to `.poly` input. Missing entries default to 0.
+    pub segment_markers: Vec<i32>,
     /// Hole seed points in Triangle `.poly` syntax.
     pub holes: Vec<[f64; 2]>,
+    /// Region seed points with attributes and optional maximum area.
+    pub regions: Vec<TriangleRegion>,
+}
+
+/// Region metadata for Triangle `.poly` inputs.
+#[derive(Clone, Copy, Debug)]
+pub struct TriangleRegion {
+    /// Interior point identifying the region.
+    pub point: [f64; 2],
+    /// Region attribute restored as `triangle:region` labels on output cells.
+    pub attribute: i32,
+    /// Optional maximum area for this region.
+    pub max_area: Option<f64>,
 }
 
 /// Runtime options for the Triangle command-line backend.
@@ -407,10 +453,27 @@ impl Default for TriangleOptions {
 pub struct TetGenInput {
     /// Spatial vertex coordinates. Facets use zero-based vertex indices.
     pub vertices: Vec<[f64; 3]>,
+    /// Optional per-vertex boundary markers restored as `tetgen:vertex_marker` labels when present.
+    pub vertex_markers: Vec<i32>,
     /// Boundary facets, each represented by one polygon with at least three vertices.
     pub facets: Vec<Vec<usize>>,
+    /// Optional per-facet boundary markers written to `.poly` input. Missing entries default to 0.
+    pub facet_markers: Vec<i32>,
     /// Hole seed points in TetGen `.poly` syntax.
     pub holes: Vec<[f64; 3]>,
+    /// Region seed points with attributes and optional maximum volume.
+    pub regions: Vec<TetGenRegion>,
+}
+
+/// Region metadata for TetGen `.poly` inputs.
+#[derive(Clone, Copy, Debug)]
+pub struct TetGenRegion {
+    /// Interior point identifying the region.
+    pub point: [f64; 3],
+    /// Region attribute restored as `tetgen:region` labels on output cells.
+    pub attribute: i32,
+    /// Optional maximum volume for this region.
+    pub max_volume: Option<f64>,
 }
 
 /// Runtime options for the TetGen command-line backend.
@@ -583,30 +646,83 @@ fn write_triangle_poly(path: &Path, input: &TriangleInput) -> Result<(), MeshSie
         }
     }
     let mut file = File::create(path)?;
-    writeln!(file, "{} 2 0 0", input.vertices.len())?;
+    let has_vertex_markers = input.vertex_markers.iter().any(|marker| *marker != 0);
+    writeln!(
+        file,
+        "{} 2 0 {}",
+        input.vertices.len(),
+        usize::from(has_vertex_markers)
+    )?;
     for (idx, [x, y]) in input.vertices.iter().enumerate() {
-        writeln!(file, "{} {x} {y}", idx + 1)?;
+        if has_vertex_markers {
+            let marker = input.vertex_markers.get(idx).copied().unwrap_or_default();
+            writeln!(file, "{} {x} {y} {marker}", idx + 1)?;
+        } else {
+            writeln!(file, "{} {x} {y}", idx + 1)?;
+        }
     }
-    writeln!(file, "{} 0", input.segments.len())?;
+    let has_segment_markers = input.segment_markers.iter().any(|marker| *marker != 0);
+    writeln!(
+        file,
+        "{} {}",
+        input.segments.len(),
+        usize::from(has_segment_markers)
+    )?;
     for (idx, [a, b]) in input.segments.iter().enumerate() {
-        writeln!(file, "{} {} {}", idx + 1, a + 1, b + 1)?;
+        let marker = input.segment_markers.get(idx).copied().unwrap_or_default();
+        if has_segment_markers {
+            writeln!(file, "{} {} {} {marker}", idx + 1, a + 1, b + 1)?;
+        } else {
+            writeln!(file, "{} {} {}", idx + 1, a + 1, b + 1)?;
+        }
     }
     writeln!(file, "{}", input.holes.len())?;
     for (idx, [x, y]) in input.holes.iter().enumerate() {
         writeln!(file, "{} {x} {y}", idx + 1)?;
+    }
+    writeln!(file, "{}", input.regions.len())?;
+    for (idx, region) in input.regions.iter().enumerate() {
+        let [x, y] = region.point;
+        if let Some(area) = region.max_area {
+            writeln!(file, "{} {x} {y} {} {area}", idx + 1, region.attribute)?;
+        } else {
+            writeln!(file, "{} {x} {y} {}", idx + 1, region.attribute)?;
+        }
     }
     Ok(())
 }
 
 #[cfg(feature = "triangle-support")]
 fn read_triangle_output(prefix: &Path) -> MeshGenResult {
-    let nodes = read_triangle_nodes(&prefix.with_extension("1.node"))?;
-    let cells = read_triangle_elements(&prefix.with_extension("1.ele"), 3)?;
-    build_mesh(2, &nodes, &cells, CellType::Triangle, None)
+    let (nodes, node_markers) = read_triangle_nodes(&prefix.with_extension("1.node"))?;
+    let (cells, cell_attrs) = read_triangle_elements(&prefix.with_extension("1.ele"), 3)?;
+    let mut mesh = build_mesh(2, &nodes, &cells, CellType::Triangle, None)?;
+    let mut labels = LabelSet::new();
+    for (idx, marker) in node_markers.into_iter().enumerate() {
+        if marker != 0 {
+            labels.set_label(
+                generated_vertex_point(idx)?,
+                "triangle:vertex_marker",
+                marker,
+            );
+            labels.set_label(generated_vertex_point(idx)?, "boundary", marker);
+        }
+    }
+    for (idx, attrs) in cell_attrs.into_iter().enumerate() {
+        if let Some(region) = attrs.first().copied() {
+            labels.set_label(
+                generated_cell_point(nodes.len(), idx)?,
+                "triangle:region",
+                region,
+            );
+        }
+    }
+    merge_labels(&mut mesh, labels);
+    Ok(mesh)
 }
 
 #[cfg(feature = "triangle-support")]
-fn read_triangle_nodes(path: &Path) -> Result<Vec<Vec<f64>>, MeshSieveError> {
+fn read_triangle_nodes(path: &Path) -> Result<(Vec<Vec<f64>>, Vec<i32>), MeshSieveError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let header = read_non_comment_line(&mut reader)?;
@@ -617,7 +733,9 @@ fn read_triangle_nodes(path: &Path) -> Result<Vec<Vec<f64>>, MeshSieveError> {
         ));
     }
     let count = parse_usize(parts[0], "Triangle .node header")?;
+    let has_marker = parts.get(3).is_some_and(|raw| *raw != "0");
     let mut out = Vec::with_capacity(count);
+    let mut markers = Vec::with_capacity(count);
     for _ in 0..count {
         let line = read_non_comment_line(&mut reader)?;
         let parts: Vec<_> = line.split_whitespace().collect();
@@ -628,15 +746,25 @@ fn read_triangle_nodes(path: &Path) -> Result<Vec<Vec<f64>>, MeshSieveError> {
             parse_f64(parts[1], "Triangle .node row")?,
             parse_f64(parts[2], "Triangle .node row")?,
         ]);
+        markers.push(if has_marker && parts.len() > 3 {
+            parts[3].parse::<i32>().map_err(|_| {
+                invalid_geometry(format!(
+                    "invalid marker in Triangle .node row: {}",
+                    parts[3]
+                ))
+            })?
+        } else {
+            0
+        });
     }
-    Ok(out)
+    Ok((out, markers))
 }
 
 #[cfg(feature = "triangle-support")]
 fn read_triangle_elements(
     path: &Path,
     expected_nodes: usize,
-) -> Result<Vec<Vec<usize>>, MeshSieveError> {
+) -> Result<(Vec<Vec<usize>>, Vec<Vec<i32>>), MeshSieveError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let header = read_non_comment_line(&mut reader)?;
@@ -647,7 +775,11 @@ fn read_triangle_elements(
         ));
     }
     let count = parse_usize(parts[0], "Triangle .ele header")?;
+    let attribute_count = parts
+        .get(2)
+        .map_or(Ok(0), |raw| parse_usize(raw, "Triangle .ele header"))?;
     let mut out = Vec::with_capacity(count);
+    let mut attrs = Vec::with_capacity(count);
     for _ in 0..count {
         let line = read_non_comment_line(&mut reader)?;
         let parts: Vec<_> = line.split_whitespace().collect();
@@ -663,9 +795,16 @@ fn read_triangle_elements(
                     .ok_or_else(|| invalid_geometry("Triangle wrote node id 0"))?,
             );
         }
+        let mut row_attrs = Vec::with_capacity(attribute_count);
+        for raw in parts.iter().skip(expected_nodes + 1).take(attribute_count) {
+            row_attrs.push(raw.parse::<i32>().map_err(|_| {
+                invalid_geometry(format!("invalid attribute in Triangle .ele row: {raw}"))
+            })?);
+        }
         out.push(cell);
+        attrs.push(row_attrs);
     }
-    Ok(out)
+    Ok((out, attrs))
 }
 
 /// Generate a 2-D constrained triangulation by invoking Triangle.
@@ -710,11 +849,28 @@ fn write_tetgen_poly(path: &Path, input: &TetGenInput) -> Result<(), MeshSieveEr
         return Err(invalid_geometry("TetGen requires at least four vertices"));
     }
     let mut file = File::create(path)?;
-    writeln!(file, "{} 3 0 0", input.vertices.len())?;
+    let has_vertex_markers = input.vertex_markers.iter().any(|marker| *marker != 0);
+    writeln!(
+        file,
+        "{} 3 0 {}",
+        input.vertices.len(),
+        usize::from(has_vertex_markers)
+    )?;
     for (idx, [x, y, z]) in input.vertices.iter().enumerate() {
-        writeln!(file, "{} {x} {y} {z}", idx + 1)?;
+        if has_vertex_markers {
+            let marker = input.vertex_markers.get(idx).copied().unwrap_or_default();
+            writeln!(file, "{} {x} {y} {z} {marker}", idx + 1)?;
+        } else {
+            writeln!(file, "{} {x} {y} {z}", idx + 1)?;
+        }
     }
-    writeln!(file, "{} 0", input.facets.len())?;
+    let has_facet_markers = input.facet_markers.iter().any(|marker| *marker != 0);
+    writeln!(
+        file,
+        "{} {}",
+        input.facets.len(),
+        usize::from(has_facet_markers)
+    )?;
     for (facet_idx, facet) in input.facets.iter().enumerate() {
         if facet.len() < 3 {
             return Err(invalid_geometry(format!(
@@ -728,7 +884,16 @@ fn write_tetgen_poly(path: &Path, input: &TetGenInput) -> Result<(), MeshSieveEr
                 )));
             }
         }
-        writeln!(file, "1 0")?;
+        if has_facet_markers {
+            let marker = input
+                .facet_markers
+                .get(facet_idx)
+                .copied()
+                .unwrap_or_default();
+            writeln!(file, "1 0 {marker}")?;
+        } else {
+            writeln!(file, "1 0")?;
+        }
         write!(file, "{}", facet.len())?;
         for idx in facet {
             write!(file, " {}", idx + 1)?;
@@ -739,19 +904,50 @@ fn write_tetgen_poly(path: &Path, input: &TetGenInput) -> Result<(), MeshSieveEr
     for (idx, [x, y, z]) in input.holes.iter().enumerate() {
         writeln!(file, "{} {x} {y} {z}", idx + 1)?;
     }
-    writeln!(file, "0")?;
+    writeln!(file, "{}", input.regions.len())?;
+    for (idx, region) in input.regions.iter().enumerate() {
+        let [x, y, z] = region.point;
+        if let Some(volume) = region.max_volume {
+            writeln!(
+                file,
+                "{} {x} {y} {z} {} {volume}",
+                idx + 1,
+                region.attribute
+            )?;
+        } else {
+            writeln!(file, "{} {x} {y} {z} {}", idx + 1, region.attribute)?;
+        }
+    }
     Ok(())
 }
 
 #[cfg(feature = "tetgen-support")]
 fn read_tetgen_output(prefix: &Path) -> MeshGenResult {
-    let nodes = read_tetgen_nodes(&prefix.with_extension("1.node"))?;
-    let cells = read_tetgen_elements(&prefix.with_extension("1.ele"))?;
-    build_mesh(3, &nodes, &cells, CellType::Tetrahedron, None)
+    let (nodes, node_markers) = read_tetgen_nodes(&prefix.with_extension("1.node"))?;
+    let (cells, cell_attrs) = read_tetgen_elements(&prefix.with_extension("1.ele"))?;
+    let mut mesh = build_mesh(3, &nodes, &cells, CellType::Tetrahedron, None)?;
+    let mut labels = LabelSet::new();
+    for (idx, marker) in node_markers.into_iter().enumerate() {
+        if marker != 0 {
+            labels.set_label(generated_vertex_point(idx)?, "tetgen:vertex_marker", marker);
+            labels.set_label(generated_vertex_point(idx)?, "boundary", marker);
+        }
+    }
+    for (idx, attrs) in cell_attrs.into_iter().enumerate() {
+        if let Some(region) = attrs.first().copied() {
+            labels.set_label(
+                generated_cell_point(nodes.len(), idx)?,
+                "tetgen:region",
+                region,
+            );
+        }
+    }
+    merge_labels(&mut mesh, labels);
+    Ok(mesh)
 }
 
 #[cfg(feature = "tetgen-support")]
-fn read_tetgen_nodes(path: &Path) -> Result<Vec<Vec<f64>>, MeshSieveError> {
+fn read_tetgen_nodes(path: &Path) -> Result<(Vec<Vec<f64>>, Vec<i32>), MeshSieveError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let header = read_non_comment_line(&mut reader)?;
@@ -762,7 +958,9 @@ fn read_tetgen_nodes(path: &Path) -> Result<Vec<Vec<f64>>, MeshSieveError> {
         ));
     }
     let count = parse_usize(parts[0], "TetGen .node header")?;
+    let has_marker = parts.get(3).is_some_and(|raw| *raw != "0");
     let mut out = Vec::with_capacity(count);
+    let mut markers = Vec::with_capacity(count);
     for _ in 0..count {
         let line = read_non_comment_line(&mut reader)?;
         let parts: Vec<_> = line.split_whitespace().collect();
@@ -774,12 +972,19 @@ fn read_tetgen_nodes(path: &Path) -> Result<Vec<Vec<f64>>, MeshSieveError> {
             parse_f64(parts[2], "TetGen .node row")?,
             parse_f64(parts[3], "TetGen .node row")?,
         ]);
+        markers.push(if has_marker && parts.len() > 4 {
+            parts[4].parse::<i32>().map_err(|_| {
+                invalid_geometry(format!("invalid marker in TetGen .node row: {}", parts[4]))
+            })?
+        } else {
+            0
+        });
     }
-    Ok(out)
+    Ok((out, markers))
 }
 
 #[cfg(feature = "tetgen-support")]
-fn read_tetgen_elements(path: &Path) -> Result<Vec<Vec<usize>>, MeshSieveError> {
+fn read_tetgen_elements(path: &Path) -> Result<(Vec<Vec<usize>>, Vec<Vec<i32>>), MeshSieveError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let header = read_non_comment_line(&mut reader)?;
@@ -790,7 +995,11 @@ fn read_tetgen_elements(path: &Path) -> Result<Vec<Vec<usize>>, MeshSieveError> 
         ));
     }
     let count = parse_usize(parts[0], "TetGen .ele header")?;
+    let attribute_count = parts
+        .get(2)
+        .map_or(Ok(0), |raw| parse_usize(raw, "TetGen .ele header"))?;
     let mut out = Vec::with_capacity(count);
+    let mut attrs = Vec::with_capacity(count);
     for _ in 0..count {
         let line = read_non_comment_line(&mut reader)?;
         let parts: Vec<_> = line.split_whitespace().collect();
@@ -806,9 +1015,16 @@ fn read_tetgen_elements(path: &Path) -> Result<Vec<Vec<usize>>, MeshSieveError> 
                     .ok_or_else(|| invalid_geometry("TetGen wrote node id 0"))?,
             );
         }
+        let mut row_attrs = Vec::with_capacity(attribute_count);
+        for raw in parts.iter().skip(5).take(attribute_count) {
+            row_attrs.push(raw.parse::<i32>().map_err(|_| {
+                invalid_geometry(format!("invalid attribute in TetGen .ele row: {raw}"))
+            })?);
+        }
         out.push(cell);
+        attrs.push(row_attrs);
     }
-    Ok(out)
+    Ok((out, attrs))
 }
 
 /// Generate a 3-D tetrahedralization by invoking TetGen.
@@ -927,7 +1143,24 @@ fn write_plain_gmsh_v2(
             CellType::Pyramid => 7,
             _ => continue,
         };
-        write!(file, "{} {} 0", point.get(), elem_type)?;
+        let (physical, entity) = mesh
+            .labels
+            .as_ref()
+            .map(|labels| {
+                (
+                    labels
+                        .get_label(point, "gmsh:physical")
+                        .or_else(|| labels.get_label(point, "region"))
+                        .unwrap_or_default(),
+                    labels.get_label(point, "gmsh:entity").unwrap_or_default(),
+                )
+            })
+            .unwrap_or_default();
+        if physical != 0 || entity != 0 {
+            write!(file, "{} {} 2 {physical} {entity}", point.get(), elem_type)?;
+        } else {
+            write!(file, "{} {} 0", point.get(), elem_type)?;
+        }
         for node in mesh.sieve.cone_points(point) {
             write!(file, " {}", node.get())?;
         }

--- a/tests/external_mesh_backends.rs
+++ b/tests/external_mesh_backends.rs
@@ -1,0 +1,320 @@
+use std::fs;
+use std::path::PathBuf;
+
+use mesh_sieve::topology::cell_type::CellType;
+use mesh_sieve::topology::point::PointId;
+
+#[cfg(unix)]
+fn fake_executable(name: &str, body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "mesh-sieve-{name}-{}-{}.sh",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::write(&path, body).unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+#[cfg(feature = "triangle-support")]
+#[test]
+fn triangle_backend_preserves_region_and_boundary_markers() {
+    use mesh_sieve::algs::meshgen::{
+        TriangleInput, TriangleOptions, TriangleRegion, generate_with_triangle,
+    };
+
+    let exe = fake_executable(
+        "triangle",
+        r#"#!/usr/bin/env bash
+set -eu
+poly="${@: -1}"
+prefix="${poly%.poly}"
+cat > "${prefix}.1.node" <<'EOF'
+3 2 0 1
+1 0 0 11
+2 1 0 12
+3 0 1 13
+EOF
+cat > "${prefix}.1.ele" <<'EOF'
+1 3 1
+1 1 2 3 99
+EOF
+"#,
+    );
+    let input = TriangleInput {
+        vertices: vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+        vertex_markers: vec![11, 12, 13],
+        segments: vec![[0, 1], [1, 2], [2, 0]],
+        segment_markers: vec![21, 22, 23],
+        regions: vec![TriangleRegion {
+            point: [0.25, 0.25],
+            attribute: 99,
+            max_area: Some(0.1),
+        }],
+        ..TriangleInput::default()
+    };
+    let mesh = generate_with_triangle(
+        &input,
+        &TriangleOptions {
+            executable: exe.display().to_string(),
+            ..TriangleOptions::default()
+        },
+    )
+    .expect("triangle fake backend");
+
+    let labels = mesh.labels.as_ref().expect("labels");
+    assert_eq!(
+        labels.get_label(PointId::new(1).unwrap(), "triangle:vertex_marker"),
+        Some(11)
+    );
+    assert_eq!(
+        labels.get_label(PointId::new(2).unwrap(), "boundary"),
+        Some(12)
+    );
+    assert_eq!(
+        labels.get_label(PointId::new(4).unwrap(), "triangle:region"),
+        Some(99)
+    );
+    assert_eq!(
+        mesh.cell_types
+            .as_ref()
+            .unwrap()
+            .try_restrict(PointId::new(4).unwrap())
+            .unwrap()[0],
+        CellType::Triangle
+    );
+}
+
+#[cfg(feature = "triangle-support")]
+#[test]
+fn triangle_backend_reports_malformed_output() {
+    use mesh_sieve::algs::meshgen::{TriangleInput, TriangleOptions, generate_with_triangle};
+
+    let exe = fake_executable(
+        "triangle-bad",
+        r#"#!/usr/bin/env bash
+set -eu
+poly="${@: -1}"
+prefix="${poly%.poly}"
+cat > "${prefix}.1.node" <<'EOF'
+3 2 0 0
+1 0 0
+2 1 0
+3 0 1
+EOF
+cat > "${prefix}.1.ele" <<'EOF'
+1 6 0
+1 1 2 3 4 5 6
+EOF
+"#,
+    );
+    let err = generate_with_triangle(
+        &TriangleInput {
+            vertices: vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            segments: vec![[0, 1], [1, 2], [2, 0]],
+            ..TriangleInput::default()
+        },
+        &TriangleOptions {
+            executable: exe.display().to_string(),
+            ..TriangleOptions::default()
+        },
+    )
+    .expect_err("unsupported element order should fail")
+    .to_string();
+    assert!(err.contains("unsupported element order"), "{err}");
+}
+
+#[cfg(feature = "tetgen-support")]
+#[test]
+fn tetgen_backend_preserves_region_and_boundary_markers() {
+    use mesh_sieve::algs::meshgen::{
+        TetGenInput, TetGenOptions, TetGenRegion, generate_with_tetgen,
+    };
+
+    let exe = fake_executable(
+        "tetgen",
+        r#"#!/usr/bin/env bash
+set -eu
+poly="${@: -1}"
+prefix="${poly%.poly}"
+cat > "${prefix}.1.node" <<'EOF'
+4 3 0 1
+1 0 0 0 31
+2 1 0 0 32
+3 0 1 0 33
+4 0 0 1 34
+EOF
+cat > "${prefix}.1.ele" <<'EOF'
+1 4 1
+1 1 2 3 4 77
+EOF
+"#,
+    );
+    let input = TetGenInput {
+        vertices: vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        vertex_markers: vec![31, 32, 33, 34],
+        facets: vec![vec![0, 2, 1], vec![0, 1, 3], vec![1, 2, 3], vec![2, 0, 3]],
+        facet_markers: vec![41, 42, 43, 44],
+        regions: vec![TetGenRegion {
+            point: [0.1, 0.1, 0.1],
+            attribute: 77,
+            max_volume: Some(0.2),
+        }],
+        ..TetGenInput::default()
+    };
+    let mesh = generate_with_tetgen(
+        &input,
+        &TetGenOptions {
+            executable: exe.display().to_string(),
+            ..TetGenOptions::default()
+        },
+    )
+    .expect("tetgen fake backend");
+
+    let labels = mesh.labels.as_ref().expect("labels");
+    assert_eq!(
+        labels.get_label(PointId::new(1).unwrap(), "tetgen:vertex_marker"),
+        Some(31)
+    );
+    assert_eq!(
+        labels.get_label(PointId::new(5).unwrap(), "tetgen:region"),
+        Some(77)
+    );
+    assert_eq!(
+        mesh.cell_types
+            .as_ref()
+            .unwrap()
+            .try_restrict(PointId::new(5).unwrap())
+            .unwrap()[0],
+        CellType::Tetrahedron
+    );
+}
+
+#[cfg(feature = "gmsh-support")]
+#[test]
+fn gmsh_backend_generates_and_remeshes_with_physical_labels() {
+    use mesh_sieve::algs::meshgen::{
+        GmshInput, GmshOptions, MeshGenOptions, StructuredCellType, generate_with_gmsh,
+        remesh_with_gmsh, structured_box_2d,
+    };
+    use mesh_sieve::topology::labels::LabelSet;
+
+    let exe = fake_executable(
+        "gmsh",
+        r#"#!/usr/bin/env bash
+set -eu
+out=""
+in=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; out="$1" ;;
+    *.msh) in="$1" ;;
+  esac
+  shift || true
+done
+if [ -n "$in" ] && [ -f "$in" ]; then
+  cp "$in" "$out"
+else
+cat > "$out" <<'EOF'
+$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+3
+1 0 0 0
+2 1 0 0
+3 0 1 0
+$EndNodes
+$Elements
+1
+10 2 2 7 42 1 2 3
+$EndElements
+EOF
+fi
+"#,
+    );
+    let opts = GmshOptions {
+        executable: exe.display().to_string(),
+        format: "msh2".into(),
+        ..GmshOptions::default()
+    };
+    let mesh = generate_with_gmsh(
+        &GmshInput {
+            geo: "Point(1) = {0,0,0};".into(),
+            dimension: 2,
+        },
+        &opts,
+    )
+    .expect("gmsh fake backend");
+    let labels = mesh.labels.as_ref().expect("labels");
+    assert_eq!(
+        labels.get_label(PointId::new(10).unwrap(), "gmsh:physical"),
+        Some(7)
+    );
+    assert_eq!(
+        labels.get_label(PointId::new(10).unwrap(), "gmsh:entity"),
+        Some(42)
+    );
+
+    let mut seed = structured_box_2d(
+        1,
+        1,
+        [0.0, 0.0],
+        [1.0, 1.0],
+        StructuredCellType::Triangle,
+        MeshGenOptions::default(),
+    )
+    .unwrap();
+    let mut labels = LabelSet::new();
+    labels.set_label(PointId::new(5).unwrap(), "gmsh:physical", 9);
+    labels.set_label(PointId::new(5).unwrap(), "gmsh:entity", 5);
+    seed.labels = Some(labels);
+    let remeshed = remesh_with_gmsh(&seed, 2, &opts).expect("gmsh fake remesh");
+    assert_eq!(
+        remeshed
+            .labels
+            .as_ref()
+            .unwrap()
+            .get_label(PointId::new(5).unwrap(), "gmsh:physical"),
+        Some(9)
+    );
+}
+
+#[cfg(any(
+    feature = "triangle-support",
+    feature = "tetgen-support",
+    feature = "gmsh-support"
+))]
+#[test]
+fn missing_executable_diagnostic_names_backend() {
+    #[cfg(feature = "triangle-support")]
+    {
+        use mesh_sieve::algs::meshgen::{TriangleInput, TriangleOptions, generate_with_triangle};
+        let err = generate_with_triangle(
+            &TriangleInput {
+                vertices: vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+                segments: vec![[0, 1], [1, 2], [2, 0]],
+                ..TriangleInput::default()
+            },
+            &TriangleOptions {
+                executable: "mesh-sieve-definitely-missing-triangle".into(),
+                ..TriangleOptions::default()
+            },
+        )
+        .expect_err("missing executable")
+        .to_string();
+        assert!(err.contains("failed to execute Triangle"), "{err}");
+    }
+}


### PR DESCRIPTION
### Motivation

- External mesh generators (Triangle, TetGen, Gmsh) must be first-class, production-ready backends that preserve topology/metadata through create/remesh round trips and give clear diagnostics. 
- Mesh generation/remeshing needs to preserve vertex/segment/facet markers, region attributes, boundary/physical tags, and cell-type metadata so downstream DMPLEX-like workflows can rely on them. 

### Description

- Add first-class metadata surfaces and inputs for external backends by extending `TriangleInput` and `TetGenInput` with `vertex_markers`, `segment_markers`/`facet_markers`, and `regions` (`TriangleRegion`/`TetGenRegion`), and wire those into the `.poly` writers in `src/algs/meshgen.rs`.
- Read backend outputs with markers/attributes and restore them as `LabelSet` entries (e.g. `triangle:vertex_marker`, `tetgen:vertex_marker`, `triangle:region`, `tetgen:region`) via new helpers `read_triangle_nodes`, `read_triangle_elements`, `read_tetgen_nodes`, `read_tetgen_elements`, and label-merge helpers `generated_vertex_point`, `generated_cell_point`, and `merge_labels` in `src/algs/meshgen.rs`.
- Preserve Gmsh physical/entity tags when round-tripping/remeshing by emitting element tag fields in `write_plain_gmsh_v2` so `remesh_with_gmsh` keeps `gmsh:physical`/`gmsh:entity` labels.
- Improve backend availability diagnostics in the metric-adaptation facade by adding `ExternalRemeshingBackend::is_feature_enabled` and `cargo_feature`, and produce a clearer `MetricRemeshingBackend::External` error message in `src/adapt/mod.rs` that describes required Cargo features and next steps.
- Update the example `examples/external_mesh_workflows.rs` to remain compatible with the richer inputs and add a new feature-gated integration test file `tests/external_mesh_backends.rs` that uses fake executables to verify marker/region/label/cell-type preservation and diagnostic messages.

### Testing

- Ran `cargo fmt` successfully to normalize formatting.
- Ran `cargo check` successfully (build completed with non-blocking warnings).
- Ran the feature-gated integration test: `cargo test --test external_mesh_backends --features triangle-support,tetgen-support,gmsh-support`, which executed the Triangle/TetGen/Gmsh fake-executable tests and all tests passed (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e21a7e1cc8329a644515790769c77)